### PR TITLE
reconnect on foregraound, network changes and disconnections.

### DIFF
--- a/android/app/libs/breez.aar
+++ b/android/app/libs/breez.aar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:be3c662baea53f29d4c103aeae12062d6040b807cf17287e2e89467e5efe2fc4
-size 48668138
+oid sha256:39d06815a7e8a5bef037f104f661da522b2ae00bb648710edf0086a0ad092f9c
+size 48671278

--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -97,17 +97,11 @@ class AccountBloc {
     }
 
     void _listenConnectivityChanges(BreezBridge breezLib){
-      var connectivity = Connectivity();
-      connectivity.checkConnectivity().then((connectivityResult) {
-         _allowReconnect = connectivityResult != ConnectivityResult.none;
-         log.info("initial connection = " + connectivityResult.toString());
-        }
-      );      
-      
-      connectivity.onConnectivityChanged.listen((connectivityResult){
-          log.info("_listenConnectivityChanges: connection changed to: " + connectivityResult.toString());
-          _allowReconnect = connectivityResult != ConnectivityResult.none;          
-            _reconnectSink.add(null);          
+      var connectivity = Connectivity();     
+      connectivity.onConnectivityChanged.skip(1).listen((connectivityResult){
+          log.info("_listenConnectivityChanges: connection changed to: " + connectivityResult.toString());          
+          _allowReconnect = (connectivityResult != ConnectivityResult.none);
+          _reconnectSink.add(null);
         });
     }
     
@@ -116,7 +110,7 @@ class AccountBloc {
       _reconnectStreamController.stream.transform(DebounceStreamTransformer(Duration(milliseconds: 500)))
       .listen((_) async {
         log.info("_listenReconnects: got Reconnect request");
-        if (_allowReconnect && !_accountController.value.connected) {          
+        if (_allowReconnect == true && _accountController.value.connected == false) {          
           connectingFuture = connectingFuture.whenComplete((){
             log.info("_listenReconnects: reconnecting...");
             breezLib.connectAccount();

--- a/lib/services/breezlib/breez_bridge.dart
+++ b/lib/services/breezlib/breez_bridge.dart
@@ -63,6 +63,10 @@ class BreezBridge {
       .then((result) => result as bool);
   }
 
+  Future connectAccount(){
+    return _invokeMethodWhenReady("connectAccount");
+  }
+
   Future sendNonDepositedCoins(String address){
     SendNonDepositedCoinsRequest request = new SendNonDepositedCoinsRequest()..address = address;
     return _invokeMethodWhenReady("sendNonDepositedCoins", {"argument": request.writeToBuffer()});

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   package_info: any  
   uuid: ^1.0.3
   ini:
+  connectivity: ^0.3.2
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
This PR handles reconnecting the account when needed according to the mobile lifecycle and network events.
More specifically a reconnection is attempted whenever:
1. The app resumed (enter foreground state)
2. The network changes to either wifi or mobile
3. On disconnection.
These attempts are buffered so we won't send redundant reconnects and every reconnect request is executed only if:
1. The account is currently disconnected
2. The network state allows it (mobile or wifi)