### PR TITLE
Pubspec and gradle improvements

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -70,8 +70,8 @@ dependencies {
     implementation 'com.android.support:support-v4:28.0.0'
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.google.firebase:firebase-invites:16.0.4'
+    implementation 'com.felipecsl:gifimageview:2.1.0'
+    implementation 'commons-io:commons-io:2.4'
     implementation 'android.arch.work:work-runtime:1.0.0-alpha10'
-    compile 'com.felipecsl:gifimageview:2.1.0'
-    compile 'commons-io:commons-io:2.4'
 }
 apply plugin: 'com.google.gms.google-services'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,20 +14,6 @@ buildscript {
 }
 
 allprojects {
-    configurations.all {
-        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-            def requested = details.requested
-            if (requested.name == 'firebase-core') {
-                details.useVersion "16.0.4"
-            }
-            if (requested.name == 'firebase-messaging') {
-                details.useVersion "17.3.3"
-            }
-            if (requested.name == 'firebase-database') {
-                details.useVersion "16.0.3"
-            }
-        }
-    }
     repositories {
         google()
         jcenter()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
-        classpath 'com.google.gms:google-services:3.1.0'
+        classpath 'com.google.gms:google-services:4.2.0'
     }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,14 +7,8 @@ dependencies:
   grpc: ^0.6.4
   protobuf: any
   path_provider: any
-  firebase_database:
-    git:
-      url: https://github.com/flutter/plugins.git
-      path: packages/firebase_database
-  firebase_messaging:
-    git:
-      url: https://github.com/flutter/plugins.git
-      path: packages/firebase_messaging
+  firebase_database: ^1.0.5
+  firebase_messaging: ^2.1.0
   shared_preferences: "^0.4.1"
   share: "^0.5.2"
   qr_flutter: ^1.1.1


### PR DESCRIPTION
- build.gradle: suppress warnings by using the 'implementation' directive
- pubspec: don't use git versions od firebase plugins
- Bump google-services to 4.2.0
- build.gradle: don't hardcode dependencies