### PR TITLE
Reenter session

### DIFF
--- a/android/app/libs/breez.aar
+++ b/android/app/libs/breez.aar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:88a663b350f24eb7a0c3580f69fdf0d522c88b4aec13580e2c8359a976831445
-size 49118151
+oid sha256:5c1c3fc2085de99de1dfe6b3eb1b02d754a7b4813afafd4037b270da15c50622
+size 49136882

--- a/lib/bloc/connect_pay/connect_pay_bloc.dart
+++ b/lib/bloc/connect_pay/connect_pay_bloc.dart
@@ -41,7 +41,7 @@ class ConnectPayBloc {
 
     //if we have already a session and it is our intiated then we are a returning payer
     if (sessionInfo.initiated) {      
-      _currentSession = new PayerRemoteSession(_currentUser, sessionLink);
+        _currentSession = new PayerRemoteSession(_currentUser, sessionLink);
     } else {
        //otherwise we are payee
       if (!existingSession) {

--- a/lib/bloc/connect_pay/connect_pay_bloc.dart
+++ b/lib/bloc/connect_pay/connect_pay_bloc.dart
@@ -41,16 +41,16 @@ class ConnectPayBloc {
 
     //if we have already a session and it is our intiated then we are a returning payer
     if (sessionInfo.initiated) {      
-      _currentSession = new PayerRemoteSession(_currentUser, sessionLink)..start();       
+      _currentSession = new PayerRemoteSession(_currentUser, sessionLink);
     } else {
        //otherwise we are payee
       if (!existingSession) {
         await _breezLib.createRatchetSession(sessionID: sessionLink.sessionID, secret: sessionLink.sessionSecret,  remotePubKey: sessionLink.initiatorPubKey);      
       }
-      _currentSession = new PayeeRemoteSession(_currentUser, sessionLink)..start();
+      _currentSession = new PayeeRemoteSession(_currentUser, sessionLink);
     }
 
-    return _currentSession;    
+    return _currentSession..start();
   }
 
   Future terminateCurrentSession() {
@@ -81,5 +81,6 @@ abstract class RemoteSession {
   BreezUserModel get currentUser => _currentUser;
   Stream<PaymentSessionState> get paymentSessionStateStream;
   Stream<PaymentSessionError> get sessionErrors;
+  Future start();
   Future terminate();
 }

--- a/lib/bloc/connect_pay/connect_pay_model.dart
+++ b/lib/bloc/connect_pay/connect_pay_model.dart
@@ -47,11 +47,7 @@ class PayerSessionData {
   PayerSessionData copyWith({String userName, String imageURL, PeerStatus status, int amount, String error, bool paymentFulfilled}) {
     return new PayerSessionData(userName ?? this.userName, imageURL ?? this.imageURL, status ?? this.status, 
         amount ?? this.amount, error: error ?? this.error, paymentFulfilled: paymentFulfilled ?? this.paymentFulfilled);
-  }
-
-   PayerSessionData update(PayerSessionData other) {
-    return copyWith(userName: other.userName, imageURL: other.imageURL, status: other.status, amount: other.amount, error: other.error, paymentFulfilled: other.paymentFulfilled);
-  }
+  }  
 }
 
 class PayeeSessionData {
@@ -73,11 +69,7 @@ class PayeeSessionData {
 
   PayeeSessionData copyWith({String userName, String imageURL, PeerStatus status, String paymentRequest, String error}) {
     return new PayeeSessionData(userName ?? this.userName, imageURL ?? this.imageURL, status ?? this.status, paymentRequest ?? this.paymentRequest, error ?? this.error);
-  }
-
-  PayeeSessionData update(PayeeSessionData other) {
-    return copyWith(userName: other.userName, imageURL: other.imageURL, status: other.status, paymentRequest: other.paymentRequest, error: other.error);
-  }
+  }  
 }
 
 class PeerStatus {

--- a/lib/bloc/connect_pay/encryption.dart
+++ b/lib/bloc/connect_pay/encryption.dart
@@ -12,15 +12,13 @@ class SessionEncryption implements MessageInterceptor {
   SessionEncryption(this._breezLib, this.sessionID);
   
   @override
-  Future<String> transformIncomingMessage(String encryptedMessage) {
-    return Future.value(encryptedMessage);
-    //return _breezLib.ratchetDecrypt(sessionID, encryptedMessage);
+  Future<String> transformIncomingMessage(String encryptedMessage) {  
+    return _breezLib.ratchetDecrypt(sessionID, encryptedMessage);
   }
 
   @override
-  Future<String> transformOutgoingMessage(String message) {
-    return Future.value(message);
-    //return _breezLib.ratchetEncrypt(sessionID, message);
+  Future<String> transformOutgoingMessage(String message) {    
+    return _breezLib.ratchetEncrypt(sessionID, message);
   }
 
 }

--- a/lib/bloc/connect_pay/encryption.dart
+++ b/lib/bloc/connect_pay/encryption.dart
@@ -13,12 +13,14 @@ class SessionEncryption implements MessageInterceptor {
   
   @override
   Future<String> transformIncomingMessage(String encryptedMessage) {
-    return _breezLib.ratchetDecrypt(sessionID, encryptedMessage);
+    return Future.value(encryptedMessage);
+    //return _breezLib.ratchetDecrypt(sessionID, encryptedMessage);
   }
 
   @override
   Future<String> transformOutgoingMessage(String message) {
-    return _breezLib.ratchetEncrypt(sessionID, message);
+    return Future.value(message);
+    //return _breezLib.ratchetEncrypt(sessionID, message);
   }
 
 }

--- a/lib/bloc/connect_pay/firebase_session_channel.dart
+++ b/lib/bloc/connect_pay/firebase_session_channel.dart
@@ -44,6 +44,10 @@ class PaymentSessionChannel {
     });    
   }
 
+  Future sendResetMessage() async{
+    await FirebaseDatabase.instance.reference().child('remote-payments/$_sessionID').remove();
+  }
+
   Future terminate({bool destroyHistory = false}) async {
     if (!_terminated) {
       await _theirDataListener.cancel();
@@ -72,13 +76,16 @@ class PaymentSessionChannel {
     });
   }
 
+  bool firstMessage = true;
   void _watchSessionTermination() {
     var terminationPath = _payer ? _sessionID : '$_sessionID/payer';
     var sessionRoot = FirebaseDatabase.instance.reference().child('remote-payments/$terminationPath');
     _sessionRootListener = sessionRoot.onValue.listen((event) {
-      if (event.snapshot.value == null) {
+      if (event.snapshot.value == null && !firstMessage) {
+        print("re_watchSessionTerminationset state**********");        
         _peerTerminatedController.add(null);
       }
+      firstMessage = false;
     });
   }
 }

--- a/lib/bloc/connect_pay/firebase_session_channel.dart
+++ b/lib/bloc/connect_pay/firebase_session_channel.dart
@@ -88,16 +88,14 @@ class PaymentSessionChannel {
       }
     });
   }
-
-  bool firstMessage = true;
+  
   void _watchSessionTermination() {
     var terminationPath = _payer ? _sessionID : '$_sessionID/payer';
     var sessionRoot = FirebaseDatabase.instance.reference().child('remote-payments/$terminationPath');
     _sessionRootListener = sessionRoot.onValue.listen((event) {
-      if (event.snapshot.value == null && !firstMessage) {        
+      if (event.snapshot.value == null) {        
         _peerTerminatedController.add(null);
-      }
-      firstMessage = false;
+      }      
     });
   }
 

--- a/lib/bloc/connect_pay/online_status_updater.dart
+++ b/lib/bloc/connect_pay/online_status_updater.dart
@@ -5,14 +5,14 @@ import 'package:firebase_database/firebase_database.dart';
 class OnlineStatusUpdater {
   StreamSubscription _onLocalConnectSubscription;    
   StreamSubscription _onRemoteConnectSubscription;    
-  DatabaseReference _userStatuPath;
+  DatabaseReference _userStatusPath;
 
 
   void startStatusUpdates(String localKey, Function(PeerStatus) onLocalStatusChanged, String remoteKey, Function(PeerStatus) onRemoteStatusChanged) {
     if (_onLocalConnectSubscription != null) {
       throw new Exception("Status tracking alredy started, must be stopped before start again");
     }
-    _userStatuPath = FirebaseDatabase.instance.reference().child(localKey);    
+    _userStatusPath = FirebaseDatabase.instance.reference().child(localKey);    
 
     _onLocalConnectSubscription = FirebaseDatabase.instance.reference().child('.info/connected').onValue.listen((event) {
       onLocalStatusChanged(PeerStatus(event.snapshot.value, DateTime.now().millisecondsSinceEpoch));      
@@ -30,15 +30,15 @@ class OnlineStatusUpdater {
   pushOnline(){
     var offlineStatus = {"online": false, "lastChanged": ServerValue.timestamp},
       onlineStatus = {"online": true, "lastChanged": ServerValue.timestamp};
-    _userStatuPath.set(onlineStatus);
-    _userStatuPath.onDisconnect().set(offlineStatus);
+    _userStatusPath.set(onlineStatus);
+    _userStatusPath.onDisconnect().set(offlineStatus);
   }
 
   Future stopStatusUpdates(){
     if (_onLocalConnectSubscription == null) {
       return Future.value(null);
     }
-    _userStatuPath.onDisconnect().remove();
+    _userStatusPath.onDisconnect().remove();
     return Future.wait(
       [_onRemoteConnectSubscription.cancel(),_onLocalConnectSubscription.cancel()]
     ).then((_) {

--- a/lib/bloc/connect_pay/payee_session.dart
+++ b/lib/bloc/connect_pay/payee_session.dart
@@ -39,7 +39,7 @@ class PayeeRemoteSession extends RemoteSession with OnlineStatusUpdater{
 
   PayeeRemoteSession(this._currentUser, this.sessionLink) : super(_currentUser);
 
-  start() async{        
+  Future start() async{        
     _channel = new PaymentSessionChannel(sessionID, false, interceptor: new SessionEncryption(_breezLib, sessionID));
     _resetSessionState();
     _channel.sendResetMessage();

--- a/lib/bloc/connect_pay/payer_session.dart
+++ b/lib/bloc/connect_pay/payer_session.dart
@@ -40,7 +40,7 @@ class PayerRemoteSession extends RemoteSession with OnlineStatusUpdater {
 
   PayerRemoteSession(this._currentUser, this.sessionLink) : super(_currentUser);
 
-  start() async{    
+  Future start() async{    
     if (sessionLink.sessionSecret != null) {             
       _watchInviteRequests(SessionLinkModel(sessionID, sessionLink.sessionSecret, sessionLink.initiatorPubKey));
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -68,7 +68,8 @@ class BreezAppState extends State<BreezApp> {
   @override
   void initState() {
     super.initState();
-    widget._blocs.connectPayBloc.sessionInvites.listen((sessionLink) async {      
+    widget._blocs.connectPayBloc.sessionInvites.listen((sessionLink) async {
+      await widget._blocs.connectPayBloc.terminateCurrentSession();      
       _navigatorKey.currentState.push(FadeInRoute(builder: (_) => new ConnectToPayPage(sessionLink)));         
     });
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -68,10 +68,8 @@ class BreezAppState extends State<BreezApp> {
   @override
   void initState() {
     super.initState();
-    widget._blocs.connectPayBloc.sessionInvites.listen((sessionLink) async {
-      print("got invite in breez app " + _navigatorKey.currentState.toString());
-      var remoteSession = await widget._blocs.connectPayBloc.joinSessionByLink(sessionLink);
-      _navigatorKey.currentState.push(FadeInRoute(builder: (_) => new ConnectToPayPage(remoteSession)));         
+    widget._blocs.connectPayBloc.sessionInvites.listen((sessionLink) async {      
+      _navigatorKey.currentState.push(FadeInRoute(builder: (_) => new ConnectToPayPage(sessionLink)));         
     });
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -68,11 +68,10 @@ class BreezAppState extends State<BreezApp> {
   @override
   void initState() {
     super.initState();
-    widget._blocs.connectPayBloc.sessionInvites.listen((sessionSecret) {
+    widget._blocs.connectPayBloc.sessionInvites.listen((sessionLink) async {
       print("got invite in breez app " + _navigatorKey.currentState.toString());
-      widget._blocs.connectPayBloc.terminateCurrentSession().then((_){
-        _navigatorKey.currentState.push(FadeInRoute(builder: (_) => new ConnectToPayPage(sessionSecret)));
-      });      
+      var remoteSession = await widget._blocs.connectPayBloc.joinSessionByLink(sessionLink);
+      _navigatorKey.currentState.push(FadeInRoute(builder: (_) => new ConnectToPayPage(remoteSession)));         
     });
   }
 

--- a/lib/routes/user/connect_to_pay/connect_to_pay_page.dart
+++ b/lib/routes/user/connect_to_pay/connect_to_pay_page.dart
@@ -65,20 +65,19 @@ class _ConnectToPayState extends State<_ConnectToPayPage> {
 
   _initSession() async {
     if (widget._sessionLink != null) {
-      widget._connectPayBloc.joinSessionByLink(widget._sessionLink)
-      .then((session){        
-        setState(() {
-          _currentSession = session;
+      _currentSession = await widget._connectPayBloc.joinSessionByLink(widget._sessionLink);
+      setState(() {          
           _payer = false;
           _title = "Receive Payment";   
           _onSessionCreated();   
-        });
-      });      
+        });   
     } else {
-      _currentSession = widget._connectPayBloc.startSessionAsPayer();
-      _payer = true;
-      _title = "Connect To Pay";
-      _onSessionCreated();
+      _currentSession = await widget._connectPayBloc.startSessionAsPayer();
+       setState(() { 
+        _payer = true;
+        _title = "Connect To Pay";
+        _onSessionCreated();
+       });
     }   
   }
 

--- a/lib/routes/user/connect_to_pay/connect_to_pay_page.dart
+++ b/lib/routes/user/connect_to_pay/connect_to_pay_page.dart
@@ -5,17 +5,13 @@ import 'package:breez/bloc/bloc_widget_connector.dart';
 import 'package:breez/bloc/connect_pay/connect_pay_bloc.dart';
 import 'package:breez/bloc/connect_pay/connect_pay_model.dart';
 import 'package:breez/bloc/connect_pay/payer_session.dart';
-import 'package:breez/logger.dart';
 import 'package:breez/routes/user/connect_to_pay/payee_session_widget.dart';
 import 'package:breez/routes/user/connect_to_pay/payer_session_widget.dart';
-import 'package:breez/routes/user/connect_to_pay/session_instructions.dart';
-import 'package:breez/services/deep_links.dart';
 import 'package:breez/theme_data.dart' as theme;
 import 'package:breez/widgets/back_button.dart' as backBtn;
 import 'package:breez/widgets/error_dialog.dart';
 import 'package:breez/widgets/flushbar.dart';
 import 'package:breez/widgets/loader.dart';
-import 'package:breez/widgets/static_loader.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:flutter/material.dart';
 
@@ -30,16 +26,15 @@ class ConnectToPayPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return new BlocConnector<AppBlocs>((context, blocs) => new _ConnectToPayPage(blocs.connectPayBloc, blocs.accountBloc, this._currentSession));
+    return new BlocConnector<AppBlocs>((context, blocs) => new _ConnectToPayPage(blocs.accountBloc, this._currentSession));
   }
 }
 
-class _ConnectToPayPage extends StatefulWidget {
-  final ConnectPayBloc _connectPayBloc;
+class _ConnectToPayPage extends StatefulWidget {  
   final AccountBloc _accountBloc;
   final RemoteSession _currentSession;
 
-  const _ConnectToPayPage(this._connectPayBloc, this._accountBloc, this._currentSession);
+  const _ConnectToPayPage(this._accountBloc, this._currentSession);
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/routes/user/connect_to_pay/connected_peer.dart
+++ b/lib/routes/user/connect_to_pay/connected_peer.dart
@@ -47,12 +47,14 @@ class ConnectedPeer extends StatelessWidget {
             right: 25.0,
             height: 24.0,
             width: 24.0,
-            child: _online ? Container(
+            child: _online ? DelayRender(              	
+              duration: PaymentSessionState.connectionEmulationDuration,	
+              child: Container(
                   decoration: BoxDecoration(
                 color: Colors.greenAccent[400],
                 border: Border.all(color: Colors.white, width: 3.0),
                 borderRadius: BorderRadius.all(Radius.circular(12.0)),
-              )) : SizedBox()) : SizedBox()
+              ))) : SizedBox()) : SizedBox()
       ])
     ]));
   }

--- a/lib/routes/user/connect_to_pay/connected_peer.dart
+++ b/lib/routes/user/connect_to_pay/connected_peer.dart
@@ -42,20 +42,17 @@ class ConnectedPeer extends StatelessWidget {
               border: Border.all(color: Colors.white, width: 3.0),
               borderRadius: BorderRadius.all(Radius.circular(12.0)),
             ))) : SizedBox(),
-        _paymentSessionData.invitationReady || _renderPayer ? Positioned(
+        _paymentSessionData.invitationReady || _renderPayer || _online ? Positioned(
             bottom: 25.0,
             right: 25.0,
             height: 24.0,
             width: 24.0,
-            child: _online ? DelayRender(              
-              duration: PaymentSessionState.connectionEmulationDuration,
-              child: Container(
+            child: _online ? Container(
                   decoration: BoxDecoration(
                 color: Colors.greenAccent[400],
                 border: Border.all(color: Colors.white, width: 3.0),
                 borderRadius: BorderRadius.all(Radius.circular(12.0)),
-              )),
-            ) : SizedBox()) : SizedBox()
+              )) : SizedBox()) : SizedBox()
       ])
     ]));
   }

--- a/lib/routes/user/connect_to_pay/payer_session_widget.dart
+++ b/lib/routes/user/connect_to_pay/payer_session_widget.dart
@@ -85,10 +85,10 @@ class _PayerInstructions extends StatelessWidget {
     } else if (sessionState.payerData.amount == null) {
       if (sessionState.payeeData.status.online) {
         message = '${sessionState.payeeData.userName} joined the session.\nPlease enter an amount and tap Pay to proceed.';
-      } else if (!sessionState.invitationSent) {
+      } else if (!sessionState.invitationSent && sessionState.payeeData.userName == null) {
         message = "Tap the Share button to share a link with a person that you want to pay.\nThen, please wait while this person clicks the link and joins the session.";
       } else {
-        return LoadingAnimatedText("Waiting for someone to join this session", textStyle: theme.sessionNotificationStyle);
+        return LoadingAnimatedText('Waiting for ${sessionState.payeeData.userName ?? "someone"} to join this session', textStyle: theme.sessionNotificationStyle);
       }
     } else if (sessionState.payeeData.paymentRequest == null) {
       return LoadingAnimatedText('Waiting for ${sessionState.payeeData.userName} to approve your payment', textStyle: theme.sessionNotificationStyle);

--- a/lib/services/breezlib/breez_bridge.dart
+++ b/lib/services/breezlib/breez_bridge.dart
@@ -108,11 +108,16 @@ class BreezBridge {
     return _invokeMethodWhenReady("addInvoice", {"argument": invoice.writeToBuffer()}).then((payReq) => payReq as String);
   }
 
-  Future<CreateRatchetSessionReply> createRatchetSession({String secret, String remotePubKey}) {
+  Future<CreateRatchetSessionReply> createRatchetSession({String sessionID, String secret, String remotePubKey}) {
     var request = CreateRatchetSessionRequest()
       ..secret = secret ?? ""
+      ..sessionID = sessionID ?? ""
       ..remotePubKey = remotePubKey ?? "";
     return _invokeMethodImmediate("createRatchetSession", {"argument": request.writeToBuffer()}).then((res) =>  new CreateRatchetSessionReply()..mergeFromBuffer(res ?? []));
+  }
+
+  Future<RatchetSessionInfoReply> ratchetSessionInfo(String sessionID) {
+    return _invokeMethodImmediate("ratchetSessionInfo", {"argument": sessionID}).then((res) =>  new RatchetSessionInfoReply()..mergeFromBuffer(res ?? []));
   }
 
   Future<String> ratchetEncrypt(String sessionID, String message) {

--- a/lib/services/breezlib/data/rpc.pb.dart
+++ b/lib/services/breezlib/data/rpc.pb.dart
@@ -735,6 +735,7 @@ class CreateRatchetSessionRequest extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('CreateRatchetSessionRequest')
     ..aOS(1, 'secret')
     ..aOS(2, 'remotePubKey')
+    ..aOS(3, 'sessionID')
     ..hasRequiredFields = false
   ;
 
@@ -763,6 +764,11 @@ class CreateRatchetSessionRequest extends GeneratedMessage {
   set remotePubKey(String v) { $_setString(1, v); }
   bool hasRemotePubKey() => $_has(1);
   void clearRemotePubKey() => clearField(2);
+
+  String get sessionID => $_getS(2, '');
+  set sessionID(String v) { $_setString(2, v); }
+  bool hasSessionID() => $_has(2);
+  void clearSessionID() => clearField(3);
 }
 
 class _ReadonlyCreateRatchetSessionRequest extends CreateRatchetSessionRequest with ReadonlyMessageMixin {}
@@ -808,6 +814,42 @@ class CreateRatchetSessionReply extends GeneratedMessage {
 }
 
 class _ReadonlyCreateRatchetSessionReply extends CreateRatchetSessionReply with ReadonlyMessageMixin {}
+
+class RatchetSessionInfoReply extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('RatchetSessionInfoReply')
+    ..aOS(1, 'sessionID')
+    ..aOB(2, 'initiated')
+    ..hasRequiredFields = false
+  ;
+
+  RatchetSessionInfoReply() : super();
+  RatchetSessionInfoReply.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  RatchetSessionInfoReply.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
+  RatchetSessionInfoReply clone() => new RatchetSessionInfoReply()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static RatchetSessionInfoReply create() => new RatchetSessionInfoReply();
+  static PbList<RatchetSessionInfoReply> createRepeated() => new PbList<RatchetSessionInfoReply>();
+  static RatchetSessionInfoReply getDefault() {
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyRatchetSessionInfoReply();
+    return _defaultInstance;
+  }
+  static RatchetSessionInfoReply _defaultInstance;
+  static void $checkItem(RatchetSessionInfoReply v) {
+    if (v is! RatchetSessionInfoReply) checkItemFailed(v, 'RatchetSessionInfoReply');
+  }
+
+  String get sessionID => $_getS(0, '');
+  set sessionID(String v) { $_setString(0, v); }
+  bool hasSessionID() => $_has(0);
+  void clearSessionID() => clearField(1);
+
+  bool get initiated => $_get(1, false);
+  set initiated(bool v) { $_setBool(1, v); }
+  bool hasInitiated() => $_has(1);
+  void clearInitiated() => clearField(2);
+}
+
+class _ReadonlyRatchetSessionInfoReply extends RatchetSessionInfoReply with ReadonlyMessageMixin {}
 
 class RatchetEncryptRequest extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('RatchetEncryptRequest')

--- a/lib/services/breezlib/data/rpc.pbjson.dart
+++ b/lib/services/breezlib/data/rpc.pbjson.dart
@@ -211,6 +211,7 @@ const CreateRatchetSessionRequest$json = const {
   '2': const [
     const {'1': 'secret', '3': 1, '4': 1, '5': 9, '10': 'secret'},
     const {'1': 'remotePubKey', '3': 2, '4': 1, '5': 9, '10': 'remotePubKey'},
+    const {'1': 'sessionID', '3': 3, '4': 1, '5': 9, '10': 'sessionID'},
   ],
 };
 
@@ -220,6 +221,14 @@ const CreateRatchetSessionReply$json = const {
     const {'1': 'sessionID', '3': 1, '4': 1, '5': 9, '10': 'sessionID'},
     const {'1': 'secret', '3': 2, '4': 1, '5': 9, '10': 'secret'},
     const {'1': 'pubKey', '3': 3, '4': 1, '5': 9, '10': 'pubKey'},
+  ],
+};
+
+const RatchetSessionInfoReply$json = const {
+  '1': 'RatchetSessionInfoReply',
+  '2': const [
+    const {'1': 'sessionID', '3': 1, '4': 1, '5': 9, '10': 'sessionID'},
+    const {'1': 'initiated', '3': 2, '4': 1, '5': 8, '10': 'initiated'},
   ],
 };
 


### PR DESCRIPTION
This PR totally refactor the connect to pay mechanism to meet the following requirements:

- Session is now persistent and re-entrant, both payee/payer can enter the session multiple time using a session link. Both are recognized as corresponding payee/payer.
- Entering an existing session means it is reseted to the initial state.
- Both parties hold internally the same session identifier so the system will be able to notify them when other party entered a session.
