### PR TITLE
FCM based sync

### DIFF
--- a/android/app/src/main/java/com/breez/client/job/JobManager.java
+++ b/android/app/src/main/java/com/breez/client/job/JobManager.java
@@ -1,0 +1,37 @@
+package com.breez.client.job;
+
+import com.breez.client.plugins.breez.breezlib.ChainSync;
+import androidx.work.Constraints;
+import androidx.work.ExistingWorkPolicy;
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.WorkManager;
+
+import static com.breez.client.plugins.breez.breezlib.ChainSync.UNIQUE_WORK_NAME;
+
+public class JobManager {
+
+    public static JobManager instance = new JobManager();
+
+    private JobManager(){}
+
+    public void enqueJob(String workName) throws Exception {
+        switch (workName) {
+            case UNIQUE_WORK_NAME:
+                startSyncJob();
+                return;
+            default:
+                throw new Exception("There is no associated work with " + workName);
+        }
+    }
+
+    private void startSyncJob(){
+        OneTimeWorkRequest oneTime = new OneTimeWorkRequest.Builder(ChainSync.class)
+                .setConstraints(
+                        new Constraints.Builder()
+                                .setRequiresBatteryNotLow(true)
+                                .build())
+                .build();
+
+        WorkManager.getInstance().enqueue(oneTime);        
+    }
+}

--- a/android/app/src/main/java/com/breez/client/plugins/breez/breezlib/Breez.java
+++ b/android/app/src/main/java/com/breez/client/plugins/breez/breezlib/Breez.java
@@ -66,19 +66,7 @@ public class Breez implements MethodChannel.MethodCallHandler, bindings.BreezNot
 
         Log.i(TAG, "workingDir = " + workingDir);
 
-        PeriodicWorkRequest periodic =
-                new PeriodicWorkRequest.Builder(ChainSync.class, 30, TimeUnit.MINUTES)
-                        .setConstraints(
-                                new Constraints.Builder()
-                                        .setRequiresBatteryNotLow(true)
-                                        .build())
-                        .setInputData(
-                                new Data.Builder()
-                                        .putString("workingDir", workingDir)
-                                        .build())
-                        .build();
-
-        WorkManager.getInstance().enqueueUniquePeriodicWork(UNIQUE_WORK_NAME, ExistingPeriodicWorkPolicy.KEEP, periodic);
+        WorkManager.getInstance().cancelUniqueWork(UNIQUE_WORK_NAME);
     }
 
     private void stop(MethodCall call, MethodChannel.Result result){

--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -228,8 +228,7 @@ class AccountBloc {
     }
 
     _listenUserChanges(Stream<BreezUserModel> userProfileStream, BreezBridge breezLib, Device device){      
-      userProfileStream.listen((user) async {
-        print("user profile bloc got user token=" + user.token);
+      userProfileStream.listen((user) async {        
         if (user.token != _currentUser?.token) {
           print("user profile bloc registering for channel open notifications");
           breezLib.registerChannelOpenedNotification(user.token);
@@ -245,6 +244,7 @@ class AccountBloc {
               print("Account bloc bootstrap has finished");   
               _accountController.add(_accountController.value.copyWith(bootstraping: false));     
               breezLib.startLightning();
+              breezLib.registerPeriodicSync(user.token);
               _checkNodeConflict(breezLib);              
               _fetchFundStatus(breezLib);
               _listenConnectivityChanges(breezLib);
@@ -387,7 +387,7 @@ class AccountBloc {
       breezLib.getAccount()
         .then((acc) {
           print("ACCOUNT CHANGED BALANCE=" + acc.balance.toString() + " STATUS = " + acc.status.toString());
-          _accountController.add(_accountController.value.copyWith(accountResponse: acc, currency: _currentUser.currency, bootstraping: false));          
+          _accountController.add(_accountController.value.copyWith(accountResponse: acc, currency: _currentUser?.currency));          
         })
         .catchError(_accountController.addError);
       _refreshPayments(breezLib);      

--- a/lib/bloc/account/account_model.dart
+++ b/lib/bloc/account/account_model.dart
@@ -51,7 +51,7 @@ class AccountModel {
       ..status = Account_AccountStatus.WAITING_DEPOSIT
       ..maxAllowedToReceive = Int64(0)
       ..maxPaymentAmount = Int64(0)      
-      , Currency.SAT, initial: true);
+      , Currency.SAT, initial: true, bootstraping: true);
   AccountModel copyWith({Account accountResponse, Currency currency, FundStatusReply_FundStatus addedFundsStatus, String paymentRequestInProgress, bool connected, Int64 onChainFeeRate, bool bootstraping}) {
     return AccountModel(
       accountResponse ?? this._accountResponse, 

--- a/lib/routes/user/home/wallet_dashboard.dart
+++ b/lib/routes/user/home/wallet_dashboard.dart
@@ -21,6 +21,7 @@ class WalletDashboard extends StatelessWidget {
   Widget build(BuildContext context) {
     double startHeaderSize = theme.headline.fontSize;
     double endHeaderFontSize = theme.headline.fontSize - 8.0;
+    bool showProgressBar = _accSettings?.showConnectProgress == true || _accountModel?.channelRequested == false;
 
     return Stack(
       alignment: AlignmentDirectional.topCenter,
@@ -43,7 +44,7 @@ class WalletDashboard extends StatelessWidget {
                       fit: BoxFit.fitWidth,
                       alignment: FractionalOffset.bottomCenter,
                     )))),
-        _accSettings?.showConnectProgress == true || _accountModel?.channelRequested == false ? 
+        showProgressBar ? 
           Positioned(top: 0.0, child: StatusIndicator(_accountModel)) : SizedBox(), 
         Positioned(
             top: 10.0,

--- a/lib/services/breezlib/breez_bridge.dart
+++ b/lib/services/breezlib/breez_bridge.dart
@@ -267,6 +267,10 @@ class BreezBridge {
     return _invokeMethodImmediate("getDefaultOnChainFeeRate").then((res) => Int64( res as int));        
   }
 
+  Future registerPeriodicSync(String token){
+    return _invokeMethodImmediate("registerPeriodicSync", {"argument": token});        
+  }
+
   Future copyBreezConfig(String workingDir) async{
     print("copyBreezConfig started");
     


### PR DESCRIPTION
This PR changes the "sync job" that should download the compact filters to be triggered from FCM rather than WorkManager.
The main reason is that the best practice should consider FCM trigger as first option to sync.
Currently we also cancels the job trigger to observe the FCM trigger behavior on different devices.