### PR TITLE
Add 1% channel reserve proper explanation

### DIFF
--- a/lib/bloc/account/account_model.dart
+++ b/lib/bloc/account/account_model.dart
@@ -106,7 +106,7 @@ class AccountModel {
 
   String validateOutgoingOnChainPayment(Int64 amount) {
     if (amount > walletBalance) {
-      String message = "You can't use more than ${currency.format(amount)}.";      
+      String message = "Not enough funds.";      
       return message;
     }
     return null;
@@ -121,18 +121,18 @@ class AccountModel {
   }
 
   String validatePayment(Int64 amount, bool outgoing) {
-    Int64 maxAmount = outgoing ? maxAllowedToPay : maxAllowedToReceive;
+    Int64 maxAmount = outgoing ? balance : maxAllowedToReceive;
     if (maxPaymentAmount != null && amount > maxPaymentAmount) {
       return 'Payment exceeds the limit (${currency.format(maxPaymentAmount)})';
     }
 
     if (amount > maxAmount) {
-      String message = "You can't use more than ${currency.format(maxAmount)}.";
-      if (outgoing) {
-        message += "\nBreez requires you to keep ${currency.format(reserveAmount)} in your balance.";
-      }
-      return message;
+      return "Not enough funds.";
     }
+
+    if (outgoing && amount > maxAllowedToPay ) {
+      return "Breez requires you to keep ${currency.format(reserveAmount)} in your balance.";
+    }     
 
     return null;
   }

--- a/lib/routes/user/connect_to_pay/payment_details_form.dart
+++ b/lib/routes/user/connect_to_pay/payment_details_form.dart
@@ -49,10 +49,9 @@ class _PaymentDetailsFormState extends State<PaymentDetailsForm> {
                   child: Column(
                     children: [
                       AmountFormField(
-                        maxPaymentAmount: widget._account.maxPaymentAmount,
+                        validatorFn: widget._account.validateOutgoingPayment,
                         currency: widget._account.currency,
-                        controller: _amountController,
-                        maxAmount: widget._account.maxAllowedToPay - widget._account.routingNodeFee,
+                        controller: _amountController,                        
                         decoration: new InputDecoration(
                             labelText: widget._account.currency.displayName +
                                 " Amount"),

--- a/lib/routes/user/create_invoice/create_invoice_page.dart
+++ b/lib/routes/user/create_invoice/create_invoice_page.dart
@@ -143,8 +143,7 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
                   new AmountFormField(
                       controller: _amountController,
                       currency: acc.currency,
-                      maxPaymentAmount: acc.maxPaymentAmount,
-                      maxAmount: acc.maxAllowedToReceive,
+                      validatorFn: acc.validateIncomingPayment,
                       decoration: new InputDecoration(
                           labelText: acc.currency.displayName + " Amount"),
                       style: theme.FieldTextStyle.textStyle),

--- a/lib/routes/user/pay_nearby/pay_nearby_page.dart
+++ b/lib/routes/user/pay_nearby/pay_nearby_page.dart
@@ -82,12 +82,11 @@ class PayNearbyPageState extends State<PayNearbyPage> {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
                     new AmountFormField(
-                      maxPaymentAmount: account.maxPaymentAmount,
+                      validatorFn: account.validateOutgoingPayment,
                       decoration: new InputDecoration(
                           contentPadding: EdgeInsets.only(top: 21.0, bottom: 8.0), labelText: account.currency.displayName + " Amount"),
                       style: theme.FieldTextStyle.textStyle,
-                      currency: account.currency,
-                      maxAmount: account.maxAllowedToPay,
+                      currency: account.currency,                      
                       onFieldSubmitted: (String value) {
                         _amountToSendSatoshi = account.currency.parse(value);
                       },

--- a/lib/routes/user/withdraw_funds/send_coins_dialog.dart
+++ b/lib/routes/user/withdraw_funds/send_coins_dialog.dart
@@ -211,8 +211,7 @@ class SendWalletFundsDialogState extends State<SendWalletFundsDialog> {
                         new AmountFormField(
                             controller: _amountController,
                             currency: acc.currency,
-                            maxPaymentAmount: acc.walletBalance,
-                            maxAmount: acc.walletBalance,
+                            validatorFn: acc.validateOutgoingOnChainPayment,                            
                             decoration: new InputDecoration(
                                 labelText:
                                     acc.currency.displayName + " Amount"),

--- a/lib/routes/user/withdraw_funds/withdraw_funds_page.dart
+++ b/lib/routes/user/withdraw_funds/withdraw_funds_page.dart
@@ -187,8 +187,7 @@ class WithdrawFundsPageState extends State<WithdrawFundsPage> {
                   new AmountFormField(
                       controller: _amountController,                      
                       currency: acc.currency,
-                      maxPaymentAmount: acc.maxPaymentAmount,
-                      maxAmount: acc.maxAllowedToPay,
+                      validatorFn: acc.validateOutgoingPayment,
                       decoration: new InputDecoration(
                           labelText: acc.currency.displayName + " Amount"),
                       style: theme.FieldTextStyle.textStyle),                 

--- a/lib/widgets/amount_form_field.dart
+++ b/lib/widgets/amount_form_field.dart
@@ -6,14 +6,12 @@ import 'package:fixnum/fixnum.dart';
 
 
 class AmountFormField extends TextFormField {
-  final Currency currency;
-  final Int64 maxAmount;
-  final Int64 maxPaymentAmount;  
+  final Currency currency;  
+  final String Function(Int64 amount) validatorFn;
 
-  AmountFormField({    
-    this.maxPaymentAmount,
-    this.currency,
-    this.maxAmount,
+  AmountFormField({        
+    this.currency,    
+    this.validatorFn,
     TextEditingController controller,
     Key key,
     String initialValue,
@@ -46,14 +44,11 @@ class AmountFormField extends TextFormField {
       if (intAmount <= 0) {
         return "Invalid amount";
       }
-
-      if (maxPaymentAmount != null && intAmount > maxPaymentAmount) {
-        return 'Payment exceeds the limit (${currency.format(maxPaymentAmount)})';
+      String msg;
+      if (validatorFn != null) {
+        msg = validatorFn(intAmount);
       }   
-
-      if (maxAmount != null && intAmount > maxAmount) {
-        return "You can't use more than ${currency.format(maxAmount)}";
-      }         
+      return msg;   
     };
   }
 }

--- a/lib/widgets/payment_request_dialog.dart
+++ b/lib/widgets/payment_request_dialog.dart
@@ -60,7 +60,7 @@ class PaymentRequestDialogState extends State<PaymentRequestDialog> {
                     fadeInDuration: new Duration(milliseconds: 200)),
               )
             ]),
-      contentPadding: EdgeInsets.fromLTRB(16.0, 0.0, 16.0, 16.0),
+      contentPadding: EdgeInsets.fromLTRB(8.0, 0.0, 8.0, 16.0),
       content: StreamBuilder<AccountModel>(
         stream: widget.accountBloc.accountStream,
         builder: (context, snapshot) {
@@ -106,13 +106,14 @@ class PaymentRequestDialogState extends State<PaymentRequestDialog> {
   }
 
   Widget _buildErrorMessage(AccountModel account) {
-    if (account.maxAllowedToPay >= amountToPay(account) || widget.invoice.amount == 0) {
+    String validationError = account.validateOutgoingPayment(amountToPay(account));
+    if (validationError == null || widget.invoice.amount == 0) {
       return null;
     }
 
     return Padding(
       padding: const EdgeInsets.only(top: 8.0, left: 8.0, right: 8.0),
-      child: AutoSizeText("Not enough funds to complete this payment",
+      child: AutoSizeText(validationError,
           maxLines: 3,
           textAlign: TextAlign.center,
           style: theme.paymentRequestSubtitleStyle.copyWith(color: Colors.red)),
@@ -150,10 +151,9 @@ class PaymentRequestDialogState extends State<PaymentRequestDialog> {
                 height: 80.0,
                 child: AmountFormField(                
                   style: theme.alertStyle.copyWith(height: 1.0),
-                  maxPaymentAmount: account.maxPaymentAmount,
+                  validatorFn: account.validateOutgoingPayment,
                   currency: account.currency,
-                  controller: _invoiceAmountController,
-                  maxAmount: account.maxAllowedToPay - account.routingNodeFee,
+                  controller: _invoiceAmountController,                  
                   decoration: new InputDecoration(
                       labelText: account.currency.displayName +
                           " Amount"),


### PR DESCRIPTION
This PR add proper validation error in the cases of sent/request payments.
It takes into account the 1% channel reservation and all the logic for this validation is moved into the account model so it can be used not only from form fields.