### PR TITLE
Restore progress

### DIFF
--- a/lib/bloc/account/account_model.dart
+++ b/lib/bloc/account/account_model.dart
@@ -69,8 +69,7 @@ class AccountModel {
   bool get processingBreezConnection => _accountResponse.status == Account_AccountStatus.PROCESSING_BREEZ_CONNECTION;
   bool get processingWithdrawal => _accountResponse.status == Account_AccountStatus.PROCESSING_WITHDRAWAL;
   bool get active => _accountResponse.status == Account_AccountStatus.ACTIVE;  
-  bool get isInitialBootstrap => bootstraping || (!active && !processingWithdrawal && !processingBreezConnection);
-  bool get channelRequested => processingBreezConnection || active;
+  bool get isInitialBootstrap => bootstraping || (!active && !processingWithdrawal && !processingBreezConnection);  
   Int64 get balance => _accountResponse.balance;  
   Int64 get walletBalance => _accountResponse.walletBalance;
   String get statusLine => _accountResponse.status.toString();

--- a/lib/routes/pos/home/pos_invoice.dart
+++ b/lib/routes/pos/home/pos_invoice.dart
@@ -171,7 +171,7 @@ class POSInvoiceState extends State<POSInvoice> {
                                 builder: (context, snapshot) {
                                   AccountModel acc = snapshot.data;
                                   AccountSettings settings = settingSnapshot.data;
-                                  if (settings?.showConnectProgress == true || acc?.channelRequested == false ) {
+                                  if (settings?.showConnectProgress == true || acc?.isInitialBootstrap == true ) {
                                     return new StatusIndicator(snapshot.data);
                                   }
                                   return SizedBox();

--- a/lib/routes/shared/initial_walkthrough.dart
+++ b/lib/routes/shared/initial_walkthrough.dart
@@ -41,10 +41,10 @@ class InitialWalkthroughPageState extends State<InitialWalkthroughPage>
           return;
         }
 
-        // if (options.length == 1) {
-        //   widget._backupBloc.restoreRequestSink.add(options.first.nodeID);
-        //   return;
-        // }
+        if (options.length == 1) {
+          widget._backupBloc.restoreRequestSink.add(options.first.nodeID);
+          return;
+        }
 
         popToWalkthrough();
         showDialog(context: context, builder: (_) => new RestoreDialog(context, widget._backupBloc, options))

--- a/lib/routes/shared/initial_walkthrough.dart
+++ b/lib/routes/shared/initial_walkthrough.dart
@@ -41,10 +41,10 @@ class InitialWalkthroughPageState extends State<InitialWalkthroughPage>
           return;
         }
 
-        if (options.length == 1) {
-          widget._backupBloc.restoreRequestSink.add(options.first.nodeID);
-          return;
-        }
+        // if (options.length == 1) {
+        //   widget._backupBloc.restoreRequestSink.add(options.first.nodeID);
+        //   return;
+        // }
 
         popToWalkthrough();
         showDialog(context: context, builder: (_) => new RestoreDialog(context, widget._backupBloc, options))

--- a/lib/routes/user/home/wallet_dashboard.dart
+++ b/lib/routes/user/home/wallet_dashboard.dart
@@ -21,7 +21,7 @@ class WalletDashboard extends StatelessWidget {
   Widget build(BuildContext context) {
     double startHeaderSize = theme.headline.fontSize;
     double endHeaderFontSize = theme.headline.fontSize - 8.0;
-    bool showProgressBar = _accSettings?.showConnectProgress == true || _accountModel?.channelRequested == false;
+    bool showProgressBar = _accSettings?.showConnectProgress == true || _accountModel?.isInitialBootstrap == true;
 
     return Stack(
       alignment: AlignmentDirectional.topCenter,

--- a/lib/services/breezlib/breez_bridge.dart
+++ b/lib/services/breezlib/breez_bridge.dart
@@ -343,7 +343,7 @@ class BreezBridge {
     );
   }
 
-  Future<void> bootstrap() async {
+  Future<bool> bootstrap() async {
     return getApplicationDocumentsDirectory().then(
             (appDir) {
           var lndBootstrapper = new LNDBootstrapper();

--- a/lib/services/breezlib/lnd_bootstrapper.dart
+++ b/lib/services/breezlib/lnd_bootstrapper.dart
@@ -12,7 +12,7 @@ class LNDBootstrapper {
   final StreamController<DownloadFileInfo> _bootstrapFilesProgress = new StreamController.broadcast();
   Stream<DownloadFileInfo> get bootstrapProgressStreams => _bootstrapFilesProgress.stream;
 
-  Future downloadBootstrapFiles(String lndDir) async {
+  Future<bool> downloadBootstrapFiles(String lndDir) async {
     Config config = await _readConfig();
     String network = config.get('Application Options', 'network');
     String bootstrapUrl = config.get('Application Options', 'bootstrap');
@@ -35,7 +35,7 @@ class LNDBootstrapper {
     //if bootstrap files already exist
     if (destinationFiles.every((f) => File(f).existsSync())) {     
       _bootstrapFilesProgress.close();
-      return Future.value(null);
+      return Future.value(false);
     }
 
     //clean temp dir and target dir.
@@ -51,7 +51,7 @@ class LNDBootstrapper {
       log.severe("Error downloading CURRENT file");
       //_bootstrapFilesProgress.add(??);
       _bootstrapFilesProgress.close();
-      return Future.value(null);
+      return Future.error("Error downloading bootstrap files");
     }
     var currentDir = response.body.trim();
     Iterable<String> urls = allFiles.map((file) => urlPrefix + '/' + currentDir + '/' + file);
@@ -64,6 +64,7 @@ class LNDBootstrapper {
         }).then((value) {
         tempDir.deleteSync(recursive: true);
         _bootstrapFilesProgress.close();
+        return true;
       });
     });   
   }


### PR DESCRIPTION
In this PR we consolidate the restore/initial start flows to show progressing indicator as long as the client didn't finish its bootstrap phase.
This PR also define better the bootstrap phase as the time range between the first startup and the first connection establishment with the routing node.
As long as the user haven't cross that line (the first connect) the app state will be "bootstrapping" and the progress indicator will be shown (regardless of its settings).
The above behavior applies for both fresh node and restored node.