### PR TITLE
Disable account

### DIFF
--- a/lib/bloc/account/account_model.dart
+++ b/lib/bloc/account/account_model.dart
@@ -41,10 +41,11 @@ class AccountModel {
   final Int64 onChainFeeRate;  
   final bool initial;
   final bool bootstraping;
+  final bool enableInProgress;
 
   FundStatusReply_FundStatus get addedFundsStatus => addedFundsReply == null ? FundStatusReply_FundStatus.NO_FUND : addedFundsReply.status;
 
-  AccountModel(this._accountResponse, this._currency, {this.initial = false, this.addedFundsReply, this.paymentRequestInProgress, this.connected = false, this.onChainFeeRate, this.bootstraping = false});
+  AccountModel(this._accountResponse, this._currency, {this.initial = false, this.addedFundsReply, this.paymentRequestInProgress, this.connected = false, this.onChainFeeRate, this.bootstraping = false, this.enableInProgress = false});
 
   AccountModel.initial() : 
     this(Account()
@@ -52,9 +53,10 @@ class AccountModel {
       ..walletBalance = Int64(0)
       ..status = Account_AccountStatus.WAITING_DEPOSIT
       ..maxAllowedToReceive = Int64(0)
-      ..maxPaymentAmount = Int64(0)      
+      ..maxPaymentAmount = Int64(0)
+      ..enabled = true      
       , Currency.SAT, initial: true, bootstraping: true);
-  AccountModel copyWith({Account accountResponse, Currency currency, FundStatusReply addedFundsReply, String paymentRequestInProgress, bool connected, Int64 onChainFeeRate, bool bootstraping}) {
+  AccountModel copyWith({Account accountResponse, Currency currency, FundStatusReply addedFundsReply, String paymentRequestInProgress, bool connected, Int64 onChainFeeRate, bool bootstraping, bool enableInProgress}) {
     return AccountModel(
       accountResponse ?? this._accountResponse, 
       currency ?? this.currency, 
@@ -62,6 +64,7 @@ class AccountModel {
       connected: connected ?? this.connected,      
       onChainFeeRate: onChainFeeRate ?? this.onChainFeeRate,
       bootstraping: bootstraping ?? this.bootstraping,
+      enableInProgress: enableInProgress ?? this.enableInProgress,
       paymentRequestInProgress: paymentRequestInProgress ?? this.paymentRequestInProgress);
   }
 
@@ -82,6 +85,7 @@ class AccountModel {
   Int64 get reserveAmount => balance - maxAllowedToPay;
   Int64 get maxPaymentAmount => _accountResponse.maxPaymentAmount;
   Int64 get routingNodeFee => _accountResponse.routingNodeFee;
+  bool get enabled => _accountResponse.enabled;
 
   String get statusMessage {
     if (this.initial) {

--- a/lib/routes/shared/dev/dev.dart
+++ b/lib/routes/shared/dev/dev.dart
@@ -27,8 +27,7 @@ class LinkTextSpan extends TextSpan {
             recognizer: new TapGestureRecognizer()
               ..onTap = () {
                 _cliInputController.text = command + " ";
-                FocusScope
-                    .of(_scaffoldKey.currentState.context)
+                FocusScope.of(_scaffoldKey.currentState.context)
                     .requestFocus(_cliEntryFocusNode);
               });
 }
@@ -104,174 +103,197 @@ class DevViewState extends State<DevView> {
   Widget build(BuildContext context) {
     AccountBloc accBloc = AppBlocsProvider.of<AccountBloc>(context);
     return StreamBuilder(
-      stream: accBloc.accountSettingsStream,
-      builder: (context, settingsSnapshot) {
-        return new Scaffold(
-          key: _scaffoldKey,
-          appBar: new AppBar(
-            iconTheme: theme.appBarIconTheme,
-            textTheme: theme.appBarTextTheme,
-            backgroundColor: theme.BreezColors.blue[500],
-            leading: backBtn.BackButton(),
-            elevation: 0.0,
-            actions: <Widget>[
-              PopupMenuButton<Choice>(
-                onSelected: widget._select,
-                itemBuilder: (BuildContext context) {
-                  return getChoices(accBloc, settingsSnapshot.data).map((Choice choice) {
-                    return PopupMenuItem<Choice>(
-                      value: choice,
-                      child: Text(choice.title),
-                    );
-                  }).toList();
-                },
-              ),
-            ],
-            title: new Text(
-              "Developers",
-              style: theme.appBarTextStyle,
-            ),
-          ),
-          body: new Column(mainAxisSize: MainAxisSize.max, children: <Widget>[
-            Padding(
-              padding: const EdgeInsets.only(left: 10.0),
-              child: new Row(
-                children: <Widget>[
-                  new Flexible(
-                      child: new TextField(
-                    focusNode: _cliEntryFocusNode,
-                    controller: _cliInputController,
-                    decoration: InputDecoration(
-                        hintText: 'Enter a command or use the links below'),
-                    onSubmitted: (command) {
-                      _sendCommand(command);
-                    },
-                  )),
-                  new IconButton(
-                    icon: new Icon(Icons.play_arrow),
-                    tooltip: 'Run',
-                    onPressed: () {
-                      _sendCommand(_cliInputController.text);
-                    },
-                  ),
-                  new IconButton(
-                    icon: new Icon(Icons.clear),
-                    tooltip: 'Clear',
-                    onPressed: () {
-                      setState(() {
-                        _cliInputController.clear();
-                        _showDefaultCommands = true;
-                        _cliText = "";
-                        _richCliText = defaultCliCommandsText;
-                      });
-                    },
-                  ),
-                ],
-              ),
-            ),
-            new Expanded(
-                flex: 1,
-                child: new Container(
-                  padding: new EdgeInsets.all(10.0),
-                  child: new Container(
-                    padding: _showDefaultCommands
-                        ? new EdgeInsets.all(0.0)
-                        : new EdgeInsets.all(2.0),
-                    decoration: new BoxDecoration(
-                        border: _showDefaultCommands ? null : new Border.all(
-                            width: 1.0,
-                            color: Color(0x80FFFFFF))),
-                    child: new Column(
-                      mainAxisSize: MainAxisSize.max,
-                      children: <Widget>[
-                        _showDefaultCommands
-                            ? new Container()
-                            : new Row(
-                                mainAxisAlignment: MainAxisAlignment.end,
-                                children: <Widget>[
-                                  new IconButton(
-                                    icon: new Icon(Icons.content_copy),
-                                    tooltip: 'Copy to Clipboard',
-                                    iconSize: 19.0,
-                                    onPressed: () {
-                                      Clipboard.setData(
-                                          new ClipboardData(text: _cliText));
-                                      _scaffoldKey.currentState
-                                          .showSnackBar(new SnackBar(
-                                        content: new Text(
-                                          'Copied to clipboard.',
-                                          style: theme.snackBarStyle,
-                                        ),
-                                        backgroundColor:
-                                            theme.snackBarBackgroundColor,
-                                        duration: new Duration(seconds: 2),
-                                      ));
-                                    },
-                                  ),
-                                  new IconButton(
-                                    icon: new Icon(Icons.share),
-                                    iconSize: 19.0,
-                                    tooltip: 'Share',
-                                    onPressed: () {
-                                      Share.share(_cliText);
-                                    },
-                                  )
-                                ],
-                              ),
-                        new Expanded(
-                            child: new SingleChildScrollView(
-                                child: Padding(
-                          padding: const EdgeInsets.all(8.0),
-                          child: new Row(
-                            children: <Widget>[
-                              new Expanded(
-                                  child: new RichText(
-                                      text: new TextSpan(
-                                          style: _cliTextStyle,
-                                          children: _richCliText)))
-                            ],
-                          ),
-                        )))
-                      ],
+        stream: accBloc.accountStream,
+        builder: (accCtx, accSnapshot) {
+          AccountModel account = accSnapshot.data;
+          return StreamBuilder(
+              stream: accBloc.accountSettingsStream,
+              builder: (context, settingsSnapshot) {
+                return new Scaffold(
+                  key: _scaffoldKey,
+                  appBar: new AppBar(
+                    iconTheme: theme.appBarIconTheme,
+                    textTheme: theme.appBarTextTheme,
+                    backgroundColor: theme.BreezColors.blue[500],
+                    leading: backBtn.BackButton(),
+                    elevation: 0.0,
+                    actions: <Widget>[
+                      PopupMenuButton<Choice>(
+                        onSelected: widget._select,
+                        itemBuilder: (BuildContext context) {
+                          return getChoices(
+                                  accBloc, settingsSnapshot.data, account)
+                              .map((Choice choice) {
+                            return PopupMenuItem<Choice>(
+                              value: choice,
+                              child: Text(choice.title),
+                            );
+                          }).toList();
+                        },
+                      ),
+                    ],
+                    title: new Text(
+                      "Developers",
+                      style: theme.appBarTextStyle,
                     ),
                   ),
-                )),
-            new LNDBootstrapProgress(),
-          ]),
-        );
-      }
-    );
+                  body: new Column(mainAxisSize: MainAxisSize.max, children: <
+                      Widget>[
+                    Padding(
+                      padding: const EdgeInsets.only(left: 10.0),
+                      child: new Row(
+                        children: <Widget>[
+                          new Flexible(
+                              child: new TextField(
+                            focusNode: _cliEntryFocusNode,
+                            controller: _cliInputController,
+                            decoration: InputDecoration(
+                                hintText:
+                                    'Enter a command or use the links below'),
+                            onSubmitted: (command) {
+                              _sendCommand(command);
+                            },
+                          )),
+                          new IconButton(
+                            icon: new Icon(Icons.play_arrow),
+                            tooltip: 'Run',
+                            onPressed: () {
+                              _sendCommand(_cliInputController.text);
+                            },
+                          ),
+                          new IconButton(
+                            icon: new Icon(Icons.clear),
+                            tooltip: 'Clear',
+                            onPressed: () {
+                              setState(() {
+                                _cliInputController.clear();
+                                _showDefaultCommands = true;
+                                _cliText = "";
+                                _richCliText = defaultCliCommandsText;
+                              });
+                            },
+                          ),
+                        ],
+                      ),
+                    ),
+                    new Expanded(
+                        flex: 1,
+                        child: new Container(
+                          padding: new EdgeInsets.all(10.0),
+                          child: new Container(
+                            padding: _showDefaultCommands
+                                ? new EdgeInsets.all(0.0)
+                                : new EdgeInsets.all(2.0),
+                            decoration: new BoxDecoration(
+                                border: _showDefaultCommands
+                                    ? null
+                                    : new Border.all(
+                                        width: 1.0, color: Color(0x80FFFFFF))),
+                            child: new Column(
+                              mainAxisSize: MainAxisSize.max,
+                              children: <Widget>[
+                                _showDefaultCommands
+                                    ? new Container()
+                                    : new Row(
+                                        mainAxisAlignment:
+                                            MainAxisAlignment.end,
+                                        children: <Widget>[
+                                          new IconButton(
+                                            icon: new Icon(Icons.content_copy),
+                                            tooltip: 'Copy to Clipboard',
+                                            iconSize: 19.0,
+                                            onPressed: () {
+                                              Clipboard.setData(
+                                                  new ClipboardData(
+                                                      text: _cliText));
+                                              _scaffoldKey.currentState
+                                                  .showSnackBar(new SnackBar(
+                                                content: new Text(
+                                                  'Copied to clipboard.',
+                                                  style: theme.snackBarStyle,
+                                                ),
+                                                backgroundColor: theme
+                                                    .snackBarBackgroundColor,
+                                                duration:
+                                                    new Duration(seconds: 2),
+                                              ));
+                                            },
+                                          ),
+                                          new IconButton(
+                                            icon: new Icon(Icons.share),
+                                            iconSize: 19.0,
+                                            tooltip: 'Share',
+                                            onPressed: () {
+                                              Share.share(_cliText);
+                                            },
+                                          )
+                                        ],
+                                      ),
+                                new Expanded(
+                                    child: new SingleChildScrollView(
+                                        child: Padding(
+                                  padding: const EdgeInsets.all(8.0),
+                                  child: new Row(
+                                    children: <Widget>[
+                                      new Expanded(
+                                          child: new RichText(
+                                              text: new TextSpan(
+                                                  style: _cliTextStyle,
+                                                  children: _richCliText)))
+                                    ],
+                                  ),
+                                )))
+                              ],
+                            ),
+                          ),
+                        )),
+                    new LNDBootstrapProgress(),
+                  ]),
+                );
+              });
+        });
   }
 
-  List<Choice> getChoices(AccountBloc accBloc, AccountSettings settings){
-    List<Choice> choices = <Choice>[
+  List<Choice> getChoices(
+      AccountBloc accBloc, AccountSettings settings, AccountModel account) {
+    List<Choice> choices = new List<Choice>();
+    choices.addAll([
+      Choice(title: 'Share Logs', icon: Icons.share, function: shareLog),
       Choice(
-        title: 'Share Logs', 
-        icon: Icons.share, 
-        function: shareLog),
+          title: 'Show Initial Screen',
+          icon: Icons.phone_android,
+          function: _gotoInitialScreen),
       Choice(
-        title: 'Show Initial Screen',
-        icon: Icons.phone_android,
-        function: _gotoInitialScreen),
+          title: 'Battery Optimization',
+          icon: Icons.phone_android,
+          function: _showOptimizationsSettings),
       Choice(
-        title: 'Battery Optimization',
-        icon: Icons.phone_android,
-        function: _showOptimizationsSettings),
-      Choice(
-        title: '${settings.showConnectProgress ? "Hide" : "Show"} Connect Progress',
-        icon: Icons.phone_android,
-        function: (){
-          toggleConnectProgress(accBloc, settings);
-        }),
-    ];
+          title:
+              '${settings.showConnectProgress ? "Hide" : "Show"} Connect Progress',
+          icon: Icons.phone_android,
+          function: () {
+            toggleConnectProgress(accBloc, settings);
+          })
+    ]);
+
+    if (!account.enableInProgress) {
+      choices.add(Choice(
+          title: account.enabled
+              ? "Disable Breez Account"
+              : "Enable Breez Account",
+          icon: Icons.phone_android,
+          function: () {
+            accBloc.accountEnableSink.add(!account.enabled);
+          }));
+    }
+
     return choices;
-  }  
+  }
 
   void _gotoInitialScreen() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     prefs.setBool('isFirstRun', true);
-    Navigator
-        .of(_scaffoldKey.currentState.context)
+    Navigator.of(_scaffoldKey.currentState.context)
         .pushReplacementNamed("/splash");
   }
 
@@ -279,7 +301,8 @@ class DevViewState extends State<DevView> {
     widget._permissionsService.requestOptimizationSettings();
   }
 
-  void toggleConnectProgress(AccountBloc bloc, AccountSettings settings){
-    bloc.accountSettingsSink.add(settings.copyWith(showConnectProgress: !settings.showConnectProgress));
+  void toggleConnectProgress(AccountBloc bloc, AccountSettings settings) {
+    bloc.accountSettingsSink.add(
+        settings.copyWith(showConnectProgress: !settings.showConnectProgress));
   }
 }

--- a/lib/services/breez_server/generated/breez.pb.dart
+++ b/lib/services/breez_server/generated/breez.pb.dart
@@ -32,9 +32,6 @@ class OpenChannelRequest extends $pb.GeneratedMessage {
   static $pb.PbList<OpenChannelRequest> createRepeated() => new $pb.PbList<OpenChannelRequest>();
   static OpenChannelRequest getDefault() => _defaultInstance ??= create()..freeze();
   static OpenChannelRequest _defaultInstance;
-  static void $checkItem(OpenChannelRequest v) {
-    if (v is! OpenChannelRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get pubKey => $_getS(0, '');
   set pubKey(String v) { $_setString(0, v); }
@@ -63,9 +60,6 @@ class OpenChannelReply extends $pb.GeneratedMessage {
   static $pb.PbList<OpenChannelReply> createRepeated() => new $pb.PbList<OpenChannelReply>();
   static OpenChannelReply getDefault() => _defaultInstance ??= create()..freeze();
   static OpenChannelReply _defaultInstance;
-  static void $checkItem(OpenChannelReply v) {
-    if (v is! OpenChannelReply) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 }
 
 class UpdateChannelPolicyRequest extends $pb.GeneratedMessage {
@@ -85,9 +79,6 @@ class UpdateChannelPolicyRequest extends $pb.GeneratedMessage {
   static $pb.PbList<UpdateChannelPolicyRequest> createRepeated() => new $pb.PbList<UpdateChannelPolicyRequest>();
   static UpdateChannelPolicyRequest getDefault() => _defaultInstance ??= create()..freeze();
   static UpdateChannelPolicyRequest _defaultInstance;
-  static void $checkItem(UpdateChannelPolicyRequest v) {
-    if (v is! UpdateChannelPolicyRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get pubKey => $_getS(0, '');
   set pubKey(String v) { $_setString(0, v); }
@@ -111,9 +102,6 @@ class UpdateChannelPolicyReply extends $pb.GeneratedMessage {
   static $pb.PbList<UpdateChannelPolicyReply> createRepeated() => new $pb.PbList<UpdateChannelPolicyReply>();
   static UpdateChannelPolicyReply getDefault() => _defaultInstance ??= create()..freeze();
   static UpdateChannelPolicyReply _defaultInstance;
-  static void $checkItem(UpdateChannelPolicyReply v) {
-    if (v is! UpdateChannelPolicyReply) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 }
 
 class AddFundInitRequest extends $pb.GeneratedMessage {
@@ -136,9 +124,6 @@ class AddFundInitRequest extends $pb.GeneratedMessage {
   static $pb.PbList<AddFundInitRequest> createRepeated() => new $pb.PbList<AddFundInitRequest>();
   static AddFundInitRequest getDefault() => _defaultInstance ??= create()..freeze();
   static AddFundInitRequest _defaultInstance;
-  static void $checkItem(AddFundInitRequest v) {
-    if (v is! AddFundInitRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get nodeID => $_getS(0, '');
   set nodeID(String v) { $_setString(0, v); }
@@ -168,6 +153,7 @@ class AddFundInitReply extends $pb.GeneratedMessage {
     ..aInt64(3, 'lockHeight')
     ..aInt64(4, 'maxAllowedDeposit')
     ..aOS(5, 'errorMessage')
+    ..aInt64(6, 'requiredReserve')
     ..hasRequiredFields = false
   ;
 
@@ -182,9 +168,6 @@ class AddFundInitReply extends $pb.GeneratedMessage {
   static $pb.PbList<AddFundInitReply> createRepeated() => new $pb.PbList<AddFundInitReply>();
   static AddFundInitReply getDefault() => _defaultInstance ??= create()..freeze();
   static AddFundInitReply _defaultInstance;
-  static void $checkItem(AddFundInitReply v) {
-    if (v is! AddFundInitReply) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get address => $_getS(0, '');
   set address(String v) { $_setString(0, v); }
@@ -210,6 +193,11 @@ class AddFundInitReply extends $pb.GeneratedMessage {
   set errorMessage(String v) { $_setString(4, v); }
   bool hasErrorMessage() => $_has(4);
   void clearErrorMessage() => clearField(5);
+
+  Int64 get requiredReserve => $_getI64(5);
+  set requiredReserve(Int64 v) { $_setInt64(5, v); }
+  bool hasRequiredReserve() => $_has(5);
+  void clearRequiredReserve() => clearField(6);
 }
 
 class AddFundStatusRequest extends $pb.GeneratedMessage {
@@ -230,9 +218,6 @@ class AddFundStatusRequest extends $pb.GeneratedMessage {
   static $pb.PbList<AddFundStatusRequest> createRepeated() => new $pb.PbList<AddFundStatusRequest>();
   static AddFundStatusRequest getDefault() => _defaultInstance ??= create()..freeze();
   static AddFundStatusRequest _defaultInstance;
-  static void $checkItem(AddFundStatusRequest v) {
-    if (v is! AddFundStatusRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   List<String> get addresses => $_getList(0);
 
@@ -262,9 +247,6 @@ class AddFundStatusReply_AddressStatus extends $pb.GeneratedMessage {
   static $pb.PbList<AddFundStatusReply_AddressStatus> createRepeated() => new $pb.PbList<AddFundStatusReply_AddressStatus>();
   static AddFundStatusReply_AddressStatus getDefault() => _defaultInstance ??= create()..freeze();
   static AddFundStatusReply_AddressStatus _defaultInstance;
-  static void $checkItem(AddFundStatusReply_AddressStatus v) {
-    if (v is! AddFundStatusReply_AddressStatus) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get tx => $_getS(0, '');
   set tx(String v) { $_setString(0, v); }
@@ -289,7 +271,7 @@ class AddFundStatusReply_AddressStatus extends $pb.GeneratedMessage {
 
 class AddFundStatusReply extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = new $pb.BuilderInfo('AddFundStatusReply', package: const $pb.PackageName('breez'))
-    ..m<String, AddFundStatusReply_AddressStatus>(1, 'statuses', $pb.PbFieldType.OS, $pb.PbFieldType.OM, AddFundStatusReply_AddressStatus.create)
+    ..m<String, AddFundStatusReply_AddressStatus>(1, 'statuses', 'AddFundStatusReply.StatusesEntry',$pb.PbFieldType.OS, $pb.PbFieldType.OM, AddFundStatusReply_AddressStatus.create, null, null , const $pb.PackageName('breez'))
     ..hasRequiredFields = false
   ;
 
@@ -304,9 +286,6 @@ class AddFundStatusReply extends $pb.GeneratedMessage {
   static $pb.PbList<AddFundStatusReply> createRepeated() => new $pb.PbList<AddFundStatusReply>();
   static AddFundStatusReply getDefault() => _defaultInstance ??= create()..freeze();
   static AddFundStatusReply _defaultInstance;
-  static void $checkItem(AddFundStatusReply v) {
-    if (v is! AddFundStatusReply) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   Map<String, AddFundStatusReply_AddressStatus> get statuses => $_getMap(0);
 }
@@ -329,9 +308,6 @@ class RemoveFundRequest extends $pb.GeneratedMessage {
   static $pb.PbList<RemoveFundRequest> createRepeated() => new $pb.PbList<RemoveFundRequest>();
   static RemoveFundRequest getDefault() => _defaultInstance ??= create()..freeze();
   static RemoveFundRequest _defaultInstance;
-  static void $checkItem(RemoveFundRequest v) {
-    if (v is! RemoveFundRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get address => $_getS(0, '');
   set address(String v) { $_setString(0, v); }
@@ -362,9 +338,6 @@ class RemoveFundReply extends $pb.GeneratedMessage {
   static $pb.PbList<RemoveFundReply> createRepeated() => new $pb.PbList<RemoveFundReply>();
   static RemoveFundReply getDefault() => _defaultInstance ??= create()..freeze();
   static RemoveFundReply _defaultInstance;
-  static void $checkItem(RemoveFundReply v) {
-    if (v is! RemoveFundReply) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get paymentRequest => $_getS(0, '');
   set paymentRequest(String v) { $_setString(0, v); }
@@ -394,9 +367,6 @@ class RedeemRemovedFundsRequest extends $pb.GeneratedMessage {
   static $pb.PbList<RedeemRemovedFundsRequest> createRepeated() => new $pb.PbList<RedeemRemovedFundsRequest>();
   static RedeemRemovedFundsRequest getDefault() => _defaultInstance ??= create()..freeze();
   static RedeemRemovedFundsRequest _defaultInstance;
-  static void $checkItem(RedeemRemovedFundsRequest v) {
-    if (v is! RedeemRemovedFundsRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get paymenthash => $_getS(0, '');
   set paymenthash(String v) { $_setString(0, v); }
@@ -421,80 +391,11 @@ class RedeemRemovedFundsReply extends $pb.GeneratedMessage {
   static $pb.PbList<RedeemRemovedFundsReply> createRepeated() => new $pb.PbList<RedeemRemovedFundsReply>();
   static RedeemRemovedFundsReply getDefault() => _defaultInstance ??= create()..freeze();
   static RedeemRemovedFundsReply _defaultInstance;
-  static void $checkItem(RedeemRemovedFundsReply v) {
-    if (v is! RedeemRemovedFundsReply) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get txid => $_getS(0, '');
   set txid(String v) { $_setString(0, v); }
   bool hasTxid() => $_has(0);
   void clearTxid() => clearField(1);
-}
-
-class FundRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('FundRequest', package: const $pb.PackageName('breez'))
-    ..aOS(1, 'deviceID')
-    ..aOS(2, 'lightningID')
-    ..aInt64(3, 'amount')
-    ..hasRequiredFields = false
-  ;
-
-  FundRequest() : super();
-  FundRequest.fromBuffer(List<int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
-  FundRequest.fromJson(String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
-  FundRequest clone() => new FundRequest()..mergeFromMessage(this);
-  FundRequest copyWith(void Function(FundRequest) updates) => super.copyWith((message) => updates(message as FundRequest));
-  $pb.BuilderInfo get info_ => _i;
-  static FundRequest create() => new FundRequest();
-  FundRequest createEmptyInstance() => create();
-  static $pb.PbList<FundRequest> createRepeated() => new $pb.PbList<FundRequest>();
-  static FundRequest getDefault() => _defaultInstance ??= create()..freeze();
-  static FundRequest _defaultInstance;
-  static void $checkItem(FundRequest v) {
-    if (v is! FundRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
-
-  String get deviceID => $_getS(0, '');
-  set deviceID(String v) { $_setString(0, v); }
-  bool hasDeviceID() => $_has(0);
-  void clearDeviceID() => clearField(1);
-
-  String get lightningID => $_getS(1, '');
-  set lightningID(String v) { $_setString(1, v); }
-  bool hasLightningID() => $_has(1);
-  void clearLightningID() => clearField(2);
-
-  Int64 get amount => $_getI64(2);
-  set amount(Int64 v) { $_setInt64(2, v); }
-  bool hasAmount() => $_has(2);
-  void clearAmount() => clearField(3);
-}
-
-class FundReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('FundReply', package: const $pb.PackageName('breez'))
-    ..e<FundReply_ReturnCode>(1, 'returnCode', $pb.PbFieldType.OE, FundReply_ReturnCode.SUCCESS, FundReply_ReturnCode.valueOf, FundReply_ReturnCode.values)
-    ..hasRequiredFields = false
-  ;
-
-  FundReply() : super();
-  FundReply.fromBuffer(List<int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
-  FundReply.fromJson(String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
-  FundReply clone() => new FundReply()..mergeFromMessage(this);
-  FundReply copyWith(void Function(FundReply) updates) => super.copyWith((message) => updates(message as FundReply));
-  $pb.BuilderInfo get info_ => _i;
-  static FundReply create() => new FundReply();
-  FundReply createEmptyInstance() => create();
-  static $pb.PbList<FundReply> createRepeated() => new $pb.PbList<FundReply>();
-  static FundReply getDefault() => _defaultInstance ??= create()..freeze();
-  static FundReply _defaultInstance;
-  static void $checkItem(FundReply v) {
-    if (v is! FundReply) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
-
-  FundReply_ReturnCode get returnCode => $_getN(0);
-  set returnCode(FundReply_ReturnCode v) { setField(1, v); }
-  bool hasReturnCode() => $_has(0);
-  void clearReturnCode() => clearField(1);
 }
 
 class GetSwapPaymentRequest extends $pb.GeneratedMessage {
@@ -514,9 +415,6 @@ class GetSwapPaymentRequest extends $pb.GeneratedMessage {
   static $pb.PbList<GetSwapPaymentRequest> createRepeated() => new $pb.PbList<GetSwapPaymentRequest>();
   static GetSwapPaymentRequest getDefault() => _defaultInstance ??= create()..freeze();
   static GetSwapPaymentRequest _defaultInstance;
-  static void $checkItem(GetSwapPaymentRequest v) {
-    if (v is! GetSwapPaymentRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get paymentRequest => $_getS(0, '');
   set paymentRequest(String v) { $_setString(0, v); }
@@ -541,9 +439,6 @@ class GetSwapPaymentReply extends $pb.GeneratedMessage {
   static $pb.PbList<GetSwapPaymentReply> createRepeated() => new $pb.PbList<GetSwapPaymentReply>();
   static GetSwapPaymentReply getDefault() => _defaultInstance ??= create()..freeze();
   static GetSwapPaymentReply _defaultInstance;
-  static void $checkItem(GetSwapPaymentReply v) {
-    if (v is! GetSwapPaymentReply) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get paymentError => $_getS(0, '');
   set paymentError(String v) { $_setString(0, v); }
@@ -569,9 +464,6 @@ class RegisterRequest extends $pb.GeneratedMessage {
   static $pb.PbList<RegisterRequest> createRepeated() => new $pb.PbList<RegisterRequest>();
   static RegisterRequest getDefault() => _defaultInstance ??= create()..freeze();
   static RegisterRequest _defaultInstance;
-  static void $checkItem(RegisterRequest v) {
-    if (v is! RegisterRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get deviceID => $_getS(0, '');
   set deviceID(String v) { $_setString(0, v); }
@@ -601,9 +493,6 @@ class RegisterReply extends $pb.GeneratedMessage {
   static $pb.PbList<RegisterReply> createRepeated() => new $pb.PbList<RegisterReply>();
   static RegisterReply getDefault() => _defaultInstance ??= create()..freeze();
   static RegisterReply _defaultInstance;
-  static void $checkItem(RegisterReply v) {
-    if (v is! RegisterReply) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get breezID => $_getS(0, '');
   set breezID(String v) { $_setString(0, v); }
@@ -631,9 +520,6 @@ class PaymentRequest extends $pb.GeneratedMessage {
   static $pb.PbList<PaymentRequest> createRepeated() => new $pb.PbList<PaymentRequest>();
   static PaymentRequest getDefault() => _defaultInstance ??= create()..freeze();
   static PaymentRequest _defaultInstance;
-  static void $checkItem(PaymentRequest v) {
-    if (v is! PaymentRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get breezID => $_getS(0, '');
   set breezID(String v) { $_setString(0, v); }
@@ -673,9 +559,6 @@ class InvoiceReply extends $pb.GeneratedMessage {
   static $pb.PbList<InvoiceReply> createRepeated() => new $pb.PbList<InvoiceReply>();
   static InvoiceReply getDefault() => _defaultInstance ??= create()..freeze();
   static InvoiceReply _defaultInstance;
-  static void $checkItem(InvoiceReply v) {
-    if (v is! InvoiceReply) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get error => $_getS(0, '');
   set error(String v) { $_setString(0, v); }
@@ -700,9 +583,6 @@ class UploadFileRequest extends $pb.GeneratedMessage {
   static $pb.PbList<UploadFileRequest> createRepeated() => new $pb.PbList<UploadFileRequest>();
   static UploadFileRequest getDefault() => _defaultInstance ??= create()..freeze();
   static UploadFileRequest _defaultInstance;
-  static void $checkItem(UploadFileRequest v) {
-    if (v is! UploadFileRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   List<int> get content => $_getN(0);
   set content(List<int> v) { $_setBytes(0, v); }
@@ -727,9 +607,6 @@ class UploadFileReply extends $pb.GeneratedMessage {
   static $pb.PbList<UploadFileReply> createRepeated() => new $pb.PbList<UploadFileReply>();
   static UploadFileReply getDefault() => _defaultInstance ??= create()..freeze();
   static UploadFileReply _defaultInstance;
-  static void $checkItem(UploadFileReply v) {
-    if (v is! UploadFileReply) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get url => $_getS(0, '');
   set url(String v) { $_setString(0, v); }
@@ -753,9 +630,6 @@ class PingRequest extends $pb.GeneratedMessage {
   static $pb.PbList<PingRequest> createRepeated() => new $pb.PbList<PingRequest>();
   static PingRequest getDefault() => _defaultInstance ??= create()..freeze();
   static PingRequest _defaultInstance;
-  static void $checkItem(PingRequest v) {
-    if (v is! PingRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 }
 
 class PingReply extends $pb.GeneratedMessage {
@@ -775,9 +649,6 @@ class PingReply extends $pb.GeneratedMessage {
   static $pb.PbList<PingReply> createRepeated() => new $pb.PbList<PingReply>();
   static PingReply getDefault() => _defaultInstance ??= create()..freeze();
   static PingReply _defaultInstance;
-  static void $checkItem(PingReply v) {
-    if (v is! PingReply) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get version => $_getS(0, '');
   set version(String v) { $_setString(0, v); }
@@ -808,9 +679,6 @@ class OrderRequest extends $pb.GeneratedMessage {
   static $pb.PbList<OrderRequest> createRepeated() => new $pb.PbList<OrderRequest>();
   static OrderRequest getDefault() => _defaultInstance ??= create()..freeze();
   static OrderRequest _defaultInstance;
-  static void $checkItem(OrderRequest v) {
-    if (v is! OrderRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get fullName => $_getS(0, '');
   set fullName(String v) { $_setString(0, v); }
@@ -864,9 +732,6 @@ class OrderReply extends $pb.GeneratedMessage {
   static $pb.PbList<OrderReply> createRepeated() => new $pb.PbList<OrderReply>();
   static OrderReply getDefault() => _defaultInstance ??= create()..freeze();
   static OrderReply _defaultInstance;
-  static void $checkItem(OrderReply v) {
-    if (v is! OrderReply) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 }
 
 class JoinCTPSessionRequest extends $pb.GeneratedMessage {
@@ -889,9 +754,6 @@ class JoinCTPSessionRequest extends $pb.GeneratedMessage {
   static $pb.PbList<JoinCTPSessionRequest> createRepeated() => new $pb.PbList<JoinCTPSessionRequest>();
   static JoinCTPSessionRequest getDefault() => _defaultInstance ??= create()..freeze();
   static JoinCTPSessionRequest _defaultInstance;
-  static void $checkItem(JoinCTPSessionRequest v) {
-    if (v is! JoinCTPSessionRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   JoinCTPSessionRequest_PartyType get partyType => $_getN(0);
   set partyType(JoinCTPSessionRequest_PartyType v) { setField(1, v); }
@@ -932,9 +794,6 @@ class JoinCTPSessionResponse extends $pb.GeneratedMessage {
   static $pb.PbList<JoinCTPSessionResponse> createRepeated() => new $pb.PbList<JoinCTPSessionResponse>();
   static JoinCTPSessionResponse getDefault() => _defaultInstance ??= create()..freeze();
   static JoinCTPSessionResponse _defaultInstance;
-  static void $checkItem(JoinCTPSessionResponse v) {
-    if (v is! JoinCTPSessionResponse) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get sessionID => $_getS(0, '');
   set sessionID(String v) { $_setString(0, v); }
@@ -964,9 +823,6 @@ class TerminateCTPSessionRequest extends $pb.GeneratedMessage {
   static $pb.PbList<TerminateCTPSessionRequest> createRepeated() => new $pb.PbList<TerminateCTPSessionRequest>();
   static TerminateCTPSessionRequest getDefault() => _defaultInstance ??= create()..freeze();
   static TerminateCTPSessionRequest _defaultInstance;
-  static void $checkItem(TerminateCTPSessionRequest v) {
-    if (v is! TerminateCTPSessionRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get sessionID => $_getS(0, '');
   set sessionID(String v) { $_setString(0, v); }
@@ -990,9 +846,6 @@ class TerminateCTPSessionResponse extends $pb.GeneratedMessage {
   static $pb.PbList<TerminateCTPSessionResponse> createRepeated() => new $pb.PbList<TerminateCTPSessionResponse>();
   static TerminateCTPSessionResponse getDefault() => _defaultInstance ??= create()..freeze();
   static TerminateCTPSessionResponse _defaultInstance;
-  static void $checkItem(TerminateCTPSessionResponse v) {
-    if (v is! TerminateCTPSessionResponse) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 }
 
 class RegisterTransactionConfirmationRequest extends $pb.GeneratedMessage {
@@ -1014,9 +867,6 @@ class RegisterTransactionConfirmationRequest extends $pb.GeneratedMessage {
   static $pb.PbList<RegisterTransactionConfirmationRequest> createRepeated() => new $pb.PbList<RegisterTransactionConfirmationRequest>();
   static RegisterTransactionConfirmationRequest getDefault() => _defaultInstance ??= create()..freeze();
   static RegisterTransactionConfirmationRequest _defaultInstance;
-  static void $checkItem(RegisterTransactionConfirmationRequest v) {
-    if (v is! RegisterTransactionConfirmationRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get txID => $_getS(0, '');
   set txID(String v) { $_setString(0, v); }
@@ -1050,8 +900,47 @@ class RegisterTransactionConfirmationResponse extends $pb.GeneratedMessage {
   static $pb.PbList<RegisterTransactionConfirmationResponse> createRepeated() => new $pb.PbList<RegisterTransactionConfirmationResponse>();
   static RegisterTransactionConfirmationResponse getDefault() => _defaultInstance ??= create()..freeze();
   static RegisterTransactionConfirmationResponse _defaultInstance;
-  static void $checkItem(RegisterTransactionConfirmationResponse v) {
-    if (v is! RegisterTransactionConfirmationResponse) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
+}
+
+class RegisterPeriodicSyncRequest extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('RegisterPeriodicSyncRequest', package: const $pb.PackageName('breez'))
+    ..aOS(1, 'notificationToken')
+    ..hasRequiredFields = false
+  ;
+
+  RegisterPeriodicSyncRequest() : super();
+  RegisterPeriodicSyncRequest.fromBuffer(List<int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  RegisterPeriodicSyncRequest.fromJson(String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
+  RegisterPeriodicSyncRequest clone() => new RegisterPeriodicSyncRequest()..mergeFromMessage(this);
+  RegisterPeriodicSyncRequest copyWith(void Function(RegisterPeriodicSyncRequest) updates) => super.copyWith((message) => updates(message as RegisterPeriodicSyncRequest));
+  $pb.BuilderInfo get info_ => _i;
+  static RegisterPeriodicSyncRequest create() => new RegisterPeriodicSyncRequest();
+  RegisterPeriodicSyncRequest createEmptyInstance() => create();
+  static $pb.PbList<RegisterPeriodicSyncRequest> createRepeated() => new $pb.PbList<RegisterPeriodicSyncRequest>();
+  static RegisterPeriodicSyncRequest getDefault() => _defaultInstance ??= create()..freeze();
+  static RegisterPeriodicSyncRequest _defaultInstance;
+
+  String get notificationToken => $_getS(0, '');
+  set notificationToken(String v) { $_setString(0, v); }
+  bool hasNotificationToken() => $_has(0);
+  void clearNotificationToken() => clearField(1);
+}
+
+class RegisterPeriodicSyncResponse extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('RegisterPeriodicSyncResponse', package: const $pb.PackageName('breez'))
+    ..hasRequiredFields = false
+  ;
+
+  RegisterPeriodicSyncResponse() : super();
+  RegisterPeriodicSyncResponse.fromBuffer(List<int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  RegisterPeriodicSyncResponse.fromJson(String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
+  RegisterPeriodicSyncResponse clone() => new RegisterPeriodicSyncResponse()..mergeFromMessage(this);
+  RegisterPeriodicSyncResponse copyWith(void Function(RegisterPeriodicSyncResponse) updates) => super.copyWith((message) => updates(message as RegisterPeriodicSyncResponse));
+  $pb.BuilderInfo get info_ => _i;
+  static RegisterPeriodicSyncResponse create() => new RegisterPeriodicSyncResponse();
+  RegisterPeriodicSyncResponse createEmptyInstance() => create();
+  static $pb.PbList<RegisterPeriodicSyncResponse> createRepeated() => new $pb.PbList<RegisterPeriodicSyncResponse>();
+  static RegisterPeriodicSyncResponse getDefault() => _defaultInstance ??= create()..freeze();
+  static RegisterPeriodicSyncResponse _defaultInstance;
 }
 

--- a/lib/services/breez_server/generated/breez.pbenum.dart
+++ b/lib/services/breez_server/generated/breez.pbenum.dart
@@ -8,32 +8,6 @@
 import 'dart:core' show int, dynamic, String, List, Map;
 import 'package:protobuf/protobuf.dart' as $pb;
 
-class FundReply_ReturnCode extends $pb.ProtobufEnum {
-  static const FundReply_ReturnCode SUCCESS = const FundReply_ReturnCode._(0, 'SUCCESS');
-  static const FundReply_ReturnCode UNKNOWN_ERROR = const FundReply_ReturnCode._(-1, 'UNKNOWN_ERROR');
-  static const FundReply_ReturnCode NODE_BUSY = const FundReply_ReturnCode._(-2, 'NODE_BUSY');
-  static const FundReply_ReturnCode CLIENT_NOT_REGISTERED = const FundReply_ReturnCode._(-3, 'CLIENT_NOT_REGISTERED');
-  static const FundReply_ReturnCode WRONG_NODE_ID = const FundReply_ReturnCode._(-4, 'WRONG_NODE_ID');
-  static const FundReply_ReturnCode WRONG_AMOUNT = const FundReply_ReturnCode._(-5, 'WRONG_AMOUNT');
-
-  static const List<FundReply_ReturnCode> values = const <FundReply_ReturnCode> [
-    SUCCESS,
-    UNKNOWN_ERROR,
-    NODE_BUSY,
-    CLIENT_NOT_REGISTERED,
-    WRONG_NODE_ID,
-    WRONG_AMOUNT,
-  ];
-
-  static final Map<int, FundReply_ReturnCode> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static FundReply_ReturnCode valueOf(int value) => _byValue[value];
-  static void $checkItem(FundReply_ReturnCode v) {
-    if (v is! FundReply_ReturnCode) $pb.checkItemFailed(v, 'FundReply_ReturnCode');
-  }
-
-  const FundReply_ReturnCode._(int v, String n) : super(v, n);
-}
-
 class JoinCTPSessionRequest_PartyType extends $pb.ProtobufEnum {
   static const JoinCTPSessionRequest_PartyType PAYER = const JoinCTPSessionRequest_PartyType._(0, 'PAYER');
   static const JoinCTPSessionRequest_PartyType PAYEE = const JoinCTPSessionRequest_PartyType._(1, 'PAYEE');
@@ -45,9 +19,6 @@ class JoinCTPSessionRequest_PartyType extends $pb.ProtobufEnum {
 
   static final Map<int, JoinCTPSessionRequest_PartyType> _byValue = $pb.ProtobufEnum.initByValue(values);
   static JoinCTPSessionRequest_PartyType valueOf(int value) => _byValue[value];
-  static void $checkItem(JoinCTPSessionRequest_PartyType v) {
-    if (v is! JoinCTPSessionRequest_PartyType) $pb.checkItemFailed(v, 'JoinCTPSessionRequest_PartyType');
-  }
 
   const JoinCTPSessionRequest_PartyType._(int v, String n) : super(v, n);
 }
@@ -63,9 +34,6 @@ class RegisterTransactionConfirmationRequest_NotificationType extends $pb.Protob
 
   static final Map<int, RegisterTransactionConfirmationRequest_NotificationType> _byValue = $pb.ProtobufEnum.initByValue(values);
   static RegisterTransactionConfirmationRequest_NotificationType valueOf(int value) => _byValue[value];
-  static void $checkItem(RegisterTransactionConfirmationRequest_NotificationType v) {
-    if (v is! RegisterTransactionConfirmationRequest_NotificationType) $pb.checkItemFailed(v, 'RegisterTransactionConfirmationRequest_NotificationType');
-  }
 
   const RegisterTransactionConfirmationRequest_NotificationType._(int v, String n) : super(v, n);
 }

--- a/lib/services/breez_server/generated/breez.pbgrpc.dart
+++ b/lib/services/breez_server/generated/breez.pbgrpc.dart
@@ -6,54 +6,54 @@
 
 import 'dart:async' as $async;
 
-import 'package:grpc/grpc.dart';
-
+import 'package:grpc/service_api.dart' as $grpc;
 import 'breez.pb.dart';
 export 'breez.pb.dart';
 
-class InvoicerClient extends Client {
+class InvoicerClient extends $grpc.Client {
   static final _$registerDevice =
-      new ClientMethod<RegisterRequest, RegisterReply>(
+      new $grpc.ClientMethod<RegisterRequest, RegisterReply>(
           '/breez.Invoicer/RegisterDevice',
           (RegisterRequest value) => value.writeToBuffer(),
           (List<int> value) => new RegisterReply.fromBuffer(value));
-  static final _$sendInvoice = new ClientMethod<PaymentRequest, InvoiceReply>(
-      '/breez.Invoicer/SendInvoice',
-      (PaymentRequest value) => value.writeToBuffer(),
-      (List<int> value) => new InvoiceReply.fromBuffer(value));
+  static final _$sendInvoice =
+      new $grpc.ClientMethod<PaymentRequest, InvoiceReply>(
+          '/breez.Invoicer/SendInvoice',
+          (PaymentRequest value) => value.writeToBuffer(),
+          (List<int> value) => new InvoiceReply.fromBuffer(value));
 
-  InvoicerClient(ClientChannel channel, {CallOptions options})
+  InvoicerClient($grpc.ClientChannel channel, {$grpc.CallOptions options})
       : super(channel, options: options);
 
-  ResponseFuture<RegisterReply> registerDevice(RegisterRequest request,
-      {CallOptions options}) {
+  $grpc.ResponseFuture<RegisterReply> registerDevice(RegisterRequest request,
+      {$grpc.CallOptions options}) {
     final call = $createCall(
         _$registerDevice, new $async.Stream.fromIterable([request]),
         options: options);
-    return new ResponseFuture(call);
+    return new $grpc.ResponseFuture(call);
   }
 
-  ResponseFuture<InvoiceReply> sendInvoice(PaymentRequest request,
-      {CallOptions options}) {
+  $grpc.ResponseFuture<InvoiceReply> sendInvoice(PaymentRequest request,
+      {$grpc.CallOptions options}) {
     final call = $createCall(
         _$sendInvoice, new $async.Stream.fromIterable([request]),
         options: options);
-    return new ResponseFuture(call);
+    return new $grpc.ResponseFuture(call);
   }
 }
 
-abstract class InvoicerServiceBase extends Service {
+abstract class InvoicerServiceBase extends $grpc.Service {
   String get $name => 'breez.Invoicer';
 
   InvoicerServiceBase() {
-    $addMethod(new ServiceMethod<RegisterRequest, RegisterReply>(
+    $addMethod(new $grpc.ServiceMethod<RegisterRequest, RegisterReply>(
         'RegisterDevice',
         registerDevice_Pre,
         false,
         false,
         (List<int> value) => new RegisterRequest.fromBuffer(value),
         (RegisterReply value) => value.writeToBuffer()));
-    $addMethod(new ServiceMethod<PaymentRequest, InvoiceReply>(
+    $addMethod(new $grpc.ServiceMethod<PaymentRequest, InvoiceReply>(
         'SendInvoice',
         sendInvoice_Pre,
         false,
@@ -63,43 +63,43 @@ abstract class InvoicerServiceBase extends Service {
   }
 
   $async.Future<RegisterReply> registerDevice_Pre(
-      ServiceCall call, $async.Future request) async {
+      $grpc.ServiceCall call, $async.Future request) async {
     return registerDevice(call, await request);
   }
 
   $async.Future<InvoiceReply> sendInvoice_Pre(
-      ServiceCall call, $async.Future request) async {
+      $grpc.ServiceCall call, $async.Future request) async {
     return sendInvoice(call, await request);
   }
 
   $async.Future<RegisterReply> registerDevice(
-      ServiceCall call, RegisterRequest request);
+      $grpc.ServiceCall call, RegisterRequest request);
   $async.Future<InvoiceReply> sendInvoice(
-      ServiceCall call, PaymentRequest request);
+      $grpc.ServiceCall call, PaymentRequest request);
 }
 
-class CardOrdererClient extends Client {
-  static final _$order = new ClientMethod<OrderRequest, OrderReply>(
+class CardOrdererClient extends $grpc.Client {
+  static final _$order = new $grpc.ClientMethod<OrderRequest, OrderReply>(
       '/breez.CardOrderer/Order',
       (OrderRequest value) => value.writeToBuffer(),
       (List<int> value) => new OrderReply.fromBuffer(value));
 
-  CardOrdererClient(ClientChannel channel, {CallOptions options})
+  CardOrdererClient($grpc.ClientChannel channel, {$grpc.CallOptions options})
       : super(channel, options: options);
 
-  ResponseFuture<OrderReply> order(OrderRequest request,
-      {CallOptions options}) {
+  $grpc.ResponseFuture<OrderReply> order(OrderRequest request,
+      {$grpc.CallOptions options}) {
     final call = $createCall(_$order, new $async.Stream.fromIterable([request]),
         options: options);
-    return new ResponseFuture(call);
+    return new $grpc.ResponseFuture(call);
   }
 }
 
-abstract class CardOrdererServiceBase extends Service {
+abstract class CardOrdererServiceBase extends $grpc.Service {
   String get $name => 'breez.CardOrderer';
 
   CardOrdererServiceBase() {
-    $addMethod(new ServiceMethod<OrderRequest, OrderReply>(
+    $addMethod(new $grpc.ServiceMethod<OrderRequest, OrderReply>(
         'Order',
         order_Pre,
         false,
@@ -109,76 +109,57 @@ abstract class CardOrdererServiceBase extends Service {
   }
 
   $async.Future<OrderReply> order_Pre(
-      ServiceCall call, $async.Future request) async {
+      $grpc.ServiceCall call, $async.Future request) async {
     return order(call, await request);
   }
 
-  $async.Future<OrderReply> order(ServiceCall call, OrderRequest request);
+  $async.Future<OrderReply> order($grpc.ServiceCall call, OrderRequest request);
 }
 
-class PosClient extends Client {
+class PosClient extends $grpc.Client {
   static final _$registerDevice =
-      new ClientMethod<RegisterRequest, RegisterReply>(
+      new $grpc.ClientMethod<RegisterRequest, RegisterReply>(
           '/breez.Pos/RegisterDevice',
           (RegisterRequest value) => value.writeToBuffer(),
           (List<int> value) => new RegisterReply.fromBuffer(value));
-  static final _$fundChannel = new ClientMethod<FundRequest, FundReply>(
-      '/breez.Pos/FundChannel',
-      (FundRequest value) => value.writeToBuffer(),
-      (List<int> value) => new FundReply.fromBuffer(value));
   static final _$uploadLogo =
-      new ClientMethod<UploadFileRequest, UploadFileReply>(
+      new $grpc.ClientMethod<UploadFileRequest, UploadFileReply>(
           '/breez.Pos/UploadLogo',
           (UploadFileRequest value) => value.writeToBuffer(),
           (List<int> value) => new UploadFileReply.fromBuffer(value));
 
-  PosClient(ClientChannel channel, {CallOptions options})
+  PosClient($grpc.ClientChannel channel, {$grpc.CallOptions options})
       : super(channel, options: options);
 
-  ResponseFuture<RegisterReply> registerDevice(RegisterRequest request,
-      {CallOptions options}) {
+  $grpc.ResponseFuture<RegisterReply> registerDevice(RegisterRequest request,
+      {$grpc.CallOptions options}) {
     final call = $createCall(
         _$registerDevice, new $async.Stream.fromIterable([request]),
         options: options);
-    return new ResponseFuture(call);
+    return new $grpc.ResponseFuture(call);
   }
 
-  ResponseFuture<FundReply> fundChannel(FundRequest request,
-      {CallOptions options}) {
-    final call = $createCall(
-        _$fundChannel, new $async.Stream.fromIterable([request]),
-        options: options);
-    return new ResponseFuture(call);
-  }
-
-  ResponseFuture<UploadFileReply> uploadLogo(UploadFileRequest request,
-      {CallOptions options}) {
+  $grpc.ResponseFuture<UploadFileReply> uploadLogo(UploadFileRequest request,
+      {$grpc.CallOptions options}) {
     final call = $createCall(
         _$uploadLogo, new $async.Stream.fromIterable([request]),
         options: options);
-    return new ResponseFuture(call);
+    return new $grpc.ResponseFuture(call);
   }
 }
 
-abstract class PosServiceBase extends Service {
+abstract class PosServiceBase extends $grpc.Service {
   String get $name => 'breez.Pos';
 
   PosServiceBase() {
-    $addMethod(new ServiceMethod<RegisterRequest, RegisterReply>(
+    $addMethod(new $grpc.ServiceMethod<RegisterRequest, RegisterReply>(
         'RegisterDevice',
         registerDevice_Pre,
         false,
         false,
         (List<int> value) => new RegisterRequest.fromBuffer(value),
         (RegisterReply value) => value.writeToBuffer()));
-    $addMethod(new ServiceMethod<FundRequest, FundReply>(
-        'FundChannel',
-        fundChannel_Pre,
-        false,
-        false,
-        (List<int> value) => new FundRequest.fromBuffer(value),
-        (FundReply value) => value.writeToBuffer()));
-    $addMethod(new ServiceMethod<UploadFileRequest, UploadFileReply>(
+    $addMethod(new $grpc.ServiceMethod<UploadFileRequest, UploadFileReply>(
         'UploadLogo',
         uploadLogo_Pre,
         false,
@@ -188,48 +169,43 @@ abstract class PosServiceBase extends Service {
   }
 
   $async.Future<RegisterReply> registerDevice_Pre(
-      ServiceCall call, $async.Future request) async {
+      $grpc.ServiceCall call, $async.Future request) async {
     return registerDevice(call, await request);
   }
 
-  $async.Future<FundReply> fundChannel_Pre(
-      ServiceCall call, $async.Future request) async {
-    return fundChannel(call, await request);
-  }
-
   $async.Future<UploadFileReply> uploadLogo_Pre(
-      ServiceCall call, $async.Future request) async {
+      $grpc.ServiceCall call, $async.Future request) async {
     return uploadLogo(call, await request);
   }
 
   $async.Future<RegisterReply> registerDevice(
-      ServiceCall call, RegisterRequest request);
-  $async.Future<FundReply> fundChannel(ServiceCall call, FundRequest request);
+      $grpc.ServiceCall call, RegisterRequest request);
   $async.Future<UploadFileReply> uploadLogo(
-      ServiceCall call, UploadFileRequest request);
+      $grpc.ServiceCall call, UploadFileRequest request);
 }
 
-class InformationClient extends Client {
-  static final _$ping = new ClientMethod<PingRequest, PingReply>(
+class InformationClient extends $grpc.Client {
+  static final _$ping = new $grpc.ClientMethod<PingRequest, PingReply>(
       '/breez.Information/Ping',
       (PingRequest value) => value.writeToBuffer(),
       (List<int> value) => new PingReply.fromBuffer(value));
 
-  InformationClient(ClientChannel channel, {CallOptions options})
+  InformationClient($grpc.ClientChannel channel, {$grpc.CallOptions options})
       : super(channel, options: options);
 
-  ResponseFuture<PingReply> ping(PingRequest request, {CallOptions options}) {
+  $grpc.ResponseFuture<PingReply> ping(PingRequest request,
+      {$grpc.CallOptions options}) {
     final call = $createCall(_$ping, new $async.Stream.fromIterable([request]),
         options: options);
-    return new ResponseFuture(call);
+    return new $grpc.ResponseFuture(call);
   }
 }
 
-abstract class InformationServiceBase extends Service {
+abstract class InformationServiceBase extends $grpc.Service {
   String get $name => 'breez.Information';
 
   InformationServiceBase() {
-    $addMethod(new ServiceMethod<PingRequest, PingReply>(
+    $addMethod(new $grpc.ServiceMethod<PingRequest, PingReply>(
         'Ping',
         ping_Pre,
         false,
@@ -239,50 +215,50 @@ abstract class InformationServiceBase extends Service {
   }
 
   $async.Future<PingReply> ping_Pre(
-      ServiceCall call, $async.Future request) async {
+      $grpc.ServiceCall call, $async.Future request) async {
     return ping(call, await request);
   }
 
-  $async.Future<PingReply> ping(ServiceCall call, PingRequest request);
+  $async.Future<PingReply> ping($grpc.ServiceCall call, PingRequest request);
 }
 
-class FundManagerClient extends Client {
+class FundManagerClient extends $grpc.Client {
   static final _$openChannel =
-      new ClientMethod<OpenChannelRequest, OpenChannelReply>(
+      new $grpc.ClientMethod<OpenChannelRequest, OpenChannelReply>(
           '/breez.FundManager/OpenChannel',
           (OpenChannelRequest value) => value.writeToBuffer(),
           (List<int> value) => new OpenChannelReply.fromBuffer(value));
-  static final _$updateChannelPolicy =
-      new ClientMethod<UpdateChannelPolicyRequest, UpdateChannelPolicyReply>(
-          '/breez.FundManager/UpdateChannelPolicy',
-          (UpdateChannelPolicyRequest value) => value.writeToBuffer(),
-          (List<int> value) => new UpdateChannelPolicyReply.fromBuffer(value));
+  static final _$updateChannelPolicy = new $grpc
+          .ClientMethod<UpdateChannelPolicyRequest, UpdateChannelPolicyReply>(
+      '/breez.FundManager/UpdateChannelPolicy',
+      (UpdateChannelPolicyRequest value) => value.writeToBuffer(),
+      (List<int> value) => new UpdateChannelPolicyReply.fromBuffer(value));
   static final _$addFundInit =
-      new ClientMethod<AddFundInitRequest, AddFundInitReply>(
+      new $grpc.ClientMethod<AddFundInitRequest, AddFundInitReply>(
           '/breez.FundManager/AddFundInit',
           (AddFundInitRequest value) => value.writeToBuffer(),
           (List<int> value) => new AddFundInitReply.fromBuffer(value));
   static final _$addFundStatus =
-      new ClientMethod<AddFundStatusRequest, AddFundStatusReply>(
+      new $grpc.ClientMethod<AddFundStatusRequest, AddFundStatusReply>(
           '/breez.FundManager/AddFundStatus',
           (AddFundStatusRequest value) => value.writeToBuffer(),
           (List<int> value) => new AddFundStatusReply.fromBuffer(value));
   static final _$removeFund =
-      new ClientMethod<RemoveFundRequest, RemoveFundReply>(
+      new $grpc.ClientMethod<RemoveFundRequest, RemoveFundReply>(
           '/breez.FundManager/RemoveFund',
           (RemoveFundRequest value) => value.writeToBuffer(),
           (List<int> value) => new RemoveFundReply.fromBuffer(value));
-  static final _$redeemRemovedFunds =
-      new ClientMethod<RedeemRemovedFundsRequest, RedeemRemovedFundsReply>(
-          '/breez.FundManager/RedeemRemovedFunds',
-          (RedeemRemovedFundsRequest value) => value.writeToBuffer(),
-          (List<int> value) => new RedeemRemovedFundsReply.fromBuffer(value));
+  static final _$redeemRemovedFunds = new $grpc
+          .ClientMethod<RedeemRemovedFundsRequest, RedeemRemovedFundsReply>(
+      '/breez.FundManager/RedeemRemovedFunds',
+      (RedeemRemovedFundsRequest value) => value.writeToBuffer(),
+      (List<int> value) => new RedeemRemovedFundsReply.fromBuffer(value));
   static final _$getSwapPayment =
-      new ClientMethod<GetSwapPaymentRequest, GetSwapPaymentReply>(
+      new $grpc.ClientMethod<GetSwapPaymentRequest, GetSwapPaymentReply>(
           '/breez.FundManager/GetSwapPayment',
           (GetSwapPaymentRequest value) => value.writeToBuffer(),
           (List<int> value) => new GetSwapPaymentReply.fromBuffer(value));
-  static final _$registerTransactionConfirmation = new ClientMethod<
+  static final _$registerTransactionConfirmation = new $grpc.ClientMethod<
           RegisterTransactionConfirmationRequest,
           RegisterTransactionConfirmationResponse>(
       '/breez.FundManager/RegisterTransactionConfirmation',
@@ -290,137 +266,138 @@ class FundManagerClient extends Client {
       (List<int> value) =>
           new RegisterTransactionConfirmationResponse.fromBuffer(value));
 
-  FundManagerClient(ClientChannel channel, {CallOptions options})
+  FundManagerClient($grpc.ClientChannel channel, {$grpc.CallOptions options})
       : super(channel, options: options);
 
-  ResponseFuture<OpenChannelReply> openChannel(OpenChannelRequest request,
-      {CallOptions options}) {
+  $grpc.ResponseFuture<OpenChannelReply> openChannel(OpenChannelRequest request,
+      {$grpc.CallOptions options}) {
     final call = $createCall(
         _$openChannel, new $async.Stream.fromIterable([request]),
         options: options);
-    return new ResponseFuture(call);
+    return new $grpc.ResponseFuture(call);
   }
 
-  ResponseFuture<UpdateChannelPolicyReply> updateChannelPolicy(
+  $grpc.ResponseFuture<UpdateChannelPolicyReply> updateChannelPolicy(
       UpdateChannelPolicyRequest request,
-      {CallOptions options}) {
+      {$grpc.CallOptions options}) {
     final call = $createCall(
         _$updateChannelPolicy, new $async.Stream.fromIterable([request]),
         options: options);
-    return new ResponseFuture(call);
+    return new $grpc.ResponseFuture(call);
   }
 
-  ResponseFuture<AddFundInitReply> addFundInit(AddFundInitRequest request,
-      {CallOptions options}) {
+  $grpc.ResponseFuture<AddFundInitReply> addFundInit(AddFundInitRequest request,
+      {$grpc.CallOptions options}) {
     final call = $createCall(
         _$addFundInit, new $async.Stream.fromIterable([request]),
         options: options);
-    return new ResponseFuture(call);
+    return new $grpc.ResponseFuture(call);
   }
 
-  ResponseFuture<AddFundStatusReply> addFundStatus(AddFundStatusRequest request,
-      {CallOptions options}) {
+  $grpc.ResponseFuture<AddFundStatusReply> addFundStatus(
+      AddFundStatusRequest request,
+      {$grpc.CallOptions options}) {
     final call = $createCall(
         _$addFundStatus, new $async.Stream.fromIterable([request]),
         options: options);
-    return new ResponseFuture(call);
+    return new $grpc.ResponseFuture(call);
   }
 
-  ResponseFuture<RemoveFundReply> removeFund(RemoveFundRequest request,
-      {CallOptions options}) {
+  $grpc.ResponseFuture<RemoveFundReply> removeFund(RemoveFundRequest request,
+      {$grpc.CallOptions options}) {
     final call = $createCall(
         _$removeFund, new $async.Stream.fromIterable([request]),
         options: options);
-    return new ResponseFuture(call);
+    return new $grpc.ResponseFuture(call);
   }
 
-  ResponseFuture<RedeemRemovedFundsReply> redeemRemovedFunds(
+  $grpc.ResponseFuture<RedeemRemovedFundsReply> redeemRemovedFunds(
       RedeemRemovedFundsRequest request,
-      {CallOptions options}) {
+      {$grpc.CallOptions options}) {
     final call = $createCall(
         _$redeemRemovedFunds, new $async.Stream.fromIterable([request]),
         options: options);
-    return new ResponseFuture(call);
+    return new $grpc.ResponseFuture(call);
   }
 
-  ResponseFuture<GetSwapPaymentReply> getSwapPayment(
+  $grpc.ResponseFuture<GetSwapPaymentReply> getSwapPayment(
       GetSwapPaymentRequest request,
-      {CallOptions options}) {
+      {$grpc.CallOptions options}) {
     final call = $createCall(
         _$getSwapPayment, new $async.Stream.fromIterable([request]),
         options: options);
-    return new ResponseFuture(call);
+    return new $grpc.ResponseFuture(call);
   }
 
-  ResponseFuture<RegisterTransactionConfirmationResponse>
+  $grpc.ResponseFuture<RegisterTransactionConfirmationResponse>
       registerTransactionConfirmation(
           RegisterTransactionConfirmationRequest request,
-          {CallOptions options}) {
+          {$grpc.CallOptions options}) {
     final call = $createCall(_$registerTransactionConfirmation,
         new $async.Stream.fromIterable([request]),
         options: options);
-    return new ResponseFuture(call);
+    return new $grpc.ResponseFuture(call);
   }
 }
 
-abstract class FundManagerServiceBase extends Service {
+abstract class FundManagerServiceBase extends $grpc.Service {
   String get $name => 'breez.FundManager';
 
   FundManagerServiceBase() {
-    $addMethod(new ServiceMethod<OpenChannelRequest, OpenChannelReply>(
+    $addMethod(new $grpc.ServiceMethod<OpenChannelRequest, OpenChannelReply>(
         'OpenChannel',
         openChannel_Pre,
         false,
         false,
         (List<int> value) => new OpenChannelRequest.fromBuffer(value),
         (OpenChannelReply value) => value.writeToBuffer()));
-    $addMethod(
-        new ServiceMethod<UpdateChannelPolicyRequest, UpdateChannelPolicyReply>(
-            'UpdateChannelPolicy',
-            updateChannelPolicy_Pre,
-            false,
-            false,
-            (List<int> value) =>
-                new UpdateChannelPolicyRequest.fromBuffer(value),
-            (UpdateChannelPolicyReply value) => value.writeToBuffer()));
-    $addMethod(new ServiceMethod<AddFundInitRequest, AddFundInitReply>(
+    $addMethod(new $grpc.ServiceMethod<UpdateChannelPolicyRequest,
+            UpdateChannelPolicyReply>(
+        'UpdateChannelPolicy',
+        updateChannelPolicy_Pre,
+        false,
+        false,
+        (List<int> value) => new UpdateChannelPolicyRequest.fromBuffer(value),
+        (UpdateChannelPolicyReply value) => value.writeToBuffer()));
+    $addMethod(new $grpc.ServiceMethod<AddFundInitRequest, AddFundInitReply>(
         'AddFundInit',
         addFundInit_Pre,
         false,
         false,
         (List<int> value) => new AddFundInitRequest.fromBuffer(value),
         (AddFundInitReply value) => value.writeToBuffer()));
-    $addMethod(new ServiceMethod<AddFundStatusRequest, AddFundStatusReply>(
-        'AddFundStatus',
-        addFundStatus_Pre,
-        false,
-        false,
-        (List<int> value) => new AddFundStatusRequest.fromBuffer(value),
-        (AddFundStatusReply value) => value.writeToBuffer()));
-    $addMethod(new ServiceMethod<RemoveFundRequest, RemoveFundReply>(
+    $addMethod(
+        new $grpc.ServiceMethod<AddFundStatusRequest, AddFundStatusReply>(
+            'AddFundStatus',
+            addFundStatus_Pre,
+            false,
+            false,
+            (List<int> value) => new AddFundStatusRequest.fromBuffer(value),
+            (AddFundStatusReply value) => value.writeToBuffer()));
+    $addMethod(new $grpc.ServiceMethod<RemoveFundRequest, RemoveFundReply>(
         'RemoveFund',
         removeFund_Pre,
         false,
         false,
         (List<int> value) => new RemoveFundRequest.fromBuffer(value),
         (RemoveFundReply value) => value.writeToBuffer()));
+    $addMethod(new $grpc
+            .ServiceMethod<RedeemRemovedFundsRequest, RedeemRemovedFundsReply>(
+        'RedeemRemovedFunds',
+        redeemRemovedFunds_Pre,
+        false,
+        false,
+        (List<int> value) => new RedeemRemovedFundsRequest.fromBuffer(value),
+        (RedeemRemovedFundsReply value) => value.writeToBuffer()));
     $addMethod(
-        new ServiceMethod<RedeemRemovedFundsRequest, RedeemRemovedFundsReply>(
-            'RedeemRemovedFunds',
-            redeemRemovedFunds_Pre,
+        new $grpc.ServiceMethod<GetSwapPaymentRequest, GetSwapPaymentReply>(
+            'GetSwapPayment',
+            getSwapPayment_Pre,
             false,
             false,
-            (List<int> value) =>
-                new RedeemRemovedFundsRequest.fromBuffer(value),
-            (RedeemRemovedFundsReply value) => value.writeToBuffer()));
-    $addMethod(new ServiceMethod<GetSwapPaymentRequest, GetSwapPaymentReply>(
-        'GetSwapPayment',
-        getSwapPayment_Pre,
-        false,
-        false,
-        (List<int> value) => new GetSwapPaymentRequest.fromBuffer(value),
-        (GetSwapPaymentReply value) => value.writeToBuffer()));
-    $addMethod(new ServiceMethod<RegisterTransactionConfirmationRequest,
+            (List<int> value) => new GetSwapPaymentRequest.fromBuffer(value),
+            (GetSwapPaymentReply value) => value.writeToBuffer()));
+    $addMethod(new $grpc.ServiceMethod<RegisterTransactionConfirmationRequest,
             RegisterTransactionConfirmationResponse>(
         'RegisterTransactionConfirmation',
         registerTransactionConfirmation_Pre,
@@ -433,112 +410,112 @@ abstract class FundManagerServiceBase extends Service {
   }
 
   $async.Future<OpenChannelReply> openChannel_Pre(
-      ServiceCall call, $async.Future request) async {
+      $grpc.ServiceCall call, $async.Future request) async {
     return openChannel(call, await request);
   }
 
   $async.Future<UpdateChannelPolicyReply> updateChannelPolicy_Pre(
-      ServiceCall call, $async.Future request) async {
+      $grpc.ServiceCall call, $async.Future request) async {
     return updateChannelPolicy(call, await request);
   }
 
   $async.Future<AddFundInitReply> addFundInit_Pre(
-      ServiceCall call, $async.Future request) async {
+      $grpc.ServiceCall call, $async.Future request) async {
     return addFundInit(call, await request);
   }
 
   $async.Future<AddFundStatusReply> addFundStatus_Pre(
-      ServiceCall call, $async.Future request) async {
+      $grpc.ServiceCall call, $async.Future request) async {
     return addFundStatus(call, await request);
   }
 
   $async.Future<RemoveFundReply> removeFund_Pre(
-      ServiceCall call, $async.Future request) async {
+      $grpc.ServiceCall call, $async.Future request) async {
     return removeFund(call, await request);
   }
 
   $async.Future<RedeemRemovedFundsReply> redeemRemovedFunds_Pre(
-      ServiceCall call, $async.Future request) async {
+      $grpc.ServiceCall call, $async.Future request) async {
     return redeemRemovedFunds(call, await request);
   }
 
   $async.Future<GetSwapPaymentReply> getSwapPayment_Pre(
-      ServiceCall call, $async.Future request) async {
+      $grpc.ServiceCall call, $async.Future request) async {
     return getSwapPayment(call, await request);
   }
 
   $async.Future<RegisterTransactionConfirmationResponse>
       registerTransactionConfirmation_Pre(
-          ServiceCall call, $async.Future request) async {
+          $grpc.ServiceCall call, $async.Future request) async {
     return registerTransactionConfirmation(call, await request);
   }
 
   $async.Future<OpenChannelReply> openChannel(
-      ServiceCall call, OpenChannelRequest request);
+      $grpc.ServiceCall call, OpenChannelRequest request);
   $async.Future<UpdateChannelPolicyReply> updateChannelPolicy(
-      ServiceCall call, UpdateChannelPolicyRequest request);
+      $grpc.ServiceCall call, UpdateChannelPolicyRequest request);
   $async.Future<AddFundInitReply> addFundInit(
-      ServiceCall call, AddFundInitRequest request);
+      $grpc.ServiceCall call, AddFundInitRequest request);
   $async.Future<AddFundStatusReply> addFundStatus(
-      ServiceCall call, AddFundStatusRequest request);
+      $grpc.ServiceCall call, AddFundStatusRequest request);
   $async.Future<RemoveFundReply> removeFund(
-      ServiceCall call, RemoveFundRequest request);
+      $grpc.ServiceCall call, RemoveFundRequest request);
   $async.Future<RedeemRemovedFundsReply> redeemRemovedFunds(
-      ServiceCall call, RedeemRemovedFundsRequest request);
+      $grpc.ServiceCall call, RedeemRemovedFundsRequest request);
   $async.Future<GetSwapPaymentReply> getSwapPayment(
-      ServiceCall call, GetSwapPaymentRequest request);
+      $grpc.ServiceCall call, GetSwapPaymentRequest request);
   $async.Future<RegisterTransactionConfirmationResponse>
-      registerTransactionConfirmation(
-          ServiceCall call, RegisterTransactionConfirmationRequest request);
+      registerTransactionConfirmation($grpc.ServiceCall call,
+          RegisterTransactionConfirmationRequest request);
 }
 
-class CTPClient extends Client {
+class CTPClient extends $grpc.Client {
   static final _$joinCTPSession =
-      new ClientMethod<JoinCTPSessionRequest, JoinCTPSessionResponse>(
+      new $grpc.ClientMethod<JoinCTPSessionRequest, JoinCTPSessionResponse>(
           '/breez.CTP/JoinCTPSession',
           (JoinCTPSessionRequest value) => value.writeToBuffer(),
           (List<int> value) => new JoinCTPSessionResponse.fromBuffer(value));
-  static final _$terminateCTPSession =
-      new ClientMethod<TerminateCTPSessionRequest, TerminateCTPSessionResponse>(
-          '/breez.CTP/TerminateCTPSession',
-          (TerminateCTPSessionRequest value) => value.writeToBuffer(),
-          (List<int> value) =>
-              new TerminateCTPSessionResponse.fromBuffer(value));
+  static final _$terminateCTPSession = new $grpc.ClientMethod<
+          TerminateCTPSessionRequest, TerminateCTPSessionResponse>(
+      '/breez.CTP/TerminateCTPSession',
+      (TerminateCTPSessionRequest value) => value.writeToBuffer(),
+      (List<int> value) => new TerminateCTPSessionResponse.fromBuffer(value));
 
-  CTPClient(ClientChannel channel, {CallOptions options})
+  CTPClient($grpc.ClientChannel channel, {$grpc.CallOptions options})
       : super(channel, options: options);
 
-  ResponseFuture<JoinCTPSessionResponse> joinCTPSession(
+  $grpc.ResponseFuture<JoinCTPSessionResponse> joinCTPSession(
       JoinCTPSessionRequest request,
-      {CallOptions options}) {
+      {$grpc.CallOptions options}) {
     final call = $createCall(
         _$joinCTPSession, new $async.Stream.fromIterable([request]),
         options: options);
-    return new ResponseFuture(call);
+    return new $grpc.ResponseFuture(call);
   }
 
-  ResponseFuture<TerminateCTPSessionResponse> terminateCTPSession(
+  $grpc.ResponseFuture<TerminateCTPSessionResponse> terminateCTPSession(
       TerminateCTPSessionRequest request,
-      {CallOptions options}) {
+      {$grpc.CallOptions options}) {
     final call = $createCall(
         _$terminateCTPSession, new $async.Stream.fromIterable([request]),
         options: options);
-    return new ResponseFuture(call);
+    return new $grpc.ResponseFuture(call);
   }
 }
 
-abstract class CTPServiceBase extends Service {
+abstract class CTPServiceBase extends $grpc.Service {
   String get $name => 'breez.CTP';
 
   CTPServiceBase() {
-    $addMethod(new ServiceMethod<JoinCTPSessionRequest, JoinCTPSessionResponse>(
-        'JoinCTPSession',
-        joinCTPSession_Pre,
-        false,
-        false,
-        (List<int> value) => new JoinCTPSessionRequest.fromBuffer(value),
-        (JoinCTPSessionResponse value) => value.writeToBuffer()));
-    $addMethod(new ServiceMethod<TerminateCTPSessionRequest,
+    $addMethod(
+        new $grpc.ServiceMethod<JoinCTPSessionRequest, JoinCTPSessionResponse>(
+            'JoinCTPSession',
+            joinCTPSession_Pre,
+            false,
+            false,
+            (List<int> value) => new JoinCTPSessionRequest.fromBuffer(value),
+            (JoinCTPSessionResponse value) => value.writeToBuffer()));
+    $addMethod(new $grpc.ServiceMethod<TerminateCTPSessionRequest,
             TerminateCTPSessionResponse>(
         'TerminateCTPSession',
         terminateCTPSession_Pre,
@@ -549,17 +526,60 @@ abstract class CTPServiceBase extends Service {
   }
 
   $async.Future<JoinCTPSessionResponse> joinCTPSession_Pre(
-      ServiceCall call, $async.Future request) async {
+      $grpc.ServiceCall call, $async.Future request) async {
     return joinCTPSession(call, await request);
   }
 
   $async.Future<TerminateCTPSessionResponse> terminateCTPSession_Pre(
-      ServiceCall call, $async.Future request) async {
+      $grpc.ServiceCall call, $async.Future request) async {
     return terminateCTPSession(call, await request);
   }
 
   $async.Future<JoinCTPSessionResponse> joinCTPSession(
-      ServiceCall call, JoinCTPSessionRequest request);
+      $grpc.ServiceCall call, JoinCTPSessionRequest request);
   $async.Future<TerminateCTPSessionResponse> terminateCTPSession(
-      ServiceCall call, TerminateCTPSessionRequest request);
+      $grpc.ServiceCall call, TerminateCTPSessionRequest request);
+}
+
+class SyncNotifierClient extends $grpc.Client {
+  static final _$registerPeriodicSync = new $grpc.ClientMethod<
+          RegisterPeriodicSyncRequest, RegisterPeriodicSyncResponse>(
+      '/breez.SyncNotifier/RegisterPeriodicSync',
+      (RegisterPeriodicSyncRequest value) => value.writeToBuffer(),
+      (List<int> value) => new RegisterPeriodicSyncResponse.fromBuffer(value));
+
+  SyncNotifierClient($grpc.ClientChannel channel, {$grpc.CallOptions options})
+      : super(channel, options: options);
+
+  $grpc.ResponseFuture<RegisterPeriodicSyncResponse> registerPeriodicSync(
+      RegisterPeriodicSyncRequest request,
+      {$grpc.CallOptions options}) {
+    final call = $createCall(
+        _$registerPeriodicSync, new $async.Stream.fromIterable([request]),
+        options: options);
+    return new $grpc.ResponseFuture(call);
+  }
+}
+
+abstract class SyncNotifierServiceBase extends $grpc.Service {
+  String get $name => 'breez.SyncNotifier';
+
+  SyncNotifierServiceBase() {
+    $addMethod(new $grpc.ServiceMethod<RegisterPeriodicSyncRequest,
+            RegisterPeriodicSyncResponse>(
+        'RegisterPeriodicSync',
+        registerPeriodicSync_Pre,
+        false,
+        false,
+        (List<int> value) => new RegisterPeriodicSyncRequest.fromBuffer(value),
+        (RegisterPeriodicSyncResponse value) => value.writeToBuffer()));
+  }
+
+  $async.Future<RegisterPeriodicSyncResponse> registerPeriodicSync_Pre(
+      $grpc.ServiceCall call, $async.Future request) async {
+    return registerPeriodicSync(call, await request);
+  }
+
+  $async.Future<RegisterPeriodicSyncResponse> registerPeriodicSync(
+      $grpc.ServiceCall call, RegisterPeriodicSyncRequest request);
 }

--- a/lib/services/breez_server/generated/breez.pbjson.dart
+++ b/lib/services/breez_server/generated/breez.pbjson.dart
@@ -45,6 +45,7 @@ const AddFundInitReply$json = const {
     const {'1': 'lockHeight', '3': 3, '4': 1, '5': 3, '10': 'lockHeight'},
     const {'1': 'maxAllowedDeposit', '3': 4, '4': 1, '5': 3, '10': 'maxAllowedDeposit'},
     const {'1': 'errorMessage', '3': 5, '4': 1, '5': 9, '10': 'errorMessage'},
+    const {'1': 'requiredReserve', '3': 6, '4': 1, '5': 3, '10': 'requiredReserve'},
   ],
 };
 
@@ -110,35 +111,6 @@ const RedeemRemovedFundsReply$json = const {
   '1': 'RedeemRemovedFundsReply',
   '2': const [
     const {'1': 'txid', '3': 1, '4': 1, '5': 9, '10': 'txid'},
-  ],
-};
-
-const FundRequest$json = const {
-  '1': 'FundRequest',
-  '2': const [
-    const {'1': 'deviceID', '3': 1, '4': 1, '5': 9, '10': 'deviceID'},
-    const {'1': 'lightningID', '3': 2, '4': 1, '5': 9, '10': 'lightningID'},
-    const {'1': 'amount', '3': 3, '4': 1, '5': 3, '10': 'amount'},
-  ],
-};
-
-const FundReply$json = const {
-  '1': 'FundReply',
-  '2': const [
-    const {'1': 'returnCode', '3': 1, '4': 1, '5': 14, '6': '.breez.FundReply.ReturnCode', '10': 'returnCode'},
-  ],
-  '4': const [FundReply_ReturnCode$json],
-};
-
-const FundReply_ReturnCode$json = const {
-  '1': 'ReturnCode',
-  '2': const [
-    const {'1': 'SUCCESS', '2': 0},
-    const {'1': 'UNKNOWN_ERROR', '2': -1},
-    const {'1': 'NODE_BUSY', '2': -2},
-    const {'1': 'CLIENT_NOT_REGISTERED', '2': -3},
-    const {'1': 'WRONG_NODE_ID', '2': -4},
-    const {'1': 'WRONG_AMOUNT', '2': -5},
   ],
 };
 
@@ -288,5 +260,16 @@ const RegisterTransactionConfirmationRequest_NotificationType$json = const {
 
 const RegisterTransactionConfirmationResponse$json = const {
   '1': 'RegisterTransactionConfirmationResponse',
+};
+
+const RegisterPeriodicSyncRequest$json = const {
+  '1': 'RegisterPeriodicSyncRequest',
+  '2': const [
+    const {'1': 'notificationToken', '3': 1, '4': 1, '5': 9, '10': 'notificationToken'},
+  ],
+};
+
+const RegisterPeriodicSyncResponse$json = const {
+  '1': 'RegisterPeriodicSyncResponse',
 };
 

--- a/lib/services/breezlib/breez_bridge.dart
+++ b/lib/services/breezlib/breez_bridge.dart
@@ -100,6 +100,10 @@ class BreezBridge {
     return _invokeMethodWhenReady("connectAccount");
   }
 
+  Future enableAccount(bool enabled) {
+    return _invokeMethodWhenReady("enableAccount", {"argument": enabled});
+  }
+
   Future<RemoveFundReply> removeFund(String address, Int64 amount){
     RemoveFundRequest request = new RemoveFundRequest()
       ..address = address

--- a/lib/services/breezlib/data/rpc.pb.dart
+++ b/lib/services/breezlib/data/rpc.pb.dart
@@ -32,9 +32,6 @@ class ChainStatus extends $pb.GeneratedMessage {
   static $pb.PbList<ChainStatus> createRepeated() => new $pb.PbList<ChainStatus>();
   static ChainStatus getDefault() => _defaultInstance ??= create()..freeze();
   static ChainStatus _defaultInstance;
-  static void $checkItem(ChainStatus v) {
-    if (v is! ChainStatus) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   int get blockHeight => $_get(0, 0);
   set blockHeight(int v) { $_setUnsignedInt32(0, v); }
@@ -57,6 +54,7 @@ class Account extends $pb.GeneratedMessage {
     ..aInt64(6, 'maxAllowedToPay')
     ..aInt64(7, 'maxPaymentAmount')
     ..aInt64(8, 'routingNodeFee')
+    ..aOB(9, 'enabled')
     ..hasRequiredFields = false
   ;
 
@@ -71,9 +69,6 @@ class Account extends $pb.GeneratedMessage {
   static $pb.PbList<Account> createRepeated() => new $pb.PbList<Account>();
   static Account getDefault() => _defaultInstance ??= create()..freeze();
   static Account _defaultInstance;
-  static void $checkItem(Account v) {
-    if (v is! Account) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get id => $_getS(0, '');
   set id(String v) { $_setString(0, v); }
@@ -114,6 +109,11 @@ class Account extends $pb.GeneratedMessage {
   set routingNodeFee(Int64 v) { $_setInt64(7, v); }
   bool hasRoutingNodeFee() => $_has(7);
   void clearRoutingNodeFee() => clearField(8);
+
+  bool get enabled => $_get(8, false);
+  set enabled(bool v) { $_setBool(8, v); }
+  bool hasEnabled() => $_has(8);
+  void clearEnabled() => clearField(9);
 }
 
 class Payment extends $pb.GeneratedMessage {
@@ -142,9 +142,6 @@ class Payment extends $pb.GeneratedMessage {
   static $pb.PbList<Payment> createRepeated() => new $pb.PbList<Payment>();
   static Payment getDefault() => _defaultInstance ??= create()..freeze();
   static Payment _defaultInstance;
-  static void $checkItem(Payment v) {
-    if (v is! Payment) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   Payment_PaymentType get type => $_getN(0);
   set type(Payment_PaymentType v) { setField(1, v); }
@@ -199,7 +196,7 @@ class Payment extends $pb.GeneratedMessage {
 
 class PaymentsList extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = new $pb.BuilderInfo('PaymentsList', package: const $pb.PackageName('data'))
-    ..pp<Payment>(1, 'paymentsList', $pb.PbFieldType.PM, Payment.$checkItem, Payment.create)
+    ..pc<Payment>(1, 'paymentsList', $pb.PbFieldType.PM,Payment.create)
     ..hasRequiredFields = false
   ;
 
@@ -214,9 +211,6 @@ class PaymentsList extends $pb.GeneratedMessage {
   static $pb.PbList<PaymentsList> createRepeated() => new $pb.PbList<PaymentsList>();
   static PaymentsList getDefault() => _defaultInstance ??= create()..freeze();
   static PaymentsList _defaultInstance;
-  static void $checkItem(PaymentsList v) {
-    if (v is! PaymentsList) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   List<Payment> get paymentsList => $_getList(0);
 }
@@ -240,9 +234,6 @@ class SendWalletCoinsRequest extends $pb.GeneratedMessage {
   static $pb.PbList<SendWalletCoinsRequest> createRepeated() => new $pb.PbList<SendWalletCoinsRequest>();
   static SendWalletCoinsRequest getDefault() => _defaultInstance ??= create()..freeze();
   static SendWalletCoinsRequest _defaultInstance;
-  static void $checkItem(SendWalletCoinsRequest v) {
-    if (v is! SendWalletCoinsRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get address => $_getS(0, '');
   set address(String v) { $_setString(0, v); }
@@ -278,9 +269,6 @@ class PayInvoiceRequest extends $pb.GeneratedMessage {
   static $pb.PbList<PayInvoiceRequest> createRepeated() => new $pb.PbList<PayInvoiceRequest>();
   static PayInvoiceRequest getDefault() => _defaultInstance ??= create()..freeze();
   static PayInvoiceRequest _defaultInstance;
-  static void $checkItem(PayInvoiceRequest v) {
-    if (v is! PayInvoiceRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   Int64 get amount => $_getI64(0);
   set amount(Int64 v) { $_setInt64(0, v); }
@@ -317,9 +305,6 @@ class InvoiceMemo extends $pb.GeneratedMessage {
   static $pb.PbList<InvoiceMemo> createRepeated() => new $pb.PbList<InvoiceMemo>();
   static InvoiceMemo getDefault() => _defaultInstance ??= create()..freeze();
   static InvoiceMemo _defaultInstance;
-  static void $checkItem(InvoiceMemo v) {
-    if (v is! InvoiceMemo) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get description => $_getS(0, '');
   set description(String v) { $_setString(0, v); }
@@ -381,9 +366,6 @@ class Invoice extends $pb.GeneratedMessage {
   static $pb.PbList<Invoice> createRepeated() => new $pb.PbList<Invoice>();
   static Invoice getDefault() => _defaultInstance ??= create()..freeze();
   static Invoice _defaultInstance;
-  static void $checkItem(Invoice v) {
-    if (v is! Invoice) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   InvoiceMemo get memo => $_getN(0);
   set memo(InvoiceMemo v) { setField(1, v); }
@@ -419,9 +401,6 @@ class NotificationEvent extends $pb.GeneratedMessage {
   static $pb.PbList<NotificationEvent> createRepeated() => new $pb.PbList<NotificationEvent>();
   static NotificationEvent getDefault() => _defaultInstance ??= create()..freeze();
   static NotificationEvent _defaultInstance;
-  static void $checkItem(NotificationEvent v) {
-    if (v is! NotificationEvent) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   NotificationEvent_NotificationType get type => $_getN(0);
   set type(NotificationEvent_NotificationType v) { setField(1, v); }
@@ -452,9 +431,6 @@ class AddFundInitReply extends $pb.GeneratedMessage {
   static $pb.PbList<AddFundInitReply> createRepeated() => new $pb.PbList<AddFundInitReply>();
   static AddFundInitReply getDefault() => _defaultInstance ??= create()..freeze();
   static AddFundInitReply _defaultInstance;
-  static void $checkItem(AddFundInitReply v) {
-    if (v is! AddFundInitReply) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get address => $_getS(0, '');
   set address(String v) { $_setString(0, v); }
@@ -499,9 +475,6 @@ class AddFundReply extends $pb.GeneratedMessage {
   static $pb.PbList<AddFundReply> createRepeated() => new $pb.PbList<AddFundReply>();
   static AddFundReply getDefault() => _defaultInstance ??= create()..freeze();
   static AddFundReply _defaultInstance;
-  static void $checkItem(AddFundReply v) {
-    if (v is! AddFundReply) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get errorMessage => $_getS(0, '');
   set errorMessage(String v) { $_setString(0, v); }
@@ -527,9 +500,6 @@ class RefundRequest extends $pb.GeneratedMessage {
   static $pb.PbList<RefundRequest> createRepeated() => new $pb.PbList<RefundRequest>();
   static RefundRequest getDefault() => _defaultInstance ??= create()..freeze();
   static RefundRequest _defaultInstance;
-  static void $checkItem(RefundRequest v) {
-    if (v is! RefundRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get address => $_getS(0, '');
   set address(String v) { $_setString(0, v); }
@@ -560,9 +530,6 @@ class FundStatusReply extends $pb.GeneratedMessage {
   static $pb.PbList<FundStatusReply> createRepeated() => new $pb.PbList<FundStatusReply>();
   static FundStatusReply getDefault() => _defaultInstance ??= create()..freeze();
   static FundStatusReply _defaultInstance;
-  static void $checkItem(FundStatusReply v) {
-    if (v is! FundStatusReply) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   FundStatusReply_FundStatus get status => $_getN(0);
   set status(FundStatusReply_FundStatus v) { setField(1, v); }
@@ -593,9 +560,6 @@ class RemoveFundRequest extends $pb.GeneratedMessage {
   static $pb.PbList<RemoveFundRequest> createRepeated() => new $pb.PbList<RemoveFundRequest>();
   static RemoveFundRequest getDefault() => _defaultInstance ??= create()..freeze();
   static RemoveFundRequest _defaultInstance;
-  static void $checkItem(RemoveFundRequest v) {
-    if (v is! RemoveFundRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get address => $_getS(0, '');
   set address(String v) { $_setString(0, v); }
@@ -626,9 +590,6 @@ class RemoveFundReply extends $pb.GeneratedMessage {
   static $pb.PbList<RemoveFundReply> createRepeated() => new $pb.PbList<RemoveFundReply>();
   static RemoveFundReply getDefault() => _defaultInstance ??= create()..freeze();
   static RemoveFundReply _defaultInstance;
-  static void $checkItem(RemoveFundReply v) {
-    if (v is! RemoveFundReply) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get txid => $_getS(0, '');
   set txid(String v) { $_setString(0, v); }
@@ -665,9 +626,6 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   static $pb.PbList<SwapAddressInfo> createRepeated() => new $pb.PbList<SwapAddressInfo>();
   static SwapAddressInfo getDefault() => _defaultInstance ??= create()..freeze();
   static SwapAddressInfo _defaultInstance;
-  static void $checkItem(SwapAddressInfo v) {
-    if (v is! SwapAddressInfo) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get address => $_getS(0, '');
   set address(String v) { $_setString(0, v); }
@@ -709,7 +667,7 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
 
 class SwapAddressList extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = new $pb.BuilderInfo('SwapAddressList', package: const $pb.PackageName('data'))
-    ..pp<SwapAddressInfo>(1, 'addresses', $pb.PbFieldType.PM, SwapAddressInfo.$checkItem, SwapAddressInfo.create)
+    ..pc<SwapAddressInfo>(1, 'addresses', $pb.PbFieldType.PM,SwapAddressInfo.create)
     ..hasRequiredFields = false
   ;
 
@@ -724,9 +682,6 @@ class SwapAddressList extends $pb.GeneratedMessage {
   static $pb.PbList<SwapAddressList> createRepeated() => new $pb.PbList<SwapAddressList>();
   static SwapAddressList getDefault() => _defaultInstance ??= create()..freeze();
   static SwapAddressList _defaultInstance;
-  static void $checkItem(SwapAddressList v) {
-    if (v is! SwapAddressList) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   List<SwapAddressInfo> get addresses => $_getList(0);
 }
@@ -751,9 +706,6 @@ class CreateRatchetSessionRequest extends $pb.GeneratedMessage {
   static $pb.PbList<CreateRatchetSessionRequest> createRepeated() => new $pb.PbList<CreateRatchetSessionRequest>();
   static CreateRatchetSessionRequest getDefault() => _defaultInstance ??= create()..freeze();
   static CreateRatchetSessionRequest _defaultInstance;
-  static void $checkItem(CreateRatchetSessionRequest v) {
-    if (v is! CreateRatchetSessionRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get secret => $_getS(0, '');
   set secret(String v) { $_setString(0, v); }
@@ -795,9 +747,6 @@ class CreateRatchetSessionReply extends $pb.GeneratedMessage {
   static $pb.PbList<CreateRatchetSessionReply> createRepeated() => new $pb.PbList<CreateRatchetSessionReply>();
   static CreateRatchetSessionReply getDefault() => _defaultInstance ??= create()..freeze();
   static CreateRatchetSessionReply _defaultInstance;
-  static void $checkItem(CreateRatchetSessionReply v) {
-    if (v is! CreateRatchetSessionReply) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get sessionID => $_getS(0, '');
   set sessionID(String v) { $_setString(0, v); }
@@ -834,9 +783,6 @@ class RatchetSessionInfoReply extends $pb.GeneratedMessage {
   static $pb.PbList<RatchetSessionInfoReply> createRepeated() => new $pb.PbList<RatchetSessionInfoReply>();
   static RatchetSessionInfoReply getDefault() => _defaultInstance ??= create()..freeze();
   static RatchetSessionInfoReply _defaultInstance;
-  static void $checkItem(RatchetSessionInfoReply v) {
-    if (v is! RatchetSessionInfoReply) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get sessionID => $_getS(0, '');
   set sessionID(String v) { $_setString(0, v); }
@@ -872,9 +818,6 @@ class RatchetSessionSetInfoRequest extends $pb.GeneratedMessage {
   static $pb.PbList<RatchetSessionSetInfoRequest> createRepeated() => new $pb.PbList<RatchetSessionSetInfoRequest>();
   static RatchetSessionSetInfoRequest getDefault() => _defaultInstance ??= create()..freeze();
   static RatchetSessionSetInfoRequest _defaultInstance;
-  static void $checkItem(RatchetSessionSetInfoRequest v) {
-    if (v is! RatchetSessionSetInfoRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get sessionID => $_getS(0, '');
   set sessionID(String v) { $_setString(0, v); }
@@ -905,9 +848,6 @@ class RatchetEncryptRequest extends $pb.GeneratedMessage {
   static $pb.PbList<RatchetEncryptRequest> createRepeated() => new $pb.PbList<RatchetEncryptRequest>();
   static RatchetEncryptRequest getDefault() => _defaultInstance ??= create()..freeze();
   static RatchetEncryptRequest _defaultInstance;
-  static void $checkItem(RatchetEncryptRequest v) {
-    if (v is! RatchetEncryptRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get sessionID => $_getS(0, '');
   set sessionID(String v) { $_setString(0, v); }
@@ -938,9 +878,6 @@ class RatchetDecryptRequest extends $pb.GeneratedMessage {
   static $pb.PbList<RatchetDecryptRequest> createRepeated() => new $pb.PbList<RatchetDecryptRequest>();
   static RatchetDecryptRequest getDefault() => _defaultInstance ??= create()..freeze();
   static RatchetDecryptRequest _defaultInstance;
-  static void $checkItem(RatchetDecryptRequest v) {
-    if (v is! RatchetDecryptRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get sessionID => $_getS(0, '');
   set sessionID(String v) { $_setString(0, v); }
@@ -971,9 +908,6 @@ class BootstrapFilesRequest extends $pb.GeneratedMessage {
   static $pb.PbList<BootstrapFilesRequest> createRepeated() => new $pb.PbList<BootstrapFilesRequest>();
   static BootstrapFilesRequest getDefault() => _defaultInstance ??= create()..freeze();
   static BootstrapFilesRequest _defaultInstance;
-  static void $checkItem(BootstrapFilesRequest v) {
-    if (v is! BootstrapFilesRequest) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
   String get workingDir => $_getS(0, '');
   set workingDir(String v) { $_setString(0, v); }

--- a/lib/services/breezlib/data/rpc.pbenum.dart
+++ b/lib/services/breezlib/data/rpc.pbenum.dart
@@ -25,9 +25,6 @@ class Account_AccountStatus extends $pb.ProtobufEnum {
 
   static final Map<int, Account_AccountStatus> _byValue = $pb.ProtobufEnum.initByValue(values);
   static Account_AccountStatus valueOf(int value) => _byValue[value];
-  static void $checkItem(Account_AccountStatus v) {
-    if (v is! Account_AccountStatus) $pb.checkItemFailed(v, 'Account_AccountStatus');
-  }
 
   const Account_AccountStatus._(int v, String n) : super(v, n);
 }
@@ -47,9 +44,6 @@ class Payment_PaymentType extends $pb.ProtobufEnum {
 
   static final Map<int, Payment_PaymentType> _byValue = $pb.ProtobufEnum.initByValue(values);
   static Payment_PaymentType valueOf(int value) => _byValue[value];
-  static void $checkItem(Payment_PaymentType v) {
-    if (v is! Payment_PaymentType) $pb.checkItemFailed(v, 'Payment_PaymentType');
-  }
 
   const Payment_PaymentType._(int v, String n) : super(v, n);
 }
@@ -83,9 +77,6 @@ class NotificationEvent_NotificationType extends $pb.ProtobufEnum {
 
   static final Map<int, NotificationEvent_NotificationType> _byValue = $pb.ProtobufEnum.initByValue(values);
   static NotificationEvent_NotificationType valueOf(int value) => _byValue[value];
-  static void $checkItem(NotificationEvent_NotificationType v) {
-    if (v is! NotificationEvent_NotificationType) $pb.checkItemFailed(v, 'NotificationEvent_NotificationType');
-  }
 
   const NotificationEvent_NotificationType._(int v, String n) : super(v, n);
 }
@@ -105,9 +96,6 @@ class FundStatusReply_FundStatus extends $pb.ProtobufEnum {
 
   static final Map<int, FundStatusReply_FundStatus> _byValue = $pb.ProtobufEnum.initByValue(values);
   static FundStatusReply_FundStatus valueOf(int value) => _byValue[value];
-  static void $checkItem(FundStatusReply_FundStatus v) {
-    if (v is! FundStatusReply_FundStatus) $pb.checkItemFailed(v, 'FundStatusReply_FundStatus');
-  }
 
   const FundStatusReply_FundStatus._(int v, String n) : super(v, n);
 }

--- a/lib/services/breezlib/data/rpc.pbjson.dart
+++ b/lib/services/breezlib/data/rpc.pbjson.dart
@@ -23,6 +23,7 @@ const Account$json = const {
     const {'1': 'maxAllowedToPay', '3': 6, '4': 1, '5': 3, '10': 'maxAllowedToPay'},
     const {'1': 'maxPaymentAmount', '3': 7, '4': 1, '5': 3, '10': 'maxPaymentAmount'},
     const {'1': 'routingNodeFee', '3': 8, '4': 1, '5': 3, '10': 'routingNodeFee'},
+    const {'1': 'enabled', '3': 9, '4': 1, '5': 8, '10': 'enabled'},
   ],
   '4': const [Account_AccountStatus$json],
 };

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 dependencies:
   flutter:
     sdk: flutter
-  grpc: ^0.6.4
+  grpc: ^1.0.1
   protobuf: any
   path_provider: any
   firebase_database: ^1.0.5
@@ -41,7 +41,7 @@ dependencies:
 
 dev_dependencies:
   mockito: "^3.0.0"
-  protoc_plugin: 14.0.0
+  protoc_plugin: ^16.0.1
   build_runner: ^1.0.0
   json_serializable: ^2.0.0
   flutter_test:


### PR DESCRIPTION
This PR adds an internal feature to be able to disable/re-enable breez account.
When the account turns into "disabled" state, not automatic attempts to open a channel will be made.
This is useful when the user wants to close all his channels and withdraw the funds on-chain.
Later, he can re-enable the account and the attempts to open a channel will resume.
Since this is internal feature it is visible in the dev screen.