### PR TITLE
Add funds reserve

### DIFF
--- a/lib/bloc/account/account_model.dart
+++ b/lib/bloc/account/account_model.dart
@@ -85,6 +85,7 @@ class AccountModel {
   Int64 get maxAllowedToReceive => _accountResponse.maxAllowedToReceive;
   Int64 get maxAllowedToPay => Int64(min(_accountResponse.maxAllowedToPay.toInt(), _accountResponse.maxPaymentAmount.toInt()));
   Int64 get reserveAmount => balance - maxAllowedToPay;
+  Int64 get warningMaxChanReserveAmount => _accountResponse.maxChanReserve;
   Int64 get maxPaymentAmount => _accountResponse.maxPaymentAmount;
   Int64 get routingNodeFee => _accountResponse.routingNodeFee;
   bool get enabled => _accountResponse.enabled;

--- a/lib/routes/shared/account_required_actions.dart
+++ b/lib/routes/shared/account_required_actions.dart
@@ -39,7 +39,8 @@ class AccountRequiredActionsIndicatorState
         Observable(widget._backupBloc.lastBackupTimeStream)
             .delay(Duration(seconds: 1))
             .listen((lastBackup) {}, onError: (err) {
-      if (_currentSettings.promptOnError && !showingBackupDialog) {          
+      if (_currentSettings.promptOnError && !showingBackupDialog) {
+        showingBackupDialog = true;          
         popFlushbars(context);
         showDialog(
             context: context,

--- a/lib/routes/user/add_funds/add_funds_page.dart
+++ b/lib/routes/user/add_funds/add_funds_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:breez/bloc/account/account_bloc.dart';
 import 'package:breez/bloc/account/account_model.dart';
 import 'package:breez/bloc/account/add_funds_bloc.dart';
@@ -5,15 +7,15 @@ import 'package:breez/bloc/blocs_provider.dart';
 import 'package:breez/bloc/user_profile/breez_user_model.dart';
 import 'package:breez/routes/user/add_funds/address_widget.dart';
 import 'package:breez/widgets/single_button_bottom_bar.dart';
-import 'package:fixnum/fixnum.dart';
 import 'package:flutter/material.dart';
 import 'package:breez/theme_data.dart' as theme;
 import 'package:breez/widgets/back_button.dart' as backBtn;
 
 class AddFundsPage extends StatefulWidget {  
   final BreezUserModel _user;  
+  final AccountBloc _accountBloc;
 
-  const AddFundsPage(this._user);
+  const AddFundsPage(this._user, this._accountBloc);
 
   @override
   State<StatefulWidget> createState() {
@@ -24,17 +26,23 @@ class AddFundsPage extends StatefulWidget {
 class AddFundsState extends State<AddFundsPage> {  
   final String _title = "Add Funds";
   AddFundsBloc _addFundsBloc;
+  StreamSubscription<AccountModel> _accountSubscription;
 
   @override
   initState() {
     super.initState();
     _addFundsBloc = new AddFundsBloc(widget._user.userID);
-    _addFundsBloc.addFundRequestSink.add(null);    
+    _accountSubscription = widget._accountBloc.accountStream.listen((acc){
+      if (!acc.bootstraping) {
+        _addFundsBloc.addFundRequestSink.add(null);
+      }
+    });       
   }
 
   @override
   void dispose() {
     _addFundsBloc.addFundRequestSink.close();
+    _accountSubscription.cancel();
     super.dispose();
   }
 
@@ -85,9 +93,9 @@ class AddFundsState extends State<AddFundsPage> {
     String errorMessage;
     if (error != null) {
       errorMessage = error;
-    } else if (account == null) {
+    } else if (account == null || account.bootstraping) {
       errorMessage =
-          'Bitcoin address will be available as soon as Breez is synchronized.';
+          'You\'d be able to add funds after Breez is finished bootstrapping.';
     } else if (account.waitingDepositConfirmation ||
         account.processingWithdrawal) {
       errorMessage =
@@ -121,7 +129,7 @@ class AddFundsState extends State<AddFundsPage> {
               "Send up to " +
                   account.currency
                       .format(response.maxAllowedDeposit, includeSymbol: true) +
-                  " to this address." + "\nBreez requires you to keep ${account.currency.format(response.requiredReserve)} in your balance.",
+                  " to this address." + "\nBreez requires you to keep ${account.warningMaxChanReserveAmount} in your balance.",
               style: theme.warningStyle, textAlign: TextAlign.center,)),
     ]);
   }

--- a/lib/services/breezlib/data/rpc.pb.dart
+++ b/lib/services/breezlib/data/rpc.pb.dart
@@ -55,6 +55,7 @@ class Account extends $pb.GeneratedMessage {
     ..aInt64(7, 'maxPaymentAmount')
     ..aInt64(8, 'routingNodeFee')
     ..aOB(9, 'enabled')
+    ..aInt64(10, 'maxChanReserve')
     ..hasRequiredFields = false
   ;
 
@@ -114,6 +115,11 @@ class Account extends $pb.GeneratedMessage {
   set enabled(bool v) { $_setBool(8, v); }
   bool hasEnabled() => $_has(8);
   void clearEnabled() => clearField(9);
+
+  Int64 get maxChanReserve => $_getI64(9);
+  set maxChanReserve(Int64 v) { $_setInt64(9, v); }
+  bool hasMaxChanReserve() => $_has(9);
+  void clearMaxChanReserve() => clearField(10);
 }
 
 class Payment extends $pb.GeneratedMessage {

--- a/lib/services/breezlib/data/rpc.pbjson.dart
+++ b/lib/services/breezlib/data/rpc.pbjson.dart
@@ -24,6 +24,7 @@ const Account$json = const {
     const {'1': 'maxPaymentAmount', '3': 7, '4': 1, '5': 3, '10': 'maxPaymentAmount'},
     const {'1': 'routingNodeFee', '3': 8, '4': 1, '5': 3, '10': 'routingNodeFee'},
     const {'1': 'enabled', '3': 9, '4': 1, '5': 8, '10': 'enabled'},
+    const {'1': 'maxChanReserve', '3': 10, '4': 1, '5': 3, '10': 'maxChanReserve'},
   ],
   '4': const [Account_AccountStatus$json],
 };

--- a/lib/user_app.dart
+++ b/lib/user_app.dart
@@ -96,7 +96,7 @@ class UserApp extends StatelessWidget {
                   );
                 case '/add_funds':
                   return new FadeInRoute(
-                    builder: (_) => new AddFundsPage(user),
+                    builder: (_) => new AddFundsPage(user, accountBloc),
                     settings: settings,
                   );
                 case '/withdraw_funds':


### PR DESCRIPTION
This PR is the final step for using the channel reserve in add funds.
Two changes here:
1. Only start the submarine swap process after account has finished bootstrapping.
2. Show proper error message when account is bootstrapping.