### PR TITLE
Trace routes bug report

### DIFF
--- a/lib/bloc/account/account_actions.dart
+++ b/lib/bloc/account/account_actions.dart
@@ -16,8 +16,7 @@ class AsyncAction {
 }
 
 class SendPaymentFailureReport extends AsyncAction {
-  final String paymentRequest;
-  final Int64 amount;  
+  final String traceReport;  
 
-  SendPaymentFailureReport(this.paymentRequest, {this.amount});  
+  SendPaymentFailureReport(this.traceReport);  
 }

--- a/lib/bloc/account/account_model.dart
+++ b/lib/bloc/account/account_model.dart
@@ -386,9 +386,10 @@ class PayRequest {
 class PaymentError implements Exception {
   final PayRequest request;
   final Object error;
-  bool get validationError => error.toString().indexOf("rpc error") >= 0;
+  final String traceReport;
+  bool get validationError => error.toString().indexOf("rpc error") >= 0 || traceReport == null || traceReport.isEmpty;
 
-  PaymentError(this.request, this.error);
+  PaymentError(this.request, this.error, this.traceReport);
   
   String errMsg() => error?.toString();
   String toString() => errMsg();

--- a/lib/routes/user/received_invoice_notification.dart
+++ b/lib/routes/user/received_invoice_notification.dart
@@ -99,24 +99,25 @@ class InvoiceNotificationsHandler {
         message:
             "Failed to send payment: ${error.toString().split("\n").first}");
 
-    if (!error.validationError && prompt) {
-      send = await showDialog(
-          context: _context,
-          barrierDismissible: false,
-          builder: (_) =>
-              new PaymentFailedReportDialog(_context, _accountBloc));
-    }
+    if (!error.validationError) {
+      if (prompt) {
+        send = await showDialog(
+            context: _context,
+            barrierDismissible: false,
+            builder: (_) =>
+                new PaymentFailedReportDialog(_context, _accountBloc));
+      }
 
-    if (send) {
-      var sendAction = SendPaymentFailureReport(error.request.paymentRequest,
-          amount: error.request.amount);
-      _accountBloc.userActionsSink.add(sendAction);
-      await Navigator.push(
-          _context,
-          createLoaderRoute(_context,
-              message: "Sending Report...",
-              opacity: 0.8,
-              action: sendAction.future));
+      if (send) {
+        var sendAction = SendPaymentFailureReport(error.traceReport);
+        _accountBloc.userActionsSink.add(sendAction);
+        await Navigator.push(
+            _context,
+            createLoaderRoute(_context,
+                message: "Sending Report...",
+                opacity: 0.8,
+                action: sendAction.future));
+      }
     }
   }
 }

--- a/lib/services/breezlib/breez_bridge.dart
+++ b/lib/services/breezlib/breez_bridge.dart
@@ -112,24 +112,18 @@ class BreezBridge {
         .then( (res) => new RemoveFundReply()..mergeFromBuffer(res ?? []));
   }
 
-  Future sendPaymentForRequest(String blankInvoicePaymentRequest, {Int64 amount}) {
+  Future<PaymentResponse> sendPaymentForRequest(String blankInvoicePaymentRequest, {Int64 amount}) {
     PayInvoiceRequest invoice = new PayInvoiceRequest();
     if (amount == null) {
       amount = Int64(0);
     }
     invoice.amount = amount;
     invoice.paymentRequest = blankInvoicePaymentRequest;
-    return _invokeMethodWhenReady("sendPaymentForRequest", {"argument": invoice.writeToBuffer()}).then((payReq) => payReq as String);
+    return _invokeMethodWhenReady("sendPaymentForRequest", {"argument": invoice.writeToBuffer()}).then((payReq) => PaymentResponse()..mergeFromBuffer(payReq ?? []));
   }
 
-  Future sendPaymentFailureBugReport(String paymentRequest, {Int64 amount}) {
-    PayInvoiceRequest invoice = new PayInvoiceRequest();
-    if (amount == null) {
-      amount = Int64(0);
-    }
-    invoice.amount = amount;
-    invoice.paymentRequest = paymentRequest;
-    return _invokeMethodWhenReady("sendPaymentFailureBugReport", {"argument": invoice.writeToBuffer()}).then((payReq) => payReq as String);
+  Future sendPaymentFailureBugReport(String traceReport) {    
+    return _invokeMethodWhenReady("sendPaymentFailureBugReport", {"argument": traceReport});
   }
 
   Future bootstrapFiles(String workingDir, List<String> bootstrapFilesPaths) {

--- a/lib/services/breezlib/data/rpc.pb.dart
+++ b/lib/services/breezlib/data/rpc.pb.dart
@@ -221,6 +221,36 @@ class PaymentsList extends $pb.GeneratedMessage {
   List<Payment> get paymentsList => $_getList(0);
 }
 
+class PaymentResponse extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('PaymentResponse', package: const $pb.PackageName('data'))
+    ..aOS(1, 'paymentError')
+    ..aOS(2, 'traceReport')
+    ..hasRequiredFields = false
+  ;
+
+  PaymentResponse() : super();
+  PaymentResponse.fromBuffer(List<int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  PaymentResponse.fromJson(String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
+  PaymentResponse clone() => new PaymentResponse()..mergeFromMessage(this);
+  PaymentResponse copyWith(void Function(PaymentResponse) updates) => super.copyWith((message) => updates(message as PaymentResponse));
+  $pb.BuilderInfo get info_ => _i;
+  static PaymentResponse create() => new PaymentResponse();
+  PaymentResponse createEmptyInstance() => create();
+  static $pb.PbList<PaymentResponse> createRepeated() => new $pb.PbList<PaymentResponse>();
+  static PaymentResponse getDefault() => _defaultInstance ??= create()..freeze();
+  static PaymentResponse _defaultInstance;
+
+  String get paymentError => $_getS(0, '');
+  set paymentError(String v) { $_setString(0, v); }
+  bool hasPaymentError() => $_has(0);
+  void clearPaymentError() => clearField(1);
+
+  String get traceReport => $_getS(1, '');
+  set traceReport(String v) { $_setString(1, v); }
+  bool hasTraceReport() => $_has(1);
+  void clearTraceReport() => clearField(2);
+}
+
 class SendWalletCoinsRequest extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = new $pb.BuilderInfo('SendWalletCoinsRequest', package: const $pb.PackageName('data'))
     ..aOS(1, 'address')

--- a/lib/services/breezlib/data/rpc.pbjson.dart
+++ b/lib/services/breezlib/data/rpc.pbjson.dart
@@ -74,6 +74,14 @@ const PaymentsList$json = const {
   ],
 };
 
+const PaymentResponse$json = const {
+  '1': 'PaymentResponse',
+  '2': const [
+    const {'1': 'paymentError', '3': 1, '4': 1, '5': 9, '10': 'paymentError'},
+    const {'1': 'traceReport', '3': 2, '4': 1, '5': 9, '10': 'traceReport'},
+  ],
+};
+
 const SendWalletCoinsRequest$json = const {
   '1': 'SendWalletCoinsRequest',
   '2': const [


### PR DESCRIPTION
This PR adjusts the UI to the new FailedRoutes information that is added the PaymentResponse.
In the case of a payment error that is received from the router, we now send a response that contains this error and a trace routes report to send for further diagnostic (if the user accepts).