### PR TITLE
Compact QR Image

### DIFF
--- a/lib/routes/pos/home/pos_invoice.dart
+++ b/lib/routes/pos/home/pos_invoice.dart
@@ -3,9 +3,9 @@ import 'package:breez/bloc/account/account_bloc.dart';
 import 'package:breez/bloc/blocs_provider.dart';
 import 'package:breez/bloc/pos_profile/pos_profile_bloc.dart';
 import 'package:breez/bloc/user_profile/user_profile_bloc.dart';
+import 'package:breez/widgets/compact_qr_image.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:flutter/material.dart';
-import 'package:breez/bloc/app_blocs.dart';
 import 'package:breez/bloc/account/account_model.dart';
 import 'package:breez/bloc/invoice/invoice_bloc.dart';
 import 'package:breez/bloc/invoice/invoice_model.dart';
@@ -15,7 +15,6 @@ import 'package:breez/services/countdown.dart';
 import 'package:breez/widgets/error_dialog.dart';
 import 'package:breez/theme_data.dart' as theme;
 import 'package:breez/routes/user/home/status_indicator.dart';
-import 'package:qr_flutter/qr_flutter.dart';
 
 var cancellationTimeoutValue;
 
@@ -602,8 +601,7 @@ class _NfcDialogState extends State<_NfcDialog> {
                                     height: 200.0,
                                   );
                                 }
-                                return new QrImage(
-                                  version: 20,
+                                return new CompactQRImage(                                  
                                   data: snapshot.data,
                                 );
                               })),

--- a/lib/routes/user/add_funds/address_widget.dart
+++ b/lib/routes/user/add_funds/address_widget.dart
@@ -1,6 +1,6 @@
+import 'package:breez/widgets/compact_qr_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:qr_flutter/qr_flutter.dart';
 import 'package:share/share.dart';
 import 'package:breez/theme_data.dart' as theme;
 
@@ -71,7 +71,7 @@ class AddressWidget extends StatelessWidget {
                   decoration: theme.qrImageStyle,
                   child: new Container(
                     color: theme.whiteColor,
-                    child: new QrImage(
+                    child: new CompactQRImage(
                       data: "bitcoin:" + address,
                       size: 180.0,
                     ),

--- a/lib/routes/user/create_invoice/qr_code_dialog.dart
+++ b/lib/routes/user/create_invoice/qr_code_dialog.dart
@@ -1,8 +1,8 @@
+import 'package:breez/widgets/compact_qr_image.dart';
 import 'package:breez/widgets/flushbar.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:breez/theme_data.dart' as theme;
-import 'package:qr_flutter/qr_flutter.dart';
 import 'package:share/share.dart';
 import 'package:flutter/services.dart';
 import 'package:breez/bloc/invoice/invoice_bloc.dart';
@@ -85,8 +85,7 @@ class QrCodeDialog extends StatelessWidget {
                   new Container(
                     width: 230.0,
                     height: 230.0,
-                    child: new QrImage(
-                      version: 20,
+                    child: new CompactQRImage(                      
                       data: snapshot.data,
                     ),
                   ),

--- a/lib/widgets/compact_qr_image.dart
+++ b/lib/widgets/compact_qr_image.dart
@@ -1,0 +1,36 @@
+
+import 'package:flutter/material.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+
+var _versionsToMaxCharacters = [
+  17, 32, 53, 78, 106, 134, 154, 192, 230, 271, 
+  321, 367, 425, 458, 520, 586, 644, 718, 792, 858,
+  929, 1003, 1091, 1171, 1273, 1367, 1465, 1528, 1628, 1732,
+  1840, 1952, 2068, 2188, 2303, 2431, 2563, 2699, 2809, 2953
+];
+
+class CompactQRImage extends StatelessWidget {
+  final String data;
+  final double size;
+
+  CompactQRImage({Key key, this.data, this.size}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return QrImage(
+      version: _calculateVersion(),
+      data: data,
+      size: this.size,
+    );
+  }
+
+  int _calculateVersion() {
+    int index;
+    for (index = 0; index < _versionsToMaxCharacters.length; ++index) {
+      if (_versionsToMaxCharacters[index] > data.length) {
+        break;
+      }
+    }    
+    return index+1;
+  }  
+}


### PR DESCRIPTION
This PR add an adjustment to the way we render a QR image by selecting the version dynamically.
The version ranges from 1 - 40 and reflects the number of modules (black and white dots) used to render the image.
We used this table (https://www.qrcode.com/en/about/version.html) to select dynamically the version according to the data length.