### PR TITLE
support bip21 with bolt11 invoice

### DIFF
--- a/lib/bloc/invoice/invoice_bloc.dart
+++ b/lib/bloc/invoice/invoice_bloc.dart
@@ -110,6 +110,13 @@ class InvoiceBloc {
       if (lower.startsWith("lightning:")) {
         return s.substring(10);
       }
+
+      // check bip21 with bolt11
+      RegExp bip21Format = new RegExp("bitcoin:.*\?amount=.*&lightning=(.*)");
+      Match m = bip21Format.matchAsPrefix(lower);
+      if (m != null) {
+        return m.group(1);
+      }
       return s;
     })
     .asyncMap((paymentRequest) {


### PR DESCRIPTION
This PR adds support for bip21 with bolt11 invoice: https://github.com/lncm/ideas/wiki/BIP21-w-BOLT11-wallet-support.
The format contains an embedded invoice so we only need to recognize it is bip21 format and extract the lightning invoice.