### PR TITLE
Better approach for parsing bip21 URIs.

### DIFF
--- a/lib/bloc/invoice/invoice_bloc.dart
+++ b/lib/bloc/invoice/invoice_bloc.dart
@@ -4,6 +4,7 @@ import 'package:breez/services/injector.dart';
 import 'package:breez/services/breez_server/server.dart';
 import 'package:breez/services/nfc.dart';
 import 'package:breez/services/notifications.dart';
+import 'package:breez/utils/bip21.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:breez/logger.dart';
 import 'package:breez/services/breezlib/breez_bridge.dart';
@@ -112,11 +113,11 @@ class InvoiceBloc {
       }
 
       // check bip21 with bolt11
-      RegExp bip21Format = new RegExp("bitcoin:.*\?amount=.*&lightning=(.*)");
-      Match m = bip21Format.matchAsPrefix(lower);
-      if (m != null) {
-        return m.group(1);
+      String bolt11 = extractBolt11FromBip21(lower);
+      if (bolt11 != null) {
+        return bolt11;
       }
+               
       return s;
     })
     .asyncMap((paymentRequest) {

--- a/lib/utils/bip21.dart
+++ b/lib/utils/bip21.dart
@@ -1,0 +1,13 @@
+String extractBolt11FromBip21(String bip21) {
+  String lowerBit21 = bip21.toLowerCase();
+  if (lowerBit21.startsWith("bitcoin:")) {
+    try {
+      Uri uri = Uri.parse(lowerBit21);
+      String bolt11 = uri.queryParameters["lightning"];
+      if (bolt11 != null && bolt11.isNotEmpty) {
+        return bolt11;
+      }
+    } on FormatException {} // do nothing.
+  }
+  return null;
+}

--- a/lib/utils/bip21.dart
+++ b/lib/utils/bip21.dart
@@ -1,8 +1,8 @@
 String extractBolt11FromBip21(String bip21) {
-  String lowerBit21 = bip21.toLowerCase();
-  if (lowerBit21.startsWith("bitcoin:")) {
+  String lowerBip21 = bip21.toLowerCase();
+  if (lowerBip21.startsWith("bitcoin:")) {
     try {
-      Uri uri = Uri.parse(lowerBit21);
+      Uri uri = Uri.parse(lowerBip21);
       String bolt11 = uri.queryParameters["lightning"];
       if (bolt11 != null && bolt11.isNotEmpty) {
         return bolt11;

--- a/test/invoice_test.dart
+++ b/test/invoice_test.dart
@@ -1,0 +1,31 @@
+import 'package:breez/utils/bip21.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('invoice_tests', () {   
+    test("should extract bolt11 from bip21 full info", () async {
+      String bolt11 = extractBolt11FromBip21("bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?amount=0.000001&lightning=1234");
+      expect(bolt11, "1234");
+    });
+
+    test("should extract bolt11 from bip21 no amount", () async {
+      String bolt11 = extractBolt11FromBip21("bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?lightning=1234");
+      expect(bolt11, "1234");
+    });
+
+    test("should extract bolt11 from bip21 amount last", () async {
+      String bolt11 = extractBolt11FromBip21("bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?lightning=1234&amount=0.000001");
+      expect(bolt11, "1234");
+    });
+
+    test("should extract bolt11 from bip21 upper case", () async {
+      String bolt11 = extractBolt11FromBip21("BITCOIN:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?amount=0.000001&lightning=1234");
+      expect(bolt11, "1234");
+    });
+
+    test("should extract bolt11 from bip21 negative, no lightning", () async {
+      String bolt11 = extractBolt11FromBip21("bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?amount=0.000001");
+      expect(bolt11, null);
+    });
+  });
+}


### PR DESCRIPTION
This PR takes a better (more robust) approach for parsing bip21 URI's and extract the optional bolt11 invoice embedded there.
The bip (https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki) states that these URIs follow the general format for URIs as set forth in RFC 3986 so based on that the code was changes to use Uri.parse builtin in dart to get the query params and specifically the bolt11 we are interested in.
In addition, some unit tests were added based on feedback for the previous implementation.
Thanks @meeDamian.