### PR TITLE
BU-159 | Failed payment dialog doesn't close

### DIFF
--- a/lib/widgets/payment_request_dialog.dart
+++ b/lib/widgets/payment_request_dialog.dart
@@ -168,18 +168,18 @@ class PaymentRequestDialogState extends State<PaymentRequestDialog>
     if (!error.validationError) {
       if (prompt) {
         send = await showDialog(
-            context: context,
+            context: widget.context,
             barrierDismissible: false,
             builder: (_) =>
-            new PaymentFailedReportDialog(context, widget.accountBloc));
+            new PaymentFailedReportDialog(widget.context, widget.accountBloc));
       }
 
       if (send) {
         var sendAction = SendPaymentFailureReport(error.traceReport);
         widget.accountBloc.userActionsSink.add(sendAction);
         await Navigator.push(
-            context,
-            createLoaderRoute(context,
+            widget.context,
+            createLoaderRoute(widget.context,
                 message: "Sending Report...",
                 opacity: 0.8,
                 action: sendAction.future));


### PR DESCRIPTION
This PR fixes the issue with closing failed payment dialog.
- Wrong context was given to PaymentFailedReportDialog.