### PR TITLE
Safe dismiss payment dialog

### DIFF
--- a/lib/bloc/account/account_actions.dart
+++ b/lib/bloc/account/account_actions.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 
 import 'package:fixnum/fixnum.dart';
 
+import 'account_model.dart';
+
 class AsyncAction {
   Completer _completer = new Completer(); 
   Future get future => _completer.future;
@@ -26,3 +28,15 @@ class ResetNetwork extends AsyncAction {}
 class RestartDaemon extends AsyncAction {}
 
 class FetchSwapFundStatus extends AsyncAction{}
+
+class SendPayment extends AsyncAction{
+  final PayRequest paymentRequest;
+
+  SendPayment(this.paymentRequest);
+}
+
+class CancelPaymentRequest extends AsyncAction {
+  final PayRequest paymentRequest;
+
+  CancelPaymentRequest(this.paymentRequest);
+}

--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -213,8 +213,8 @@ class AccountBloc {
       _accountController.add(
         _accountController.value.copyWith(paymentRequestInProgress: ""));
 
-      if (response.paymentError.isNotEmpty) {        
-        return Future.error(response.paymentError);
+      if (response.paymentError.isNotEmpty) {         
+        return Future.error(PaymentError(payRequest, response.paymentError, response.traceReport));
       }
       
       _completedPaymentsController.add(CompletedPayment(payRequest));
@@ -223,9 +223,10 @@ class AccountBloc {
     }).catchError((err) {        
       _accountController.add(
           _accountController.value.copyWith(paymentRequestInProgress: ""));
+      var error = (err.runtimeType == PaymentError ? err : PaymentError(payRequest, err, null));
       _completedPaymentsController
-          .addError(PaymentError(payRequest, err, null));
-        return Future.error(err);
+          .addError(error);
+        return Future.error(error);
     });
   }
 

--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -80,13 +80,10 @@ class AccountBloc {
   final _accountNotificationsController =
       new StreamController<String>.broadcast();
   Stream<String> get accountNotificationsStream =>
-      _accountNotificationsController.stream;
+      _accountNotificationsController.stream;  
 
-  final _sentPaymentsController = new StreamController<PayRequest>();
-  Sink<PayRequest> get sentPaymentsSink => _sentPaymentsController.sink;
-
-  final _fulfilledPaymentsController = new StreamController<String>.broadcast();
-  Stream<String> get fulfilledPayments => _fulfilledPaymentsController.stream;
+  final _completedPaymentsController = new StreamController<CompletedPayment>.broadcast();
+  Stream<CompletedPayment> get completedPaymentsStream => _completedPaymentsController.stream;
 
   final _lightningDownController = new StreamController<bool>.broadcast();
   Stream<bool> get lightningDownStream => _lightningDownController.stream;  
@@ -121,7 +118,9 @@ class AccountBloc {
       SendPaymentFailureReport: _handleSendQueryRoute,
       ResetNetwork: _handleResetNetwork,
       RestartDaemon: _handleRestartDaemon,
-      FetchSwapFundStatus: _fetchFundStatusAction
+      FetchSwapFundStatus: _fetchFundStatusAction,
+      SendPayment: _sendPayment,
+      CancelPaymentRequest: _cancelPaymentRequest
     };
 
     _accountController.add(AccountModel.initial());
@@ -137,8 +136,7 @@ class AccountBloc {
       _listenAccountActions();      
       _hanleAccountSettings();
       _listenUserChanges(userProfileStream);
-      _listenWithdrawalRequests();
-      _listenSentPayments();
+      _listenWithdrawalRequests();      
       _listenFilterChanges();
       _listenAccountChanges();
       _listenEnableAccount();
@@ -202,6 +200,38 @@ class AccountBloc {
 
   Future _fetchFundStatusAction(FetchSwapFundStatus action) async {
     action.resolve(await _fetchFundStatus());    
+  }
+
+  Future _sendPayment(SendPayment sendPayment) {
+    var payRequest = sendPayment.paymentRequest;
+    _accountController.add(_accountController.value
+          .copyWith(paymentRequestInProgress: payRequest.paymentRequest));
+    return _breezLib
+        .sendPaymentForRequest(payRequest.paymentRequest,
+            amount: payRequest.amount)
+        .then((response) {
+      _accountController.add(
+        _accountController.value.copyWith(paymentRequestInProgress: ""));
+
+      if (response.paymentError.isNotEmpty) {        
+        return Future.error(response.paymentError);
+      }
+      
+      _completedPaymentsController.add(CompletedPayment(payRequest));
+      return Future.value(null);
+
+    }).catchError((err) {        
+      _accountController.add(
+          _accountController.value.copyWith(paymentRequestInProgress: ""));
+      _completedPaymentsController
+          .addError(PaymentError(payRequest, err, null));
+        return Future.error(err);
+    });
+  }
+
+  Future _cancelPaymentRequest(CancelPaymentRequest cancelRequest){
+    _completedPaymentsController.add(CompletedPayment(cancelRequest.paymentRequest, cancelled: true));
+    return Future.value(null);
   }
 
   void _listenRefundableDeposits() {
@@ -381,33 +411,6 @@ class AccountBloc {
     });
   }
 
-  void _listenSentPayments() {
-    _sentPaymentsController.stream.listen((payRequest) {
-      _accountController.add(_accountController.value
-          .copyWith(paymentRequestInProgress: payRequest.paymentRequest));
-      _breezLib
-          .sendPaymentForRequest(payRequest.paymentRequest,
-              amount: payRequest.amount)
-          .then((response) {
-        if (response.paymentError.isNotEmpty) {
-          _accountController.add(
-            _accountController.value.copyWith(paymentRequestInProgress: ""));
-          _fulfilledPaymentsController.addError(PaymentError(
-              payRequest, response.paymentError, response.traceReport));
-          return;
-        }
-        _accountController.add(
-            _accountController.value.copyWith(paymentRequestInProgress: ""));
-        _fulfilledPaymentsController.add(payRequest.paymentRequest);
-      }).catchError((err) {        
-        _accountController.add(
-            _accountController.value.copyWith(paymentRequestInProgress: ""));
-        _fulfilledPaymentsController
-            .addError(PaymentError(payRequest, err, null));
-      });
-    });
-  }
-
   void _listenFilterChanges() {
     _paymentFilterController.stream.skip(1).listen((filter) {
       _refreshPayments();
@@ -535,8 +538,7 @@ class AccountBloc {
   close() {
     _accountEnableController.close();    
     _paymentsController.close();
-    _accountNotificationsController.close();
-    _sentPaymentsController.close();
+    _accountNotificationsController.close();    
     _withdrawalController.close();
     _paymentFilterController.close();
     _lightningDownController.close();

--- a/lib/bloc/account/account_model.dart
+++ b/lib/bloc/account/account_model.dart
@@ -395,6 +395,13 @@ class PayRequest {
   PayRequest(this.paymentRequest, this.amount);
 }
 
+class CompletedPayment {
+  final PayRequest paymentRequest;
+  final bool cancelled;
+
+  CompletedPayment(this.paymentRequest, {this.cancelled = false});
+}
+
 class PaymentError implements Exception {
   final PayRequest request;
   final Object error;

--- a/lib/routes/user/pay_nearby/pay_nearby_complete.dart
+++ b/lib/routes/user/pay_nearby/pay_nearby_complete.dart
@@ -1,3 +1,4 @@
+import 'package:breez/bloc/account/account_model.dart';
 import 'package:breez/bloc/blocs_provider.dart';
 import 'package:breez/bloc/invoice/invoice_bloc.dart';
 import 'package:breez/bloc/account/account_bloc.dart';
@@ -30,7 +31,7 @@ class PayNearbyCompleteState extends State<PayNearbyComplete> with WidgetsBindin
 
   StreamSubscription _blankInvoiceSubscription;
   StreamSubscription _paidInvoicesSubscription;
-  StreamSubscription<String> _sentPaymentResultSubscription;
+  StreamSubscription<CompletedPayment> _sentPaymentResultSubscription;
 
   var _scaffoldKey = new GlobalKey<ScaffoldState>();
   bool _isInit = false;
@@ -76,7 +77,7 @@ class PayNearbyCompleteState extends State<PayNearbyComplete> with WidgetsBindin
           duration: new Duration(seconds: 3),
           content: new Text("Failed to send payment: " + err.toString()))));
     
-    _sentPaymentResultSubscription = _accountBloc.fulfilledPayments
+    _sentPaymentResultSubscription = _accountBloc.completedPaymentsStream
       .listen((fulfilledPayment) {
         _scaffoldKey.currentState.showSnackBar(new SnackBar(
             duration: new Duration(seconds: 3),

--- a/lib/routes/user/received_invoice_notification.dart
+++ b/lib/routes/user/received_invoice_notification.dart
@@ -19,6 +19,13 @@ class InvoiceNotificationsHandler {
   InvoiceNotificationsHandler(
       this._context, this._accountBloc, this._receivedInvoicesStream, this.firstPaymentItemKey, this.scrollController, this.scaffoldController) {
     _listenPaymentRequests();
+    _listenCompletedPayments();
+  }
+
+  _listenCompletedPayments() {
+    _accountBloc.completedPaymentsStream.listen((completedPayment){
+      _handlingRequest = false;
+    });
   }
 
   _listenPaymentRequests() {
@@ -44,8 +51,7 @@ class InvoiceNotificationsHandler {
             context: _context,
             barrierDismissible: false,
             builder: (_) => paymentRequest.PaymentRequestDialog(
-                        _context, _accountBloc, payreq, firstPaymentItemKey, scrollController))
-            .whenComplete(() => _handlingRequest = false);
+                        _context, _accountBloc, payreq, firstPaymentItemKey, scrollController));            
       }).onError((error) {
         _setLoading(false);
         _handlingRequest = false;

--- a/lib/routes/user/received_invoice_notification.dart
+++ b/lib/routes/user/received_invoice_notification.dart
@@ -23,9 +23,9 @@ class InvoiceNotificationsHandler {
   }
 
   _listenCompletedPayments() {
-    _accountBloc.completedPaymentsStream.listen((completedPayment){
-      _handlingRequest = false;
-    });
+    _accountBloc.completedPaymentsStream.listen( (completedPayment){ _handlingRequest = false;}, onError: (err){
+        _handlingRequest = false;
+      });
   }
 
   _listenPaymentRequests() {

--- a/lib/widgets/payment_confirmation_dialog.dart
+++ b/lib/widgets/payment_confirmation_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:breez/bloc/account/account_actions.dart';
 import 'package:breez/bloc/account/account_bloc.dart';
 import 'package:breez/bloc/account/account_model.dart';
 import 'package:breez/bloc/invoice/invoice_model.dart';
@@ -87,12 +88,12 @@ class PaymentConfirmationDialogState extends State<PaymentConfirmationDialog> {
     List<Widget> children = <Widget>[
       new FlatButton(
         child: new Text("NO", style: theme.buttonStyle),
-        onPressed: () => Navigator.pop(context, false),
+        onPressed: () => widget._onStateChange(PaymentRequestState.USER_CANCELLED),
       ),
       new FlatButton(
         child: new Text("YES", style: theme.buttonStyle),
         onPressed: () {
-          widget.accountBloc.sentPaymentsSink.add(PayRequest(widget.invoice.rawPayReq, widget._amountToPay));
+          widget.accountBloc.userActionsSink.add(SendPayment(PayRequest(widget.invoice.rawPayReq, widget._amountToPay)));
           widget._onStateChange(PaymentRequestState.PROCESSING_PAYMENT);
         },
       ),

--- a/lib/widgets/payment_request_dialog.dart
+++ b/lib/widgets/payment_request_dialog.dart
@@ -50,10 +50,7 @@ class PaymentRequestDialogState extends State<PaymentRequestDialog> {
   @override void didChangeDependencies() {    
     super.didChangeDependencies();
     if (_currentRoute == null) {
-      _currentRoute = ModalRoute.of(context);
-      // widget.accountBloc.fulfilledPayments.listen((_){}, onError: (){
-      //   Navigator.of(context).removeRoute(_currentRoute);
-      // });
+      _currentRoute = ModalRoute.of(context);      
     }
   }
 

--- a/lib/widgets/payment_request_info_dialog.dart
+++ b/lib/widgets/payment_request_info_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:breez/bloc/account/account_actions.dart';
 import 'package:breez/bloc/account/account_bloc.dart';
 import 'package:breez/bloc/account/account_model.dart';
 import 'package:breez/bloc/invoice/invoice_model.dart';
@@ -212,7 +213,7 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
   Widget _buildActions(AccountModel account) {
     List<Widget> actions = [
       SimpleDialogOption(
-        onPressed: () => Navigator.pop(context),
+        onPressed: () => widget._onStateChange(PaymentRequestState.USER_CANCELLED),
         child: new Text("CANCEL", style: theme.buttonStyle),
       )
     ];
@@ -229,7 +230,7 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
               widget._setAmountToPay(_amountToPayMap);
               widget._onStateChange(PaymentRequestState.WAITING_FOR_CONFIRMATION);
             } else {
-              widget.accountBloc.sentPaymentsSink.add(PayRequest(widget.invoice.rawPayReq, amountToPay(account)));
+              widget.accountBloc.userActionsSink.add(SendPayment(PayRequest(widget.invoice.rawPayReq, amountToPay(account))));
               widget._onStateChange(PaymentRequestState.PROCESSING_PAYMENT);
             }
           }


### PR DESCRIPTION
This PR makes sure we safely dismiss the payment dialog when the payment is completed/cancelled/failed.
Safely means that we don't just pop out of the stack the last route but remove explicitly the route we need.
This is to prevent from other routes (like backup dialog) that we don't directly control from the flow, from being popped by mistake.
In addition the specific controller that was dealing with send payment requests is now removed and the actions going through the generic user action controller.