### PR TITLE
Only take voucher code of the url being scanned on Redeem Fastbitcoins Voucher form.

### DIFF
--- a/lib/routes/user/add_funds/fastbitcoins_page.dart
+++ b/lib/routes/user/add_funds/fastbitcoins_page.dart
@@ -67,8 +67,9 @@ class FastbitcoinsPageState extends State<FastbitcoinsPage> {
     try {
       FocusScope.of(context).requestFocus(FocusNode());
       String barcode = await BarcodeScanner.scan();
+      String _voucherCode = barcode.substring(barcode.lastIndexOf("/") + 1);
       setState(() {
-        _codeController.text = barcode;
+        _codeController.text = _voucherCode;
         _scannerErrorMessage = "";
       });
     } on PlatformException catch (e) {


### PR DESCRIPTION
Fastbitcoins qr codes contain full url and with this PR we are reducing the scanned url to the voucher code. [BU-165](https://breeztech.atlassian.net/browse/BU-165)

