### PR TITLE
Better show swap funds errors.

### DIFF
--- a/lib/bloc/account/account_model.dart
+++ b/lib/bloc/account/account_model.dart
@@ -63,9 +63,30 @@ class SwapFundStatus {
       _addedFundsReply?.status == FundStatusReply_FundStatus.CONFIRMED;
 
   // in case of status is error, these fields will be populated.
-  String get error => _addedFundsReply?.error?.errorMessage;
-  bool get fundsExceededLimit => _addedFundsReply?.error?.fundsExceededLimit;
-  int get lockHeight => _addedFundsReply?.error?.lockHeight;
+  String get error {    
+    return refundableError ?? _addedFundsReply?.error?.swapAddressInfo?.errorMessage;
+  }
+
+  String get refundableError {
+    SwapAddressInfo address = _addedFundsReply?.error?.swapAddressInfo;
+    if (address == null) {
+      return null;
+    }
+    switch(address.swapError) {
+      case SwapError.FUNDS_EXCEED_LIMIT:
+        return "the executed transaction was above the specified limit.";
+      case SwapError.INVOICE_AMOUNT_MISMATCH:
+        return "the requested amount doesn't match the original transaction.";
+      case SwapError.SWAP_EXPIRED:
+        return " the transaction had expired.";
+      case SwapError.TX_TOO_SMALL:
+        return "the transaction size was too small to process.";
+      default:
+        return null;
+    }
+  }
+    
+  int get lockHeight => _addedFundsReply?.error?.swapAddressInfo?.lockHeight;
   double get hoursToUnlock => _addedFundsReply?.error?.hoursToUnlock;
 }
 

--- a/lib/routes/shared/account_required_actions.dart
+++ b/lib/routes/shared/account_required_actions.dart
@@ -79,60 +79,63 @@ class AccountRequiredActionsIndicatorState
           return StreamBuilder<AccountModel>(
               stream: widget._accountBloc.accountStream,
               builder: (context, accountSnapshot) {
-                return StreamBuilder<BackupState>(
-                    stream: widget._backupBloc.backupStateStream,
-                    builder: (context, backupSnapshot) {
-                      List<Widget> warnings = List<Widget>();
-                      Int64 walletBalance =
-                          accountSnapshot?.data?.walletBalance ?? Int64(0);
-                      if (walletBalance > 0 &&
-                          !settingsSnapshot.data.ignoreWalletBalance) {
-                        warnings.add(WarningAction(() =>
-                            Navigator.of(context).pushNamed("/send_coins")));
-                      }
+                return StreamBuilder<List<RefundableDepositModel>>(
+                  stream: widget._accountBloc.refundableDepositsStream,
+                  builder: (context, refundables) => StreamBuilder<BackupState>(
+                      stream: widget._backupBloc.backupStateStream,
+                      builder: (context, backupSnapshot) {
+                        List<Widget> warnings = List<Widget>();
+                        Int64 walletBalance =
+                            accountSnapshot?.data?.walletBalance ?? Int64(0);
+                        if (walletBalance > 0 &&
+                            !settingsSnapshot.data.ignoreWalletBalance) {
+                          warnings.add(WarningAction(() =>
+                              Navigator.of(context).pushNamed("/send_coins")));
+                        }
 
-                      if (backupSnapshot.hasError) {
-                        warnings.add(WarningAction(() => showDialog(
-                            barrierDismissible: false,
-                            context: context,
-                            builder: (_) => new EnableBackupDialog(
-                                context, widget._backupBloc))));
-                      } else if (backupSnapshot.data?.inProgress == true) {
-                        warnings.add(WarningAction(
-                          (){
-                            showDialog(
-                              context: context,                              
-                              builder: (_) => buildBackupInProgressDialog(context, widget._backupBloc.backupStateStream));
-                          },
-                          iconWidget: Rotator(child: Image(image: AssetImage("src/icon/sync.png"), color: Color.fromRGBO(0, 120, 253, 1.0))),
-                        ));
-                      }
+                        if (backupSnapshot.hasError) {
+                          warnings.add(WarningAction(() => showDialog(
+                              barrierDismissible: false,
+                              context: context,
+                              builder: (_) => new EnableBackupDialog(
+                                  context, widget._backupBloc))));
+                        } else if (backupSnapshot.data?.inProgress == true) {
+                          warnings.add(WarningAction(
+                            (){
+                              showDialog(
+                                context: context,                              
+                                builder: (_) => buildBackupInProgressDialog(context, widget._backupBloc.backupStateStream));
+                            },
+                            iconWidget: Rotator(child: Image(image: AssetImage("src/icon/sync.png"), color: Color.fromRGBO(0, 120, 253, 1.0))),
+                          ));
+                        }
 
-                      var swapStatus = accountSnapshot?.data?.swapFundsStatus;
-                      if (swapStatus?.fundsExceededLimit == true) {  
-                        warnings.add(WarningAction(() => showDialog(
-                            barrierDismissible: false,
-                            context: context,
-                            builder: (_) => new OverLimitFundsDialog(accountBloc: widget._accountBloc))));
-                      }
+                        var swapStatus = accountSnapshot?.data?.swapFundsStatus;
+                        if (swapStatus?.refundableError != null || refundables.data?.isNotEmpty == true) {  
+                          warnings.add(WarningAction(() => showDialog(
+                              barrierDismissible: false,
+                              context: context,
+                              builder: (_) => new SwapRefundDialog(accountBloc: widget._accountBloc))));
+                        }
 
-                      if (accountSnapshot?.data?.syncUIState == SyncUIState.COLLAPSED) {
-                        warnings.add(WarningAction(
-                          () => widget._accountBloc.userActionsSink.add(ChangeSyncUIState(SyncUIState.BLOCKING)),
-                          iconWidget: Rotator(child: Image(image: AssetImage("src/icon/sync.png"), color: Color.fromRGBO(0, 120, 253, 1.0))),
-                        ));
-                      }
+                        if (accountSnapshot?.data?.syncUIState == SyncUIState.COLLAPSED) {
+                          warnings.add(WarningAction(
+                            () => widget._accountBloc.userActionsSink.add(ChangeSyncUIState(SyncUIState.BLOCKING)),
+                            iconWidget: Rotator(child: Image(image: AssetImage("src/icon/sync.png"), color: Color.fromRGBO(0, 120, 253, 1.0))),
+                          ));
+                        }
 
-                      if (warnings.length == 0) {
-                        return SizedBox();
-                      }
+                        if (warnings.length == 0) {
+                          return SizedBox();
+                        }
 
-                      return Row(
-                        mainAxisAlignment: MainAxisAlignment.end,
-                        mainAxisSize: MainAxisSize.min,
-                        children: warnings                           
-                      );
-                    });
+                        return Row(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          mainAxisSize: MainAxisSize.min,
+                          children: warnings                           
+                        );
+                      }),
+                );
               });
         });
   }

--- a/lib/routes/shared/funds_over_limit_dialog.dart
+++ b/lib/routes/shared/funds_over_limit_dialog.dart
@@ -58,7 +58,7 @@ class SwapRefundDialogState extends State<SwapRefundDialog> {
                       double hoursToUnlock = 0;
                       int lockHeight = 0;
                       String reason = "";
-                      if (swapStatus != null) {
+                      if (swapStatus?.refundableError != null) {
                         hoursToUnlock = swapStatus.hoursToUnlock;
                         lockHeight = swapStatus.lockHeight;
                         reason = "since " + swapStatus.refundableError;

--- a/lib/services/breezlib/data/rpc.pb.dart
+++ b/lib/services/breezlib/data/rpc.pb.dart
@@ -555,10 +555,8 @@ class RefundRequest extends $pb.GeneratedMessage {
 
 class AddFundError extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo('AddFundError', package: const $pb.PackageName('data'))
-    ..aOS(1, 'errorMessage')
-    ..aOB(2, 'fundsExceededLimit')
-    ..a<$core.int>(3, 'lockHeight', $pb.PbFieldType.OU3)
-    ..a<$core.double>(4, 'hoursToUnlock', $pb.PbFieldType.OF)
+    ..a<SwapAddressInfo>(1, 'swapAddressInfo', $pb.PbFieldType.OM, SwapAddressInfo.getDefault, SwapAddressInfo.create)
+    ..a<$core.double>(2, 'hoursToUnlock', $pb.PbFieldType.OF)
     ..hasRequiredFields = false
   ;
 
@@ -574,25 +572,15 @@ class AddFundError extends $pb.GeneratedMessage {
   static AddFundError getDefault() => _defaultInstance ??= create()..freeze();
   static AddFundError _defaultInstance;
 
-  $core.String get errorMessage => $_getS(0, '');
-  set errorMessage($core.String v) { $_setString(0, v); }
-  $core.bool hasErrorMessage() => $_has(0);
-  void clearErrorMessage() => clearField(1);
+  SwapAddressInfo get swapAddressInfo => $_getN(0);
+  set swapAddressInfo(SwapAddressInfo v) { setField(1, v); }
+  $core.bool hasSwapAddressInfo() => $_has(0);
+  void clearSwapAddressInfo() => clearField(1);
 
-  $core.bool get fundsExceededLimit => $_get(1, false);
-  set fundsExceededLimit($core.bool v) { $_setBool(1, v); }
-  $core.bool hasFundsExceededLimit() => $_has(1);
-  void clearFundsExceededLimit() => clearField(2);
-
-  $core.int get lockHeight => $_get(2, 0);
-  set lockHeight($core.int v) { $_setUnsignedInt32(2, v); }
-  $core.bool hasLockHeight() => $_has(2);
-  void clearLockHeight() => clearField(3);
-
-  $core.double get hoursToUnlock => $_getN(3);
-  set hoursToUnlock($core.double v) { $_setFloat(3, v); }
-  $core.bool hasHoursToUnlock() => $_has(3);
-  void clearHoursToUnlock() => clearField(4);
+  $core.double get hoursToUnlock => $_getN(1);
+  set hoursToUnlock($core.double v) { $_setFloat(1, v); }
+  $core.bool hasHoursToUnlock() => $_has(1);
+  void clearHoursToUnlock() => clearField(2);
 }
 
 class FundStatusReply extends $pb.GeneratedMessage {
@@ -695,6 +683,7 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
     ..a<$core.int>(6, 'lockHeight', $pb.PbFieldType.OU3)
     ..aOS(7, 'errorMessage')
     ..aOS(8, 'lastRefundTxID')
+    ..e<SwapError>(9, 'swapError', $pb.PbFieldType.OE, SwapError.NO_ERROR, SwapError.valueOf, SwapError.values)
     ..hasRequiredFields = false
   ;
 
@@ -746,6 +735,11 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   set lastRefundTxID($core.String v) { $_setString(7, v); }
   $core.bool hasLastRefundTxID() => $_has(7);
   void clearLastRefundTxID() => clearField(8);
+
+  SwapError get swapError => $_getN(8);
+  set swapError(SwapError v) { setField(9, v); }
+  $core.bool hasSwapError() => $_has(8);
+  void clearSwapError() => clearField(9);
 }
 
 class SwapAddressList extends $pb.GeneratedMessage {

--- a/lib/services/breezlib/data/rpc.pbenum.dart
+++ b/lib/services/breezlib/data/rpc.pbenum.dart
@@ -8,6 +8,27 @@
 import 'dart:core' as $core show int, dynamic, String, List, Map;
 import 'package:protobuf/protobuf.dart' as $pb;
 
+class SwapError extends $pb.ProtobufEnum {
+  static const SwapError NO_ERROR = SwapError._(0, 'NO_ERROR');
+  static const SwapError FUNDS_EXCEED_LIMIT = SwapError._(1, 'FUNDS_EXCEED_LIMIT');
+  static const SwapError TX_TOO_SMALL = SwapError._(2, 'TX_TOO_SMALL');
+  static const SwapError INVOICE_AMOUNT_MISMATCH = SwapError._(3, 'INVOICE_AMOUNT_MISMATCH');
+  static const SwapError SWAP_EXPIRED = SwapError._(4, 'SWAP_EXPIRED');
+
+  static const $core.List<SwapError> values = <SwapError> [
+    NO_ERROR,
+    FUNDS_EXCEED_LIMIT,
+    TX_TOO_SMALL,
+    INVOICE_AMOUNT_MISMATCH,
+    SWAP_EXPIRED,
+  ];
+
+  static final $core.Map<$core.int, SwapError> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static SwapError valueOf($core.int value) => _byValue[value];
+
+  const SwapError._($core.int v, $core.String n) : super(v, n);
+}
+
 class Account_AccountStatus extends $pb.ProtobufEnum {
   static const Account_AccountStatus WAITING_DEPOSIT = Account_AccountStatus._(0, 'WAITING_DEPOSIT');
   static const Account_AccountStatus WAITING_DEPOSIT_CONFIRMATION = Account_AccountStatus._(1, 'WAITING_DEPOSIT_CONFIRMATION');

--- a/lib/services/breezlib/data/rpc.pbjson.dart
+++ b/lib/services/breezlib/data/rpc.pbjson.dart
@@ -4,6 +4,17 @@
 ///
 // ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 
+const SwapError$json = const {
+  '1': 'SwapError',
+  '2': const [
+    const {'1': 'NO_ERROR', '2': 0},
+    const {'1': 'FUNDS_EXCEED_LIMIT', '2': 1},
+    const {'1': 'TX_TOO_SMALL', '2': 2},
+    const {'1': 'INVOICE_AMOUNT_MISMATCH', '2': 3},
+    const {'1': 'SWAP_EXPIRED', '2': 4},
+  ],
+};
+
 const ChainStatus$json = const {
   '1': 'ChainStatus',
   '2': const [
@@ -181,10 +192,8 @@ const RefundRequest$json = const {
 const AddFundError$json = const {
   '1': 'AddFundError',
   '2': const [
-    const {'1': 'errorMessage', '3': 1, '4': 1, '5': 9, '10': 'errorMessage'},
-    const {'1': 'FundsExceededLimit', '3': 2, '4': 1, '5': 8, '10': 'FundsExceededLimit'},
-    const {'1': 'lockHeight', '3': 3, '4': 1, '5': 13, '10': 'lockHeight'},
-    const {'1': 'hoursToUnlock', '3': 4, '4': 1, '5': 2, '10': 'hoursToUnlock'},
+    const {'1': 'swapAddressInfo', '3': 1, '4': 1, '5': 11, '6': '.data.SwapAddressInfo', '10': 'swapAddressInfo'},
+    const {'1': 'hoursToUnlock', '3': 2, '4': 1, '5': 2, '10': 'hoursToUnlock'},
   ],
 };
 
@@ -234,6 +243,7 @@ const SwapAddressInfo$json = const {
     const {'1': 'lockHeight', '3': 6, '4': 1, '5': 13, '10': 'lockHeight'},
     const {'1': 'errorMessage', '3': 7, '4': 1, '5': 9, '10': 'errorMessage'},
     const {'1': 'lastRefundTxID', '3': 8, '4': 1, '5': 9, '10': 'lastRefundTxID'},
+    const {'1': 'swapError', '3': 9, '4': 1, '5': 14, '6': '.data.SwapError', '10': 'swapError'},
   ],
 };
 


### PR DESCRIPTION
This PR follows the PR in breez library (https://github.com/breez/breez/pull/74) and make the changes necessary to show proper statuses regarding the submarine swap process.
Specifically it shows warning icon on these cases:
1. Transaction amount is too small.
2. Transaction amount is over the limit.
3. Transaction amount and invoice provided contains different amount (probably when user executes another transaction to the address after the invoice was issued).
4. Transaction time lock has expired.
5. There is at least one transaction that won't be executed and the user can redeem his refund ( could be even due to unknown reason).

In addition when the funds are confirmed and the server side of the swap pays we show visual indication ( spinning progress ) on the top right corner.