### PR TITLE
NFC: remove foreground dispatch and methods for writing to Breez card

### DIFF
--- a/android/app/src/main/java/com/breez/client/MainActivity.java
+++ b/android/app/src/main/java/com/breez/client/MainActivity.java
@@ -49,13 +49,11 @@ public class MainActivity extends FlutterActivity {
     public void onPause() {
         super.onPause();
         BreezApplication.isBackground = true;
-        m_nfc.disableForegroundDispatch();
     }
 
     public void onResume() {
         super.onResume();
         BreezApplication.isBackground = false;
-        m_nfc.enableForegroundDispatch();
     }
 
     @Override


### PR DESCRIPTION
Foreground dispatch was blocking the client from paying the POS while the app is in the foreground. We only ever used it for writing to the Breez card, methods for which have also been removed.