### PR TITLE
Connect to pay fixes.

### DIFF
--- a/lib/bloc/account/account_model.dart
+++ b/lib/bloc/account/account_model.dart
@@ -225,6 +225,7 @@ class AccountModel {
   Int64 get maxPaymentAmount => _accountResponse.maxPaymentAmount;
   Int64 get routingNodeFee => _accountResponse.routingNodeFee;
   bool get enabled => _accountResponse.enabled;
+  bool get synced => syncProgress == 1.0;
 
   String get statusMessage {
 

--- a/lib/routes/user/connect_to_pay/payee_session_widget.dart
+++ b/lib/routes/user/connect_to_pay/payee_session_widget.dart
@@ -50,8 +50,10 @@ class PayeeSessionWidget extends StatelessWidget {
   }
 
   _getActions(PaymentSessionState sessionState){
-    if (sessionState.payerData.amount != null && sessionState.payeeData.paymentRequest == null) {
-      return ["Reject", "Approve"];
+    if (_account.synced) {
+      if (sessionState.payerData.amount != null && sessionState.payeeData.paymentRequest == null) {
+        return ["Reject", "Approve"];
+      }
     }
     return null;
   }
@@ -72,11 +74,13 @@ class _PayeeInstructions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    String message = "";
+    String message = "";    
     if (_sessionState.paymentFulfilled) {
             message = "You've successfully got " + _account.currency.format(Int64(_sessionState.settledAmount));
     } else if (_sessionState.payerData.amount == null) {
       return LoadingAnimatedText('Waiting for ${_sessionState.payerData.userName ?? "payer"} to enter an amount', textStyle: theme.sessionNotificationStyle);
+    } else if (!_account.synced) {
+      return LoadingAnimatedText('Please wait while Breez is synchronizing');
     }
     else if (_sessionState.payerData.amount != null && _sessionState.payeeData.paymentRequest == null) {
       message = '${_sessionState.payerData.userName} wants to pay you ${_account.currency.format(Int64(_sessionState.payerData.amount))}';

--- a/lib/routes/user/sync_ui_handler.dart
+++ b/lib/routes/user/sync_ui_handler.dart
@@ -26,11 +26,11 @@ class SyncUIHandler {
       }
     } else {            
       if (_syncUIRoute != null) {
-        // If we are no top of the stack let's pop to get the animation
+        // If we are not on top of the stack let's pop to get the animation
         if (_syncUIRoute.isCurrent) {
           Navigator.of(this._context).pop();
         } else {
-          // If we are hidden just remote the route;
+          // If we are hidden, just remove the route.
           Navigator.of(this._context).removeRoute(_syncUIRoute);
         }
         _syncUIRoute = null;

--- a/lib/routes/user/sync_ui_handler.dart
+++ b/lib/routes/user/sync_ui_handler.dart
@@ -24,9 +24,15 @@ class SyncUIHandler {
         _syncUIRoute = _createSyncRoute(_accountBloc);
         Navigator.of(_context).push(_syncUIRoute);
       }
-    } else {
-      if (_syncUIRoute != null) {        
-        Navigator.of(this._context).pop();
+    } else {            
+      if (_syncUIRoute != null) {
+        // If we are no top of the stack let's pop to get the animation
+        if (_syncUIRoute.isCurrent) {
+          Navigator.of(this._context).pop();
+        } else {
+          // If we are hidden just remote the route;
+          Navigator.of(this._context).removeRoute(_syncUIRoute);
+        }
         _syncUIRoute = null;
       }
     }


### PR DESCRIPTION
This PR improves the connect to pay experience by fixing several issues:
1. Showing "Please wait while breez is synchronizng..." for payee when breez is still synchronizing before allowing him accept/reject payments.
2. Enforcing only one payment for payer session and only one payment request is generated for payee session. This is to prevent edge cases for accidentally paying more than once in one session. 
3. Fix syncUI auto removal to take into consideration cases where it is not on top of the stack.