### PR TITLE
Allow back from pin only when back menu is shown.

### DIFF
--- a/lib/routes/shared/security_pin/change_pin_code.dart
+++ b/lib/routes/shared/security_pin/change_pin_code.dart
@@ -6,14 +6,13 @@ import 'package:flutter/material.dart';
 const PIN_CODE_LENGTH = 6;
 
 class ChangePinCode extends StatefulWidget {
-
   ChangePinCode({Key key}) : super(key: key);
 
   @override
   _ChangePinCodeState createState() => new _ChangePinCodeState();
 }
 
-class _ChangePinCodeState extends State<ChangePinCode> {  
+class _ChangePinCodeState extends State<ChangePinCode> {
   String _label = "Enter your new PIN";
 
   String _enteredPinCode = "";
@@ -22,9 +21,7 @@ class _ChangePinCodeState extends State<ChangePinCode> {
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () => Future.value(false),
-      child: Scaffold(
+    return Scaffold(
         appBar: new AppBar(
           iconTheme: theme.appBarIconTheme,
           textTheme: theme.appBarTextTheme,
@@ -43,9 +40,7 @@ class _ChangePinCodeState extends State<ChangePinCode> {
           _errorMessage,
           (numberText) => _onNumButtonPressed(numberText),
           (enteredPinCode) => _setPinCodeInput(enteredPinCode),
-        ),
-      ),
-    );
+        ));
   }
 
   _onNumButtonPressed(String numberText) {
@@ -59,16 +54,16 @@ class _ChangePinCodeState extends State<ChangePinCode> {
           _tmpPinCode = _enteredPinCode;
           _label = "Re-enter your new PIN";
           _enteredPinCode = "";
-        });        
+        });
       } else {
         if (_enteredPinCode == _tmpPinCode) {
           Navigator.pop(context, _enteredPinCode);
         } else {
           setState(() {
-            _tmpPinCode = "";            
+            _tmpPinCode = "";
             _enteredPinCode = "";
             _errorMessage = "PIN does not match";
-          });          
+          });
         }
       }
     }

--- a/lib/routes/shared/security_pin/lock_screen.dart
+++ b/lib/routes/shared/security_pin/lock_screen.dart
@@ -29,7 +29,7 @@ class _AppLockScreenState extends State<AppLockScreen> {
   Widget build(BuildContext context) {
     return WillPopScope(
       onWillPop: () { 
-        return Future.value(false);
+        return Future.value(widget.canCancel);
       },      
       child: Scaffold(
         appBar: widget.canCancel == true

--- a/lib/routes/shared/security_pin/security_pin_page.dart
+++ b/lib/routes/shared/security_pin/security_pin_page.dart
@@ -162,8 +162,9 @@ class SecurityPageState extends State<SecurityPage> {
         widget.backupBloc.backupStateStream.firstWhere((s) => s.inProgress).then((s){
           if (mounted) {
             showDialog(
-            context: context,
-            builder: (ctx) => buildBackupInProgressDialog(ctx, widget.backupBloc.backupStateStream));
+              barrierDismissible: false,
+              context: context,
+              builder: (ctx) => buildBackupInProgressDialog(ctx, widget.backupBloc.backupStateStream));
           }
         });
       }


### PR DESCRIPTION
As we have several variations of rendering the pin widget.
The variation that is rendered as AppLockScreen doesn't include a back menu item as user shouldn't be able to bypass that screen, so we ensure to disable the android back button as well at this case.