### PR TITLE
Pay Invoice flow when camera has not been unauthorized

### DIFF
--- a/lib/routes/user/home/home_page.dart
+++ b/lib/routes/user/home/home_page.dart
@@ -46,8 +46,9 @@ class Home extends StatefulWidget {
         Map<PermissionGroup, PermissionStatus> permissions = await PermissionHandler().requestPermissions([PermissionGroup.camera]);
         if (permissions[PermissionGroup.camera] == PermissionStatus.granted ||
             permissions[PermissionGroup.camera] == PermissionStatus.unknown) {
-          String decodedQr = await BarcodeScanner.scan();
-          invoiceBloc.decodeInvoiceSink.add(decodedQr);
+          BarcodeScanner.scan().then((decodedQr) {
+            invoiceBloc.decodeInvoiceSink.add(decodedQr);
+          }).catchError((_) => navigatorKey.currentState.push(FadeInRoute(builder: (_) => BarcodeScannerPlaceholder(invoiceBloc))));
         } else {
           navigatorKey.currentState.push(FadeInRoute(builder: (_) => BarcodeScannerPlaceholder(invoiceBloc)));
         }

--- a/lib/routes/user/home/home_page.dart
+++ b/lib/routes/user/home/home_page.dart
@@ -38,25 +38,8 @@ class Home extends StatefulWidget {
   final UserProfileBloc userProfileBloc;
   final ConnectPayBloc ctpBloc;
   final BackupBloc backupBloc;
-  final GlobalKey<NavigatorState> navigatorKey;
 
-  Home(this.accountBloc, this.invoiceBloc, this.userProfileBloc, this.ctpBloc, this.backupBloc, this.navigatorKey) {
-    _minorActionsInvoice = new List<DrawerItemConfig>.unmodifiable([
-      new DrawerItemConfig("/pay_invoice", "Pay Invoice", "src/icon/qr_scan.png", onItemSelected: (String name) async {
-        Map<PermissionGroup, PermissionStatus> permissions = await PermissionHandler().requestPermissions([PermissionGroup.camera]);
-        if (permissions[PermissionGroup.camera] == PermissionStatus.granted ||
-            permissions[PermissionGroup.camera] == PermissionStatus.unknown) {
-          BarcodeScanner.scan().then((decodedQr) {
-            invoiceBloc.decodeInvoiceSink.add(decodedQr);
-          }).catchError((_) => navigatorKey.currentState.push(FadeInRoute(builder: (_) => BarcodeScannerPlaceholder(invoiceBloc))));
-        } else {
-          navigatorKey.currentState.push(FadeInRoute(builder: (_) => BarcodeScannerPlaceholder(invoiceBloc)));
-        }
-      }),
-      new DrawerItemConfig(
-          "/create_invoice", "Create Invoice", "src/icon/paste.png"),
-    ]);
-  }
+  Home(this.accountBloc, this.invoiceBloc, this.userProfileBloc, this.ctpBloc, this.backupBloc);
 
   final List<DrawerItemConfig> _screens =
       new List<DrawerItemConfig>.unmodifiable(
@@ -86,8 +69,6 @@ class Home extends StatefulWidget {
     new DrawerItemConfig(
         "/lost_card", "Lost or Stolen", "src/icon/lost_card.png"),
   ]);
-
-  List<DrawerItemConfig> _minorActionsInvoice;
 
   final List<DrawerItemConfig> _minorActionsAdvanced =
       new List<DrawerItemConfig>.unmodifiable([
@@ -184,7 +165,7 @@ class HomeState extends State<Home> {
                 [
                   DrawerItemConfigGroup(_filterItems(widget._majorActionsFunds)),
                   DrawerItemConfigGroup(_filterItems(widget._majorActionsPay)),
-                  DrawerItemConfigGroup(_filterItems(widget._minorActionsInvoice)),
+                  _buildMinorActionsInvoice(context),
                   DrawerItemConfigGroup(_filterItems(widget._minorActionsCard), groupTitle: "Card", groupAssetImage: "src/icon/card.png"),
                   DrawerItemConfigGroup(_filterItems(widget._minorActionsAdvanced), groupTitle: "Advanced", groupAssetImage: "src/icon/advanced.png"),
                 ],
@@ -192,6 +173,24 @@ class HomeState extends State<Home> {
             body: widget._screenBuilders[_activeScreen]),
       ),
     );
+  }
+
+  DrawerItemConfigGroup _buildMinorActionsInvoice(BuildContext context) {
+    List<DrawerItemConfig> minorActionsInvoice = new List<DrawerItemConfig>.unmodifiable([
+      new DrawerItemConfig("/pay_invoice", "Pay Invoice", "src/icon/qr_scan.png", onItemSelected: (String name) async {
+        Map<PermissionGroup, PermissionStatus> permissions = await PermissionHandler().requestPermissions([PermissionGroup.camera]);
+        if (permissions[PermissionGroup.camera] == PermissionStatus.granted ||
+            permissions[PermissionGroup.camera] == PermissionStatus.unknown) {
+          BarcodeScanner.scan().then((decodedQr) {
+            widget.invoiceBloc.decodeInvoiceSink.add(decodedQr);
+          }).catchError((_) => Navigator.of(context).push(FadeInRoute(builder: (_) => BarcodeScannerPlaceholder(widget.invoiceBloc))));
+        } else {
+          Navigator.of(context).push(FadeInRoute(builder: (_) => BarcodeScannerPlaceholder(widget.invoiceBloc)));
+        }
+      }),
+      new DrawerItemConfig("/create_invoice", "Create Invoice", "src/icon/paste.png"),
+    ]);
+    return DrawerItemConfigGroup(_filterItems(minorActionsInvoice));
   }
 
   _onNavigationItemSelected(String itemName) {

--- a/lib/routes/user/home/home_page.dart
+++ b/lib/routes/user/home/home_page.dart
@@ -1,29 +1,32 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:barcode_scan/barcode_scan.dart';
+import 'package:breez/bloc/account/account_bloc.dart';
+import 'package:breez/bloc/backup/backup_bloc.dart';
 import 'package:breez/bloc/connect_pay/connect_pay_bloc.dart';
+import 'package:breez/bloc/invoice/invoice_bloc.dart';
+import 'package:breez/bloc/user_profile/user_profile_bloc.dart';
+import 'package:breez/routes/shared/account_required_actions.dart';
+import 'package:breez/routes/shared/no_connection_dialog.dart';
 import 'package:breez/routes/user/connect_to_pay/connect_to_pay_page.dart';
 import 'package:breez/routes/user/ctp_join_session_handler.dart';
-import 'package:breez/routes/shared/account_required_actions.dart';
+import 'package:breez/routes/user/received_invoice_notification.dart';
 import 'package:breez/routes/user/showPinHandler.dart';
+import 'package:breez/theme_data.dart' as theme;
+import 'package:breez/widgets/barcode_scanner_placeholder.dart';
 import 'package:breez/widgets/error_dialog.dart';
 import 'package:breez/widgets/fade_in_widget.dart';
-import 'package:breez/widgets/route.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:breez/widgets/flushbar.dart';
+import 'package:breez/widgets/lost_card_dialog.dart' as lostCard;
 import 'package:breez/widgets/navigation_drawer.dart';
+import 'package:breez/widgets/route.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
+
 import '../sync_ui_handler.dart';
 import 'account_page.dart';
-import 'package:breez/routes/user/received_invoice_notification.dart';
-import 'package:breez/widgets/lost_card_dialog.dart' as lostCard;
-import 'package:breez/widgets/flushbar.dart';
-import 'package:breez/theme_data.dart' as theme;
-import 'package:breez/bloc/account/account_bloc.dart';
-import 'package:breez/bloc/invoice/invoice_bloc.dart';
-import 'package:breez/routes/shared/no_connection_dialog.dart';
-import 'package:barcode_scan/barcode_scan.dart';
-import 'package:breez/bloc/backup/backup_bloc.dart';
-import 'package:breez/bloc/user_profile/user_profile_bloc.dart';
 
 final GlobalKey firstPaymentItemKey = new GlobalKey();
 final ScrollController scrollController = new ScrollController();
@@ -35,14 +38,19 @@ class Home extends StatefulWidget {
   final UserProfileBloc userProfileBloc;
   final ConnectPayBloc ctpBloc;
   final BackupBloc backupBloc;
+  final GlobalKey<NavigatorState> navigatorKey;
 
-  Home(this.accountBloc, this.invoiceBloc, this.userProfileBloc, this.ctpBloc, this.backupBloc) {
-    _minorActionsInvoice =
-    new List<DrawerItemConfig>.unmodifiable([
-      new DrawerItemConfig(
-          "/pay_invoice", "Pay Invoice", "src/icon/qr_scan.png", onItemSelected: (String name) async {
+  Home(this.accountBloc, this.invoiceBloc, this.userProfileBloc, this.ctpBloc, this.backupBloc, this.navigatorKey) {
+    _minorActionsInvoice = new List<DrawerItemConfig>.unmodifiable([
+      new DrawerItemConfig("/pay_invoice", "Pay Invoice", "src/icon/qr_scan.png", onItemSelected: (String name) async {
+        Map<PermissionGroup, PermissionStatus> permissions = await PermissionHandler().requestPermissions([PermissionGroup.camera]);
+        if (permissions[PermissionGroup.camera] == PermissionStatus.granted ||
+            permissions[PermissionGroup.camera] == PermissionStatus.unknown) {
           String decodedQr = await BarcodeScanner.scan();
           invoiceBloc.decodeInvoiceSink.add(decodedQr);
+        } else {
+          navigatorKey.currentState.push(FadeInRoute(builder: (_) => BarcodeScannerPlaceholder(invoiceBloc)));
+        }
       }),
       new DrawerItemConfig(
           "/create_invoice", "Create Invoice", "src/icon/paste.png"),

--- a/lib/user_app.dart
+++ b/lib/user_app.dart
@@ -70,7 +70,7 @@ class UserApp extends StatelessWidget {
               cardColor: theme.BreezColors.blue[500],
             ),
             initialRoute: user.registered ? (user.locked ? '/lockscreen' : null) : '/splash',
-            home: new Home(accountBloc, invoiceBloc, userProfileBloc, connectPayBloc, backupBloc),
+            home: new Home(accountBloc, invoiceBloc, userProfileBloc, connectPayBloc, backupBloc, _navigatorKey),
             onGenerateRoute: (RouteSettings settings) {
               switch (settings.name) {
                 case '/lockscreen':
@@ -83,7 +83,7 @@ class UserApp extends StatelessWidget {
                   );
                 case '/home':
                   return new FadeInRoute(
-                    builder: (_) => new Home(accountBloc,invoiceBloc,userProfileBloc,connectPayBloc,backupBloc),
+                    builder: (_) => new Home(accountBloc,invoiceBloc,userProfileBloc,connectPayBloc,backupBloc, _navigatorKey),
                     settings: settings,
                   );
                 case '/intro':

--- a/lib/user_app.dart
+++ b/lib/user_app.dart
@@ -70,7 +70,7 @@ class UserApp extends StatelessWidget {
               cardColor: theme.BreezColors.blue[500],
             ),
             initialRoute: user.registered ? (user.locked ? '/lockscreen' : null) : '/splash',
-            home: new Home(accountBloc, invoiceBloc, userProfileBloc, connectPayBloc, backupBloc, _navigatorKey),
+            home: new Home(accountBloc, invoiceBloc, userProfileBloc, connectPayBloc, backupBloc),
             onGenerateRoute: (RouteSettings settings) {
               switch (settings.name) {
                 case '/lockscreen':
@@ -83,7 +83,7 @@ class UserApp extends StatelessWidget {
                   );
                 case '/home':
                   return new FadeInRoute(
-                    builder: (_) => new Home(accountBloc,invoiceBloc,userProfileBloc,connectPayBloc,backupBloc, _navigatorKey),
+                    builder: (_) => new Home(accountBloc,invoiceBloc,userProfileBloc,connectPayBloc,backupBloc),
                     settings: settings,
                   );
                 case '/intro':

--- a/lib/widgets/barcode_scanner_placeholder.dart
+++ b/lib/widgets/barcode_scanner_placeholder.dart
@@ -1,0 +1,72 @@
+import 'package:breez/bloc/invoice/invoice_bloc.dart';
+import 'package:breez/theme_data.dart' as theme;
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+class BarcodeScannerPlaceholder extends StatefulWidget {
+  final InvoiceBloc invoiceBloc;
+
+  BarcodeScannerPlaceholder(this.invoiceBloc);
+
+  @override
+  State<StatefulWidget> createState() {
+    return BarcodeScannerPlaceholderState();
+  }
+}
+
+class BarcodeScannerPlaceholderState extends State<BarcodeScannerPlaceholder> {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: Theme.of(context).copyWith(backgroundColor: Colors.red, primaryColor: Colors.yellow, canvasColor: Colors.grey),
+      home: Scaffold(
+        appBar: new AppBar(
+          iconTheme: theme.appBarIconTheme,
+          textTheme: theme.appBarTextTheme,
+          backgroundColor: theme.BreezColors.blue[500],
+          title: GestureDetector(
+            onTap: () {
+              Clipboard.getData("text/plain").then((clipboardData) {
+                if (clipboardData != null) {
+                  widget.invoiceBloc.decodeInvoiceSink.add(clipboardData.text);
+                  Navigator.pop(context);
+                }
+              });
+            },
+            child: Row(children: <Widget>[
+              Icon(Icons.content_paste),
+              Padding(padding: EdgeInsets.only(left: 8.0)),
+              Text(
+                "PASTE INVOICE",
+                style: TextStyle(fontSize: 14.0, letterSpacing: 0.15, fontWeight: FontWeight.w500),
+              )
+            ]),
+          ),
+          elevation: 0.0,
+        ),
+        backgroundColor: Colors.black,
+        body: Padding(
+          padding: EdgeInsets.only(left: 24.0, right: 24.0),
+          child: Center(
+            child: RichText(
+              textAlign: TextAlign.center,
+              text: TextSpan(style: theme.alertStyle.copyWith(color: Colors.white), text: "Please grant Breez ", children: <TextSpan>[
+                TextSpan(
+                  text: "access to your camera",
+                  style: TextStyle(color: Colors.blue),
+                  recognizer: new TapGestureRecognizer()
+                    ..onTap = () async {
+                      bool isOpened = await PermissionHandler().openAppSettings();
+                      if (isOpened) Navigator.pop(context);
+                    },
+                ),
+              ]),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/barcode_scanner_placeholder.dart
+++ b/lib/widgets/barcode_scanner_placeholder.dart
@@ -1,6 +1,5 @@
 import 'package:breez/bloc/invoice/invoice_bloc.dart';
 import 'package:breez/theme_data.dart' as theme;
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -48,22 +47,49 @@ class BarcodeScannerPlaceholderState extends State<BarcodeScannerPlaceholder> {
         ),
         backgroundColor: Colors.black,
         body: Padding(
-          padding: EdgeInsets.only(left: 24.0, right: 24.0),
-          child: Center(
-            child: RichText(
-              textAlign: TextAlign.center,
-              text: TextSpan(style: theme.alertStyle.copyWith(color: Colors.white), text: "Please grant Breez ", children: <TextSpan>[
-                TextSpan(
-                  text: "access to your camera",
-                  style: TextStyle(color: Colors.blue),
-                  recognizer: new TapGestureRecognizer()
-                    ..onTap = () async {
-                      bool isOpened = await PermissionHandler().openAppSettings();
-                      if (isOpened) Navigator.pop(context);
-                    },
+          padding: EdgeInsets.only(left: 16.0, right: 16.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: <Widget>[
+              Text(
+                "For QR scan, please grant Breez access to your camera.",
+                style: theme.alertStyle.copyWith(
+                  color: Colors.white,
                 ),
-              ]),
-            ),
+                textAlign: TextAlign.center,
+              ),
+              Padding(
+                padding: EdgeInsets.only(top: 16.0),
+              ),
+              RaisedButton(
+                padding: EdgeInsets.only(top: 8.0, bottom: 8.0, right: 12.0, left: 12.0),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    Icon(
+                      Icons.settings,
+                      color: theme.buttonStyle.color,
+                    ),
+                    Padding(
+                      padding: EdgeInsets.only(left: 8.0),
+                    ),
+                    Text(
+                      "App Settings",
+                      style: theme.buttonStyle,
+                    )
+                  ],
+                ),
+                color: theme.BreezColors.white[500],
+                elevation: 0.0,
+                shape: const StadiumBorder(),
+                onPressed: () async {
+                  PermissionHandler().openAppSettings().then((isOpened) {
+                    if (isOpened) Navigator.pop(context);
+                  });
+                },
+              ),
+            ],
           ),
         ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
       url: https://github.com/breez/flutter_webview_plugin.git
   keyboard_actions: ^2.1.1
   flutter_secure_storage: ^3.2.1+1
+  permission_handler: ^3.2.2
 
 dev_dependencies:
   mockito: "^3.0.0"


### PR DESCRIPTION
This PR addresses issue [#143](https://github.com/breez/breezmobile/issues/143).

If camera is not authorized* we route to BarcodeScannerPlaceholder page, which is similar in design to BarcodeScanner plugin. Users can use Paste Invoice feature and go to app settings to enable camera if they desire by clicking the information text.

*: Takes into consideration of the initial state where camera authorization hasn't been prompted yet.
  
  
Packages introduced:
- [permission_handler](https://pub.dev/packages/permission_handler)