### PR TITLE
Temporary force number formatting in US locale only

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
 		3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6F068F372301566B009A1818 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F068F362301566B009A1818 /* main.swift */; };
 		6F09D3B2225DEDEC00867443 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F09D3B1225DEDEC00867443 /* AppDelegate.swift */; };
 		6F09D3D7225E232000867443 /* Breez.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F09D3D6225E232000867443 /* Breez.swift */; };
 		6F09D3DC225E7BBD00867443 /* bindings.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F09D3DB225E7BBC00867443 /* bindings.framework */; };
@@ -52,6 +53,7 @@
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3B80C3931E831B6300D905FE /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
 		570C200013480EFCF465946D /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		6F068F362301566B009A1818 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		6F09D3B0225DEDEC00867443 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		6F09D3B1225DEDEC00867443 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		6F09D3D6225E232000867443 /* Breez.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Breez.swift; sourceTree = "<group>"; };
@@ -167,6 +169,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				6F068F362301566B009A1818 /* main.swift */,
 				6F8177D92270997B00842148 /* Runner.entitlements */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
@@ -398,6 +401,7 @@
 				6FCA797622796CA6002E4572 /* ChainSync.swift in Sources */,
 				6F09D3E0225F45EB00867443 /* NativeMethods.swift in Sources */,
 				6F8177DB2270AEED00842148 /* GoogleAuthenticator.swift in Sources */,
+				6F068F372301566B009A1818 /* main.swift in Sources */,
 				6F09D3B2225DEDEC00867443 /* AppDelegate.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 				6F09D3E2225F584000867443 /* LifecycleEvents.swift in Sources */,
@@ -556,7 +560,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = technology.breez.client;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "DEV PROFILE";
+				PROVISIONING_PROFILE_SPECIFIER = DEV_PROFILE_R;
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -10,7 +10,6 @@ import UIKit
 import Flutter
 import Bindings
 
-@UIApplicationMain
 class AppDelegate : FlutterAppDelegate {        
     
     override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]?) -> Bool {

--- a/ios/Runner/main.swift
+++ b/ios/Runner/main.swift
@@ -1,8 +1,6 @@
 import UIKit
-import Flutter
+import CoreFoundation
 
-int main(int argc, char * argv[]) {
-  @autoreleasepool {
-    return UIApplicationMain(argc, argv, nil, NSStringFromClass(AppDelegate));
-  }
-}
+UserDefaults.standard.setValue("en_US", forKey: "AppleLocale");
+UIApplicationMain(CommandLine.argc, CommandLine.unsafeArgv,
+                  NSStringFromClass(UIApplication.self), NSStringFromClass(AppDelegate.self))

--- a/lib/widgets/amount_form_field.dart
+++ b/lib/widgets/amount_form_field.dart
@@ -54,17 +54,7 @@ class AmountFormField extends TextFormField {
             enabled: enabled,
             controller: controller,
             inputFormatters: accountModel.currency != Currency.SAT
-                ? [TextInputFormatter.withFunction( (TextEditingValue oldValue, TextEditingValue newValue){
-                  if (newValue.text.isEmpty) {
-                    return newValue;
-                  }
-                  try {
-                    accountModel.currency.parse(newValue.text);
-                    return newValue;
-                  } catch(e){
-                    return oldValue;
-                  }
-                })]
+                ? [WhitelistingTextInputFormatter(RegExp(r'\d+\.?\d*'))]
                 : [WhitelistingTextInputFormatter.digitsOnly],
             onFieldSubmitted: onFieldSubmitted,
             onSaved: onSaved);

--- a/lib/widgets/amount_form_field.dart
+++ b/lib/widgets/amount_form_field.dart
@@ -35,7 +35,7 @@ class AmountFormField extends TextFormField {
     bool enabled,
   }) : super(
             focusNode: focusNode,
-            keyboardType: TextInputType.numberWithOptions(decimal: true),
+            keyboardType: TextInputType.numberWithOptions(decimal: accountModel.currency != Currency.SAT),
             decoration: new InputDecoration(
               labelText: accountModel.currency.displayName + " Amount",
               suffixIcon: IconButton(
@@ -54,7 +54,17 @@ class AmountFormField extends TextFormField {
             enabled: enabled,
             controller: controller,
             inputFormatters: accountModel.currency != Currency.SAT
-                ? [WhitelistingTextInputFormatter(RegExp(r'\d+\.?\d*'))]
+                ? [TextInputFormatter.withFunction( (TextEditingValue oldValue, TextEditingValue newValue){
+                  if (newValue.text.isEmpty) {
+                    return newValue;
+                  }
+                  try {
+                    accountModel.currency.parse(newValue.text);
+                    return newValue;
+                  } catch(e){
+                    return oldValue;
+                  }
+                })]
                 : [WhitelistingTextInputFormatter.digitsOnly],
             onFieldSubmitted: onFieldSubmitted,
             onSaved: onSaved);


### PR DESCRIPTION
This PR sets the user locale to en_US in order to prevent iOS keyboard from showing locale specific decimal separator. 
The different decimal separator didn't pass the current code validator as described by this issue https://github.com/breez/breezmobile/issues/142.
As Flutter maintain its own Internalization mechanism (separated from the OS) and considering that iOS allows a wide range of locale customization, an attempt to solve the number formatting by taking into consideration different locales would be too risky and requires a big effort which is not the scope of this issue.
Closes #142  