### PR TITLE
Show error on invalid scan/clipboard items.

### DIFF
--- a/lib/bloc/invoice/invoice_bloc.dart
+++ b/lib/bloc/invoice/invoice_bloc.dart
@@ -144,7 +144,8 @@ class InvoiceBloc {
     .where((paymentRequest) => paymentRequest != null)    
     .asyncMap( (paymentRequest) {       
       return breezLib.decodePaymentRequest(paymentRequest)
-        .then( (invoice) => new PaymentRequestModel(invoice, paymentRequest));          
+        .then( (invoice) => new PaymentRequestModel(invoice, paymentRequest))
+        .catchError( (err) => throw Exception("Lightning Invoice wasn’t detected."));
     })    
     .listen(_receivedInvoicesController.add)
     .onError(_receivedInvoicesController.addError);

--- a/lib/routes/user/home/home_page.dart
+++ b/lib/routes/user/home/home_page.dart
@@ -180,9 +180,7 @@ class HomeState extends State<Home> {
       new DrawerItemConfig("/pay_invoice", "Pay Invoice", "src/icon/qr_scan.png", onItemSelected: (String name) async {
         try {
           String decodedQr = await BarcodeScanner.scan();
-          (decodedQr.toLowerCase().startsWith("ln") || decodedQr.toLowerCase().startsWith("lightning:"))
-              ? widget.invoiceBloc.decodeInvoiceSink.add(decodedQr)
-              : showFlushbar(context, message: "Lightning Invoice wasn’t detected.");
+          widget.invoiceBloc.decodeInvoiceSink.add(decodedQr);
         } on PlatformException catch (e) {
           if (e.code == BarcodeScanner.CameraAccessDenied) {
             Navigator.of(context).push(FadeInRoute(builder: (_) => BarcodeScannerPlaceholder(widget.invoiceBloc)));

--- a/lib/routes/user/home/home_page.dart
+++ b/lib/routes/user/home/home_page.dart
@@ -180,7 +180,9 @@ class HomeState extends State<Home> {
       new DrawerItemConfig("/pay_invoice", "Pay Invoice", "src/icon/qr_scan.png", onItemSelected: (String name) async {
         try {
           String decodedQr = await BarcodeScanner.scan();
-          widget.invoiceBloc.decodeInvoiceSink.add(decodedQr);
+          (decodedQr.toLowerCase().startsWith("ln") || decodedQr.toLowerCase().startsWith("lightning:"))
+              ? widget.invoiceBloc.decodeInvoiceSink.add(decodedQr)
+              : showFlushbar(context, message: "Lightning Invoice wasn’t detected.");
         } on PlatformException catch (e) {
           if (e.code == BarcodeScanner.CameraAccessDenied) {
             Navigator.of(context).push(FadeInRoute(builder: (_) => BarcodeScannerPlaceholder(widget.invoiceBloc)));

--- a/lib/routes/user/home/invoice_bottom_sheet.dart
+++ b/lib/routes/user/home/invoice_bottom_sheet.dart
@@ -44,9 +44,7 @@ class InvoiceBottomSheetState extends State<InvoiceBottomSheet> with TickerProvi
               _buildInvoiceMenuItem("PAY", "src/icon/qr_scan.png", () async {
                 try {
                   String decodedQr = await BarcodeScanner.scan();
-                  (decodedQr.toLowerCase().startsWith("ln") || decodedQr.toLowerCase().startsWith("lightning:"))
-                      ? widget.invoiceBloc.decodeInvoiceSink.add(decodedQr)
-                      : showFlushbar(context, message: "Lightning Invoice wasn’t detected.");
+                  widget.invoiceBloc.decodeInvoiceSink.add(decodedQr);
                 } on PlatformException catch (e) {
                   if (e.code == BarcodeScanner.CameraAccessDenied) {
                     Navigator.of(context).push(FadeInRoute(builder: (_) => BarcodeScannerPlaceholder(widget.invoiceBloc)));

--- a/lib/routes/user/received_invoice_notification.dart
+++ b/lib/routes/user/received_invoice_notification.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
-import 'package:breez/widgets/loader.dart';
-import 'package:flutter/material.dart';
+
 import 'package:breez/bloc/account/account_bloc.dart';
 import 'package:breez/bloc/invoice/invoice_model.dart';
+import 'package:breez/widgets/flushbar.dart';
+import 'package:breez/widgets/loader.dart';
 import 'package:breez/widgets/payment_request_dialog.dart' as paymentRequest;
+import 'package:flutter/material.dart';
 
 class InvoiceNotificationsHandler {
   final BuildContext _context;
@@ -55,6 +57,7 @@ class InvoiceNotificationsHandler {
       }).onError((error) {
         _setLoading(false);
         _handlingRequest = false;
+        showFlushbar(_context, message: error.toString().substring(10));
       });
     });
   }

--- a/lib/widgets/barcode_scanner_placeholder.dart
+++ b/lib/widgets/barcode_scanner_placeholder.dart
@@ -1,6 +1,7 @@
 import 'package:app_settings/app_settings.dart';
 import 'package:breez/bloc/invoice/invoice_bloc.dart';
 import 'package:breez/theme_data.dart' as theme;
+import 'package:breez/widgets/flushbar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -29,8 +30,12 @@ class BarcodeScannerPlaceholderState extends State<BarcodeScannerPlaceholder> {
             onTap: () {
               Clipboard.getData("text/plain").then((clipboardData) {
                 if (clipboardData != null) {
-                  widget.invoiceBloc.decodeInvoiceSink.add(clipboardData.text);
                   Navigator.pop(context);
+                  if (clipboardData.text.toLowerCase().startsWith("ln") || clipboardData.text.toLowerCase().startsWith("lightning:")) {
+                    widget.invoiceBloc.decodeInvoiceSink.add(clipboardData.text);
+                  } else {
+                    showFlushbar(context, message: "Lightning Invoice wasn’t detected.");
+                  }
                 }
               });
             },

--- a/lib/widgets/barcode_scanner_placeholder.dart
+++ b/lib/widgets/barcode_scanner_placeholder.dart
@@ -30,12 +30,8 @@ class BarcodeScannerPlaceholderState extends State<BarcodeScannerPlaceholder> {
             onTap: () {
               Clipboard.getData("text/plain").then((clipboardData) {
                 if (clipboardData != null) {
+                  widget.invoiceBloc.decodeInvoiceSink.add(clipboardData.text);
                   Navigator.pop(context);
-                  if (clipboardData.text.toLowerCase().startsWith("ln") || clipboardData.text.toLowerCase().startsWith("lightning:")) {
-                    widget.invoiceBloc.decodeInvoiceSink.add(clipboardData.text);
-                  } else {
-                    showFlushbar(context, message: "Lightning Invoice wasn’t detected.");
-                  }
                 }
               });
             },


### PR DESCRIPTION
This PR addresses [BU-181](https://breeztech.atlassian.net/browse/BU-181?utm_medium=referral-external&utm_source=jira-slack&utm_term=)

Flushbar with "Lightning Invoice wasn’t detected." is shown on invalid qr scans and clipboard items using BarcodeScanner plugin and it's placeholder.

This PR also adds error handling to Invoice Bottom Sheet's Pay button which got overlooked in #146 