### PR TITLE
Only show refund warning in case refund wasn't executed for a specific address

### DIFF
--- a/lib/routes/shared/account_required_actions.dart
+++ b/lib/routes/shared/account_required_actions.dart
@@ -130,7 +130,12 @@ class AccountRequiredActionsIndicatorState
                       }
 
                       var swapStatus = accountSnapshot?.data?.swapFundsStatus;
-                      if (swapStatus != null && swapStatus.refundableAddresses.length > 0) {  
+
+                      // only warn on refundable addresses that weren't refunded in the past.
+                      var shouldWarnRefund = swapStatus != null &&
+                        swapStatus.refundableAddresses.where((r) => r.lastRefundTxID.isEmpty).length > 0;
+
+                      if (shouldWarnRefund) {  
                         warnings.add(WarningAction(() => showDialog(
                             barrierDismissible: false,
                             context: context,


### PR DESCRIPTION
When a refund is executed on some set of UTXOs the transaction enters the mempool but the amount associated with the address is still positive and in status confirmed.
Until confirmation we treat the address as still refundable and show it on the refundable list.
Since we don't want the refund warning icon to stay visible at this case we filter those refundable addresses to only contain those that there were no refund transaction associated with them in the past.