### PR TITLE
Force rescan

### DIFF
--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -413,7 +413,15 @@ class AccountBloc {
              _accountController.add(_accountController.value.copyWith(syncUIState: SyncUIState.BLOCKING));
           }
       },
-      onProgress: (progress) => _accountController.add(_accountController.value.copyWith(syncProgress: progress)),
+      onProgress: (startPollTimestamp, progress) async {
+        if (
+            Duration(milliseconds: DateTime.now().millisecondsSinceEpoch - startPollTimestamp) > Duration(days: 1) &&
+            _accountController.value.syncUIState == SyncUIState.NONE) {
+              await userProfileStream.where((u) => u.locked == false).first;
+             _accountController.add(_accountController.value.copyWith(syncUIState: SyncUIState.BLOCKING));
+          }
+        _accountController.add(_accountController.value.copyWith(syncProgress: progress));
+      },
       onComplete: () => _accountController.add(_accountController.value.copyWith(syncUIState: SyncUIState.NONE, syncProgress: 1.0))
     );   
   }

--- a/lib/bloc/account/account_synchronizer.dart
+++ b/lib/bloc/account/account_synchronizer.dart
@@ -24,7 +24,7 @@ class AccountSynchronizer {
 
   final bool bootstraping;
   final Function(int startTimestamp, bool bootstraping) onStart;
-  final Function(double progress) onProgress;
+  final Function(int startTimestamp, double progress) onProgress;
   final Function onComplete;
 
   AccountSynchronizer(this._breezLib,
@@ -119,7 +119,7 @@ class AccountSynchronizer {
     if (_bootstrapProgress != null) {
       totalProgress = (_bootstrapProgress * BOOTSTRAP_FILES_FRACTION + totalProgress * (1- BOOTSTRAP_FILES_FRACTION));
     }
-    onProgress(totalProgress);
+    onProgress(_startPollTimestamp, totalProgress);
   }
 
   DateTime _lastChainCalcChangeTime;

--- a/lib/services/breezlib/breez_bridge.dart
+++ b/lib/services/breezlib/breez_bridge.dart
@@ -59,6 +59,10 @@ class BreezBridge {
       });
   }
 
+  Future<Directory> getWorkingDir(){
+    return getApplicationDocumentsDirectory();
+  }
+
   Future init(String appDir, String tmpDir) {    
     return _methodChannel.invokeMethod("init", {
       "workingDir": appDir,


### PR DESCRIPTION
This PR enables the user to force a rescan from the wallet's birthday.
It is useful as a recovery mechanism when the ongoing rescan missed one of the blocks relevant to the user's transactions.
Such case may happen due to a bug or unknown reason and In that case the balance associated with some addresses  (including submarine swap addresses) won't be correct. 
In order to recover from such cases, we added this UI option.
When the user chooses this option, he will be required to restart the app for this to take effect where on the next restart breez will synchronize from its birthday given the opportunity to go over the missing blocks.