### PR TITLE
Only fetch pin code on demand.

### DIFF
--- a/lib/bloc/user_profile/security_model.dart
+++ b/lib/bloc/user_profile/security_model.dart
@@ -3,22 +3,20 @@ class SecurityModel {
   static List<int> lockIntervals = List.unmodifiable([0, 30, 120, 300, 600, 1800, 3600]);
   static const int _defaultLockInterval = 120;
 
-  final bool requiresPin;
-  final String pinCode;
+  final bool requiresPin;  
   final bool secureBackupWithPin;
   final int automaticallyLockInterval;
 
-  SecurityModel({this.requiresPin, this.pinCode, this.secureBackupWithPin, this.automaticallyLockInterval});
+  SecurityModel({this.requiresPin, this.secureBackupWithPin, this.automaticallyLockInterval});
 
-  SecurityModel copyWith({bool requiresPin, String pinCode, bool secureBackupWithPin, int automaticallyLockInterval}) {
-    return new SecurityModel(requiresPin: requiresPin ?? this.requiresPin, pinCode: pinCode ?? this.pinCode, secureBackupWithPin: secureBackupWithPin ?? this.secureBackupWithPin, automaticallyLockInterval: automaticallyLockInterval ?? this.automaticallyLockInterval);
+  SecurityModel copyWith({bool requiresPin, bool secureBackupWithPin, int automaticallyLockInterval}) {
+    return new SecurityModel(requiresPin: requiresPin ?? this.requiresPin, secureBackupWithPin: secureBackupWithPin ?? this.secureBackupWithPin, automaticallyLockInterval: automaticallyLockInterval ?? this.automaticallyLockInterval);
   }
 
-  SecurityModel.initial() : this(requiresPin:false, pinCode: null, secureBackupWithPin: false, automaticallyLockInterval: _defaultLockInterval);
+  SecurityModel.initial() : this(requiresPin:false, secureBackupWithPin: false, automaticallyLockInterval: _defaultLockInterval);
 
   SecurityModel.fromJson(Map<String, dynamic> json)
-      : pinCode = null,
-        requiresPin = json['requiresPin'] ?? false,
+      : requiresPin = json['requiresPin'] ?? false,
         automaticallyLockInterval = json['automaticallyLockInterval'] ?? _defaultLockInterval,
         secureBackupWithPin = json['secureBackupWithPin'] ?? false;
 

--- a/lib/bloc/user_profile/user_actions.dart
+++ b/lib/bloc/user_profile/user_actions.dart
@@ -7,3 +7,15 @@ class UpdateSecurityModel extends AsyncAction {
 
   UpdateSecurityModel(this.newModel);
 }
+
+class UpdatePinCode extends AsyncAction {
+  final String newPin;
+
+  UpdatePinCode(this.newPin);
+}
+
+class ValidatePinCode extends AsyncAction {
+  final String enteredPin;
+
+  ValidatePinCode(this.enteredPin);
+}

--- a/lib/bloc/user_profile/user_profile_bloc.dart
+++ b/lib/bloc/user_profile/user_profile_bloc.dart
@@ -134,10 +134,11 @@ class UserProfileBloc {
 
       // Read the pin from the secure storage and initialize the breez user model appropriately
       String pinCode;
-      if (user.securityModel.requiresPin) {
+      if (user.securityModel.requiresPin) {        
         pinCode = await _secureStorage.read(key: 'pinCode');
       }      
       await _breezLib.setPinCode(user.securityModel.secureBackupWithPin ? pinCode : null);
+      user = user.copyWith(locked: user.securityModel.requiresPin);
 
       if (user.userID != null) {
         saveUser(injector, preferences, user).then(_publishUser);
@@ -172,9 +173,8 @@ class UserProfileBloc {
   }
 
   Future _updatePinCode(UpdatePinCode action) async {
-    await _secureStorage.write(key: 'pinCode', value: action.newPin);
-    var currentUser = _userController.value;
-    await _breezLib.setPinCode(currentUser.securityModel.secureBackupWithPin ? action.newPin : null);
+    await _secureStorage.write(key: 'pinCode', value: action.newPin);    
+    await _breezLib.setPinCode(_currentUser.securityModel.secureBackupWithPin ? action.newPin : null);
     action.resolve(null);
   }
 

--- a/lib/routes/shared/security_pin/change_pin_code.dart
+++ b/lib/routes/shared/security_pin/change_pin_code.dart
@@ -38,7 +38,7 @@ class _ChangePinCodeState extends State<ChangePinCode> {
         ));
   }
 
-  _onPinEntered(String enteredPinCode) {
+  _onPinEntered(String enteredPinCode) async {
     if (_tmpPinCode.isEmpty) {
       setState(() {
         _tmpPinCode = enteredPinCode;

--- a/lib/routes/shared/security_pin/lock_screen.dart
+++ b/lib/routes/shared/security_pin/lock_screen.dart
@@ -1,4 +1,3 @@
-import 'package:breez/bloc/user_profile/security_model.dart';
 import 'package:breez/theme_data.dart' as theme;
 import 'package:breez/widgets/back_button.dart' as backBtn;
 import 'package:breez/widgets/pin_code_widget.dart';
@@ -6,12 +5,11 @@ import 'package:flutter/material.dart';
 
 const PIN_CODE_LENGTH = 6;
 
-class AppLockScreen extends StatefulWidget {
-  final SecurityModel securityModel;
+class AppLockScreen extends StatefulWidget {  
   final bool canCancel;
-  final Function onUnlock;
+  final Future Function(String pinCode) onPinEntered;
 
-  AppLockScreen(this.securityModel, {Key key, this.canCancel = false, this.onUnlock}) : super(key: key);
+  AppLockScreen(this.onPinEntered, {Key key, this.canCancel = false}) : super(key: key);
 
   @override
   _AppLockScreenState createState() => new _AppLockScreenState();
@@ -43,21 +41,9 @@ class _AppLockScreenState extends State<AppLockScreen> {
         body: PinCodeWidget(
           _label,
           widget.canCancel,
-          (enteredPinCode) => _onPinEntered(enteredPinCode),
+          widget.onPinEntered,
         ),
       ),
     );
-  }
-
-  _onPinEntered(String enteredPinCode) {
-    if (enteredPinCode == widget.securityModel.pinCode) {
-      if (widget.onUnlock != null) {
-        widget.onUnlock();
-        return;
-      }
-      Navigator.pop(context, true);
-    } else {
-      throw Exception("Incorrect PIN");
-    }
   }
 }

--- a/lib/routes/shared/security_pin/restore_pin.dart
+++ b/lib/routes/shared/security_pin/restore_pin.dart
@@ -41,6 +41,6 @@ class _RestorePinCodeState extends State<RestorePinCode> {
   }
 
   _onPinEntered(String enteredPinCode) {
-    Navigator.pop(context, enteredPinCode);
+    return Navigator.pop(context, enteredPinCode);
   }
 }

--- a/lib/routes/shared/security_pin/restore_pin.dart
+++ b/lib/routes/shared/security_pin/restore_pin.dart
@@ -41,6 +41,7 @@ class _RestorePinCodeState extends State<RestorePinCode> {
   }
 
   _onPinEntered(String enteredPinCode) {
-    return Navigator.pop(context, enteredPinCode);
+    Navigator.pop(context, enteredPinCode);
+    return Future.value(null);
   }
 }

--- a/lib/user_app.dart
+++ b/lib/user_app.dart
@@ -75,9 +75,13 @@ class UserApp extends StatelessWidget {
               switch (settings.name) {
                 case '/lockscreen':
                   return new FadeInRoute(
-                      builder: (_) => new AppLockScreen(user.securityModel, onUnlock: (){
-                        _navigatorKey.currentState.pop();                        
-                        userProfileBloc.userSink.add(user.copyWith(locked: false));
+                      builder: (ctx) => new AppLockScreen((pinEntered) {
+                        var validateAction = ValidatePinCode(pinEntered);
+                        userProfileBloc.userActionsSink.add(validateAction);
+                        return validateAction.future.then((_){
+                          Navigator.pop(ctx);                          
+                          userProfileBloc.userSink.add(user.copyWith(locked: false));
+                        });                        
                       },),
                       settings: settings
                   );

--- a/lib/widgets/pin_code_widget.dart
+++ b/lib/widgets/pin_code_widget.dart
@@ -8,7 +8,7 @@ const PIN_CODE_LENGTH = 6;
 class PinCodeWidget extends StatefulWidget {
   final String label;
   final bool dismissible;
-  final Function(String pinEntered) onPinEntered;
+  final Future Function(String pinEntered) onPinEntered;
 
   PinCodeWidget(this.label, this.dismissible, this.onPinEntered);
 
@@ -170,12 +170,9 @@ class PinCodeWidgetState extends State<PinCodeWidget> {
     }
     if (_enteredPinCode.length == PIN_CODE_LENGTH) {
       Future.delayed(Duration(milliseconds: 200), () {
-        try {
-          widget.onPinEntered(_enteredPinCode);
-        } catch (error) {
-          _errorMessage = error.toString().substring(10);
-        }
-        _setPinCodeInput("");
+        widget.onPinEntered(_enteredPinCode)   
+          .catchError((err) => _errorMessage = err.toString().substring(10))
+          .whenComplete(() => _setPinCodeInput(""));        
       });
     }
   }


### PR DESCRIPTION
In this PR we change the way we validate and update the pin code saved in the keychain.
Previously, the pin code was loaded to memory, kept in the UserModel as part of the SecurityModel. When user entered his pin code we validated it by comparing the key in the model with the entered key.
This change removes this field from the SecurityModel and eliminate the need to keep the value in memory. Instead, the Validation/Update actions were created and called on demand.
This approach should be more secure and less vulnerable to unexpected bugs.