### PR TITLE
Reset chain info

### DIFF
--- a/android/app/src/main/java/com/breez/client/plugins/breez/breezlib/Breez.java
+++ b/android/app/src/main/java/com/breez/client/plugins/breez/breezlib/Breez.java
@@ -112,7 +112,7 @@ public class Breez implements MethodChannel.MethodCallHandler, StreamHandler, Ac
             _started = true;
             success(result,true);
         } catch (Exception e) {
-            fail(result, "ResultError", e.getMessage(), "Failed to Start breez library";
+            fail(result, "ResultError", e.getMessage(), "Failed to Start breez library");
         }
 
         ChainSync.schedule();

--- a/lib/bloc/account/account_actions.dart
+++ b/lib/bloc/account/account_actions.dart
@@ -10,6 +10,8 @@ class SendPaymentFailureReport extends AsyncAction {
 
 class ResetNetwork extends AsyncAction {}
 
+class ResetChainService extends AsyncAction {}
+
 class RestartDaemon extends AsyncAction {}
 
 class FetchSwapFundStatus extends AsyncAction{}

--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -538,7 +538,7 @@ class AccountBloc {
   void _listenAccountChanges() {
     StreamSubscription<NotificationEvent> eventSubscription;
     eventSubscription =
-        Observable(_breezLib.notificationStream).listen((event) {
+        Observable(_breezLib.notificationStream).listen((event) async {
       if (event.type ==
           NotificationEvent_NotificationType.LIGHTNING_SERVICE_DOWN) {
             _pollSyncStatus();
@@ -548,6 +548,7 @@ class AccountBloc {
               return;
             }
             _retryingLightningService = false;
+            await userProfileStream.where((u) => u.locked == false).first;
             _lightningDownController.add(true);         
       }
       if (event.type == NotificationEvent_NotificationType.ACCOUNT_CHANGED) {

--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'package:breez/bloc/async_action.dart';
 import 'package:breez/bloc/account/account_actions.dart';
 import 'package:breez/bloc/account/account_permissions_handler.dart';
@@ -25,6 +26,7 @@ import 'package:flutter/services.dart';
 import 'account_synchronizer.dart';
 
 class AccountBloc {
+  static const FORCE_BOOTSTRAP_FILE_NAME = "FORCE_BOOTSTRAP";
   static const String ACCOUNT_SETTINGS_PREFERENCES_KEY = "account_settings";
   static const String PERSISTENT_NODE_ID_PREFERENCES_KEY = "PERSISTENT_NODE_ID";
   static const String BOOTSTRAPING_PREFERENCES_KEY = "BOOTSTRAPING";
@@ -137,6 +139,7 @@ class AccountBloc {
       CancelPaymentRequest: _cancelPaymentRequest,
       ChangeSyncUIState: _collapseSyncUI,
       FetchRates: _fetchRates,
+      ResetChainService: _handleResetChainService,
     };
 
     _accountController.add(AccountModel.initial());
@@ -221,6 +224,12 @@ class AccountBloc {
 
   Future _handleResetNetwork(ResetNetwork action) async {
     action.resolve(await _breezLib.setPeers([]));    
+  }
+
+  Future _handleResetChainService(ResetChainService action) async {
+    var workingDir = await _breezLib.getWorkingDir();
+    var bootstrapFile = File(workingDir.path + "/$FORCE_BOOTSTRAP_FILE_NAME");    
+    action.resolve(await bootstrapFile.create(recursive: true));
   }
 
   Future _handleRestartDaemon(RestartDaemon action) async {

--- a/lib/routes/shared/no_connection_dialog.dart
+++ b/lib/routes/shared/no_connection_dialog.dart
@@ -24,13 +24,19 @@ void listenNoConnection(BuildContext context, AccountBloc accountBloc) {
           TextSpan(text: "• Checking the signal in your area\n", style: theme.dialogGrayStyle),
           TextSpan(text: "• ", style: theme.dialogGrayStyle),
           TextSpan(
-            text: "Reset ",
+            text: "Recover ",
             style: theme.blueLinkStyle,
-            recognizer: TapGestureRecognizer()..onTap = () async {              
-              ResetChainService resetAction = ResetChainService();
-              accountBloc.userActionsSink.add(resetAction);
-              await resetAction.future;
-              _promptForRestart(context);
+            recognizer: TapGestureRecognizer()..onTap = () async {                            
+              _promptForRestart(context).then(
+                (ok) async {
+                  if (ok) {
+                    ResetChainService resetAction = ResetChainService();
+                    accountBloc.userActionsSink.add(resetAction);
+                    await resetAction.future;
+                    exit(0);
+                  }
+                }
+              );
             }),
           TextSpan(text: "chain information\n", style: theme.dialogGrayStyle),
           TextSpan(text: "• ", style: theme.dialogGrayStyle),  
@@ -69,13 +75,7 @@ void listenNoConnection(BuildContext context, AccountBloc accountBloc) {
 }
 
 Future _promptForRestart(BuildContext context) {
-    return promptAreYouSure(context, null,
-            Text("Please restart to reset chain information.", style: theme.alertStyle),
-            cancelText: "Cancel", okText: "Exit Breez")
-        .then((shouldExit) {
-      if (shouldExit) {
-        exit(0);
-      }
-      return;
-    });
-  }
+  return promptAreYouSure(context, null,
+          Text("Restoring chain information might take several minutes.", style: theme.alertStyle),
+          cancelText: "Cancel", okText: "Exit Breez");    
+}

--- a/lib/routes/shared/no_connection_dialog.dart
+++ b/lib/routes/shared/no_connection_dialog.dart
@@ -21,7 +21,18 @@ void listenNoConnection(BuildContext context, AccountBloc accountBloc) {
         children:<TextSpan>[
           TextSpan(text: "• Turning off airplane mode\n", style: theme.dialogGrayStyle),
           TextSpan(text: "• Turning on mobile data or Wi-Fi\n", style: theme.dialogGrayStyle),
-          TextSpan(text: "• Checking the signal in your area\n", style: theme.dialogGrayStyle),        
+          TextSpan(text: "• Checking the signal in your area\n", style: theme.dialogGrayStyle),
+          TextSpan(text: "• ", style: theme.dialogGrayStyle),
+          TextSpan(
+            text: "Reset ",
+            style: theme.blueLinkStyle,
+            recognizer: TapGestureRecognizer()..onTap = () async {              
+              ResetChainService resetAction = ResetChainService();
+              accountBloc.userActionsSink.add(resetAction);
+              await resetAction.future;
+              _promptForRestart(context);
+            }),
+          TextSpan(text: "chain information\n", style: theme.dialogGrayStyle),
           TextSpan(text: "• ", style: theme.dialogGrayStyle),  
           TextSpan(
             text: "Reset ", 
@@ -56,3 +67,15 @@ void listenNoConnection(BuildContext context, AccountBloc accountBloc) {
     );
   });
 }
+
+Future _promptForRestart(BuildContext context) {
+    return promptAreYouSure(context, null,
+            Text("Please restart to reset chain information.", style: theme.alertStyle),
+            cancelText: "Cancel", okText: "Exit Breez")
+        .then((shouldExit) {
+      if (shouldExit) {
+        exit(0);
+      }
+      return;
+    });
+  }


### PR DESCRIPTION
This PR enables the user to restore the chain information and start the chain bootstrap process from the beginning.
It is introduced as a recovery mechanism when neutrino files are corrupted from some reason.
The impact of this action is a couple of minutes in a bootstrap process during the next restart.