### PR TITLE
Emit stream events when backup dialog visibility changes.

### DIFF
--- a/lib/bloc/backup/backup_bloc.dart
+++ b/lib/bloc/backup/backup_bloc.dart
@@ -17,6 +17,10 @@ class BackupBloc {
   final StreamController<void> _promptBackupController = new StreamController<void>.broadcast();
   Stream<void> get promptBackupStream => _promptBackupController.stream;
 
+  final StreamController<bool> _backupPromptVisibleController = new BehaviorSubject<bool>(seedValue: false);
+  Stream<bool> get backupPromptVisibleStream => _backupPromptVisibleController.stream;
+  Sink<bool> get backupPromptVisibleSink => _backupPromptVisibleController.sink;
+
   final BehaviorSubject<BackupSettings> _backupSettingsController =
       new BehaviorSubject<BackupSettings>(seedValue: BackupSettings.start());
   Stream<BackupSettings> get backupSettingsStream =>
@@ -193,6 +197,7 @@ class BackupBloc {
     _multipleRestoreController.close();
     _restoreFinishedController.close();    
     _backupSettingsController.close();
+    _backupPromptVisibleController.close();
   }
 }
 

--- a/lib/routes/shared/account_required_actions.dart
+++ b/lib/routes/shared/account_required_actions.dart
@@ -51,6 +51,7 @@ class AccountRequiredActionsIndicatorState
               .listen((_) {                
                 if (_currentSettings.promptOnError && !showingBackupDialog) {
                   showingBackupDialog = true;
+                  widget._backupBloc.backupPromptVisibleSink.add(true);
                   popFlushbars(context);                  
                   showDialog(
                       barrierDismissible: false,
@@ -58,6 +59,7 @@ class AccountRequiredActionsIndicatorState
                       builder: (_) =>
                           new EnableBackupDialog(context, widget._backupBloc)).then((_) {
                     showingBackupDialog = false;
+                    widget._backupBloc.backupPromptVisibleSink.add(false);
                   });
                 }
               });   


### PR DESCRIPTION
This PR add stream events to the backup bloc in case the backup dialog visibility changes.
Since this is a global dialog that is shown on top of the current context, it enables the current context be aware of it and take some necessary actions if needed. One example for such action is the webview that needs to change its own visibility.