### PR TITLE
Don't show backup dialog when pin is shown.

### DIFF
--- a/lib/pos_app.dart
+++ b/lib/pos_app.dart
@@ -37,13 +37,13 @@ class PosApp extends StatelessWidget {
           return MaterialApp(
             title: 'Breez POS',
             initialRoute: user.registered ? null : '/intro',
-            home: PosHome(accountBloc, backupBloc),
+            home: PosHome(accountBloc, backupBloc, userProfileBloc),
             onGenerateRoute: (RouteSettings settings) {
               switch (settings.name) {
                 case '/home':
                   return new FadeInRoute(
                     builder: (_) =>
-                        new PosHome(accountBloc, backupBloc),
+                        new PosHome(accountBloc, backupBloc, userProfileBloc),
                     settings: settings,
                   );
                 case '/intro':

--- a/lib/routes/pos/home/pos_home_page.dart
+++ b/lib/routes/pos/home/pos_home_page.dart
@@ -1,4 +1,5 @@
 import 'package:breez/bloc/backup/backup_bloc.dart';
+import 'package:breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:breez/routes/shared/account_required_actions.dart';
 import 'package:breez/routes/user/sync_ui_handler.dart';
 
@@ -12,8 +13,9 @@ import 'package:breez/bloc/account/account_bloc.dart';
 class PosHome extends StatefulWidget {
   final AccountBloc accountBloc;
   final BackupBloc backupBloc;
+  final UserProfileBloc userBlock;
 
-  PosHome(this.accountBloc, this.backupBloc);
+  PosHome(this.accountBloc, this.backupBloc, this.userBlock);
 
   final List<DrawerItemConfig> _screens =
       new List<DrawerItemConfig>.unmodifiable([]);
@@ -60,7 +62,7 @@ class PosHomeState extends State<PosHome> {
             Padding(
               padding: const EdgeInsets.all(14.0),
               child: AccountRequiredActionsIndicator(
-                  widget.backupBloc, widget.accountBloc),
+                  widget.backupBloc, widget.accountBloc, widget.userBlock),
             ),
           ],
           leading: new IconButton(

--- a/lib/routes/shared/account_required_actions.dart
+++ b/lib/routes/shared/account_required_actions.dart
@@ -2,6 +2,7 @@ import 'package:breez/bloc/account/account_actions.dart';
 import 'package:breez/bloc/account/account_bloc.dart';
 import 'package:breez/bloc/account/account_model.dart';
 import 'package:breez/bloc/backup/backup_model.dart';
+import 'package:breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:breez/routes/shared/funds_over_limit_dialog.dart';
 import 'package:breez/widgets/error_dialog.dart';
 import 'package:breez/widgets/flushbar.dart';
@@ -21,8 +22,9 @@ import 'transfer_funds_in_progress_dialog.dart';
 class AccountRequiredActionsIndicator extends StatefulWidget {
   final BackupBloc _backupBloc;
   final AccountBloc _accountBloc;
+  final UserProfileBloc _userProfileBloc;
 
-  AccountRequiredActionsIndicator(this._backupBloc, this._accountBloc);
+  AccountRequiredActionsIndicator(this._backupBloc, this._accountBloc, this._userProfileBloc);
 
   @override
   AccountRequiredActionsIndicatorState createState() {
@@ -48,11 +50,12 @@ class AccountRequiredActionsIndicatorState
       _promptEnableSubscription =
           Observable(widget._backupBloc.promptBackupStream)
               .delay(Duration(seconds: 4))
-              .listen((_) {                
+              .listen((_) async {                
                 if (_currentSettings.promptOnError && !showingBackupDialog) {
                   showingBackupDialog = true;
                   widget._backupBloc.backupPromptVisibleSink.add(true);
-                  popFlushbars(context);                  
+                  popFlushbars(context);
+                  await widget._userProfileBloc.userStream.where((u) => u.locked == false).first;
                   showDialog(
                       barrierDismissible: false,
                       context: context,

--- a/lib/routes/user/home/home_page.dart
+++ b/lib/routes/user/home/home_page.dart
@@ -142,7 +142,7 @@ class HomeState extends State<Home> {
               actions: <Widget>[
                 Padding(
                   padding: const EdgeInsets.all(14.0),
-                  child: AccountRequiredActionsIndicator(widget.backupBloc, widget.accountBloc),
+                  child: AccountRequiredActionsIndicator(widget.backupBloc, widget.accountBloc, widget.userProfileBloc),
                 ),],
               leading: new IconButton(
                   icon: ImageIcon(


### PR DESCRIPTION
This PR ensure the backup dialog won't show up on top of the pin code widget.