### PR TITLE
Change status bar icon and text color to white

### DIFF
--- a/lib/routes/user/home/home_page.dart
+++ b/lib/routes/user/home/home_page.dart
@@ -13,6 +13,7 @@ import 'package:breez/routes/user/connect_to_pay/connect_to_pay_page.dart';
 import 'package:breez/routes/user/ctp_join_session_handler.dart';
 import 'package:breez/routes/user/received_invoice_notification.dart';
 import 'package:breez/routes/user/showPinHandler.dart';
+import 'package:breez/theme_data.dart' as theme;
 import 'package:breez/widgets/barcode_scanner_placeholder.dart';
 import 'package:breez/widgets/error_dialog.dart';
 import 'package:breez/widgets/fade_in_widget.dart';
@@ -134,6 +135,7 @@ class HomeState extends State<Home> {
         child: new Scaffold(
             key: _scaffoldKey,
             appBar: new AppBar(
+              brightness: theme.themeId == "BLUE" ? Brightness.light : Theme.of(context).appBarTheme.brightness,
               centerTitle: false,
               actions: <Widget>[
                 Padding(

--- a/lib/theme_data.dart
+++ b/lib/theme_data.dart
@@ -33,7 +33,9 @@ final ThemeData blueTheme = ThemeData(
         color: Colors.white,
       ),
       color: Colors.transparent,
-      actionsIconTheme: IconThemeData(color: Color.fromRGBO(0, 120, 253, 1.0))),
+      actionsIconTheme: IconThemeData(color: Color.fromRGBO(0, 120, 253, 1.0)),
+      brightness: Brightness.dark,
+  ),
   dialogTheme: DialogTheme(
       titleTextStyle: TextStyle(color: BreezColors.grey[600], fontSize: 20.5, letterSpacing: 0.25),
       contentTextStyle: TextStyle(color: BreezColors.grey[500], fontSize: 16.0, height: 1.5),
@@ -84,7 +86,9 @@ final ThemeData darkTheme = ThemeData(
         color: Colors.white,
       ),
       color: Colors.white,
-      actionsIconTheme: IconThemeData(color: Colors.white)),
+      actionsIconTheme: IconThemeData(color: Colors.white),
+      brightness: Brightness.dark,
+  ),
   dialogTheme: DialogTheme(
       titleTextStyle: TextStyle(color: Colors.white, fontSize: 20.5, letterSpacing: 0.25),
       contentTextStyle: TextStyle(color: Colors.white70, fontSize: 16.0, height: 1.5),

--- a/lib/user_app.dart
+++ b/lib/user_app.dart
@@ -56,6 +56,7 @@ class UserApp extends StatelessWidget {
 
           BreezUserModel user = snapshot.data;
           theme.themeId = user.themeId;
+          SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(statusBarColor: Colors.transparent));
           return  BlocProvider(
             creator: () => new AddFundsBloc(userProfileBloc.userStream, accountBloc.accountStream),
             builder: (ctx) => MaterialApp(


### PR DESCRIPTION
This PR fixes status bar color issue described on https://github.com/breez/breezmobile/issues/194

Both themes use white colored status bar icon and text instead of the previous black value.