### PR TITLE
Do not reset enrolledBiometrics before proceeding to register

### DIFF
--- a/lib/bloc/user_profile/user_actions.dart
+++ b/lib/bloc/user_profile/user_actions.dart
@@ -8,6 +8,8 @@ class UpdateSecurityModel extends AsyncAction {
   UpdateSecurityModel(this.newModel);
 }
 
+class ResetSecurityModel extends AsyncAction {}
+
 class UpdatePinCode extends AsyncAction {
   final String newPin;
 

--- a/lib/bloc/user_profile/user_profile_bloc.dart
+++ b/lib/bloc/user_profile/user_profile_bloc.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:breez/bloc/async_action.dart';
 import 'package:breez/bloc/user_profile/breez_user_model.dart';
+import 'package:breez/bloc/user_profile/security_model.dart';
 import 'package:breez/bloc/user_profile/currency.dart';
 import 'package:breez/bloc/user_profile/default_profile_generator.dart';
 import 'package:breez/bloc/user_profile/user_actions.dart';
@@ -71,6 +72,7 @@ class UserProfileBloc {
     _notifications = injector.notifications;
     _actionHandlers = {
       UpdateSecurityModel: _updateSecurityModelAction,
+      ResetSecurityModel: _resetSecurityModelAction,
       UpdatePinCode: _updatePinCode,
       ValidatePinCode: _validatePinCode,
       ChangeTheme: _changeThemeAction,
@@ -212,6 +214,11 @@ class UserProfileBloc {
       UpdateSecurityModel updateSecurityModelAction) async {
     updateSecurityModelAction
         .resolve(await _updateSecurityModel(updateSecurityModelAction));
+  }
+
+  Future _resetSecurityModelAction(ResetSecurityModel resetSecurityModelAction) async {
+    var updateSecurityModelAction = UpdateSecurityModel(SecurityModel.initial().copyWith(enrolledBiometrics: _currentUser.securityModel.enrolledBiometrics));
+    resetSecurityModelAction.resolve(await _updateSecurityModel(updateSecurityModelAction));
   }
 
   Future _updateSecurityModel(

--- a/lib/bloc/user_profile/user_profile_bloc.dart
+++ b/lib/bloc/user_profile/user_profile_bloc.dart
@@ -216,9 +216,13 @@ class UserProfileBloc {
         .resolve(await _updateSecurityModel(updateSecurityModelAction));
   }
 
-  Future _resetSecurityModelAction(ResetSecurityModel resetSecurityModelAction) async {
-    var updateSecurityModelAction = UpdateSecurityModel(SecurityModel.initial().copyWith(enrolledBiometrics: _currentUser.securityModel.enrolledBiometrics));
-    resetSecurityModelAction.resolve(await _updateSecurityModel(updateSecurityModelAction));
+  Future _resetSecurityModelAction(
+      ResetSecurityModel resetSecurityModelAction) async {
+    var updateSecurityModelAction = UpdateSecurityModel(SecurityModel.initial()
+        .copyWith(
+            enrolledBiometrics: _currentUser.securityModel.enrolledBiometrics));
+    resetSecurityModelAction
+        .resolve(await _updateSecurityModel(updateSecurityModelAction));
   }
 
   Future _updateSecurityModel(

--- a/lib/routes/shared/initial_walkthrough.dart
+++ b/lib/routes/shared/initial_walkthrough.dart
@@ -291,11 +291,10 @@ class InitialWalkthroughPageState extends State<InitialWalkthroughPage>
                               return BetaWarningDialog();
                             }).then((approved) {
                           if (approved) {
-                            UpdateSecurityModel updateSecurityModelAction =
-                                UpdateSecurityModel(SecurityModel.initial());
+                            ResetSecurityModel resetSecurityModelAction = ResetSecurityModel();
                             widget._registrationBloc.userActionsSink
-                                .add(updateSecurityModelAction);
-                            updateSecurityModelAction.future.then((_) {
+                                .add(resetSecurityModelAction);
+                            resetSecurityModelAction.future.then((_) {
                               _proceedToRegister();
                             }).catchError((err) {
                               promptError(

--- a/lib/routes/shared/security_pin/security_pin_page.dart
+++ b/lib/routes/shared/security_pin/security_pin_page.dart
@@ -347,11 +347,7 @@ class SecurityPageState extends State<SecurityPage> {
               activeColor: Colors.white,
               onChanged: (bool value) {
                 if (this.mounted) {
-                  _updateSecurityModel(
-                      securityModel,
-                      SecurityModel.initial().copyWith(
-                          enrolledBiometrics: securityModel.enrolledBiometrics),
-                      backupSettings);
+                  _resetSecurityModel();
                 }
               },
             )
@@ -388,6 +384,20 @@ class SecurityPageState extends State<SecurityPage> {
               ));
         });
       }
+    });
+  }
+
+  Future _resetSecurityModel() async {
+    var action = ResetSecurityModel();
+    widget.userProfileBloc.userActionsSink.add(action);
+    action.future.catchError((err) {
+      promptError(
+          context,
+          "Internal Error",
+          Text(
+            err.toString(),
+            style: Theme.of(context).dialogTheme.contentTextStyle,
+          ));
     });
   }
 


### PR DESCRIPTION
This issue addresses [BU-208](https://breeztech.atlassian.net/browse/BU-208).

SecurityModel was being reverted to it's original state before proceeding to register, which caused  fingertip menu to not show up on fresh installs unless users restarted or resumed the app.

enrolledBiometrics is now updated before processing register requests.