### PR TITLE
Enable SEPA bank transfer payment method for MoonPay

### DIFF
--- a/lib/bloc/account/add_funds_bloc.dart
+++ b/lib/bloc/account/add_funds_bloc.dart
@@ -158,7 +158,7 @@ class AddFundsBloc extends Bloc {
     String currencyCode = config.get("MoonPay Parameters", 'currencyCode');
     String colorCode = config.get("MoonPay Parameters", 'colorCode');
     String redirectURL = config.get("MoonPay Parameters", 'redirectURL');
-    return "$baseUrl?apiKey=$apiKey&currencyCode=$currencyCode&colorCode=$colorCode&redirectURL=${Uri.encodeComponent(redirectURL)}";
+    return "$baseUrl?apiKey=$apiKey&currencyCode=$currencyCode&colorCode=$colorCode&redirectURL=${Uri.encodeComponent(redirectURL)}&enabledPaymentMethods=credit_debit_card,sepa_bank_transfer";
   }
 
   Future<Config> _readConfig() async {


### PR DESCRIPTION
This PR addresses [BU-214](https://breeztech.atlassian.net/browse/BU-214).

Users can now add any of their bank accounts that can make SEPA payments as a payment method using MoonPay. 