### PR TITLE
Change shape of numpad buttons

### DIFF
--- a/lib/routes/shared/security_pin/change_pin_code.dart
+++ b/lib/routes/shared/security_pin/change_pin_code.dart
@@ -32,7 +32,6 @@ class _ChangePinCodeState extends State<ChangePinCode> {
         ),
         body: PinCodeWidget(
           _label,
-          true,
           (enteredPinCode) => _onPinEntered(enteredPinCode),
         ));
   }

--- a/lib/routes/shared/security_pin/lock_screen.dart
+++ b/lib/routes/shared/security_pin/lock_screen.dart
@@ -49,7 +49,6 @@ class _AppLockScreenState extends State<AppLockScreen> {
             : null,
         body: PinCodeWidget(
           _label,
-          widget.canCancel,
           widget.onPinEntered,
           onFingerprintEntered: widget.onFingerprintEntered,
           userProfileBloc: widget.userProfileBloc,

--- a/lib/routes/shared/security_pin/restore_pin.dart
+++ b/lib/routes/shared/security_pin/restore_pin.dart
@@ -35,7 +35,6 @@ class _RestorePinCodeState extends State<RestorePinCode> {
         ),
         body: PinCodeWidget(
           _label,
-          true,
           (enteredPinCode) => _onPinEntered(enteredPinCode),
         ),
       ),

--- a/lib/widgets/circular_button.dart
+++ b/lib/widgets/circular_button.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class CircularButton extends StatelessWidget {
+  final Widget child;
+  final Function onTap;
+
+  const CircularButton({
+    Key key,
+    @required this.child,
+    @required this.onTap,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+        customBorder: new CircleBorder(),
+        child: Container(
+            child: FlatButton(padding: EdgeInsets.all(16), child: child)),
+        onTap: onTap);
+  }
+}

--- a/lib/widgets/pin_code_widget.dart
+++ b/lib/widgets/pin_code_widget.dart
@@ -4,6 +4,7 @@ import 'package:breez/bloc/user_profile/breez_user_model.dart';
 import 'package:breez/bloc/user_profile/user_actions.dart';
 import 'package:breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:breez/theme_data.dart' as theme;
+import 'package:breez/widgets/circular_button.dart';
 import 'package:breez/widgets/flushbar.dart';
 import 'package:flutter/material.dart';
 
@@ -172,13 +173,7 @@ class PinCodeWidgetState extends State<PinCodeWidget> {
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             mainAxisSize: MainAxisSize.max,
             children: <Widget>[
-              IconButton(
-                onPressed: () => _setPinCodeInput(""),
-                icon: Icon(
-                  Icons.delete_forever,
-                  color: Colors.white,
-                ),
-              ),
+              _buildClearButton(),
               _numberButton("0"),
               widget.onFingerprintEntered == null ||
                       ((widget.onFingerprintEntered != null) &&
@@ -216,24 +211,33 @@ class PinCodeWidgetState extends State<PinCodeWidget> {
     );
   }
 
-  Container _buildEraseButton() {
-    return Container(
-      child: IconButton(
-        onPressed: () => _setPinCodeInput(
-            _enteredPinCode.substring(0, max(_enteredPinCode.length, 1) - 1)),
-        icon: Icon(
-          Icons.backspace,
-          color: Colors.white,
-        ),
+  Widget _buildClearButton() {
+    return CircularButton(
+      child: Icon(
+        Icons.delete_forever,
+        color: Colors.white,
+      ),
+      onTap: () => _setPinCodeInput(""),
+    );
+  }
+
+  Widget _buildEraseButton() {
+    return CircularButton(
+      child: Icon(
+        Icons.backspace,
+        color: Colors.white,
+      ),
+      onTap: () => _setPinCodeInput(
+        _enteredPinCode.substring(0, max(_enteredPinCode.length, 1) - 1),
       ),
     );
   }
 
   Widget _numberButton(String number) {
-    return FlatButton(
-      onPressed: () => _onNumButtonPressed(number),
+    return CircularButton(
       child: Text(number,
           textAlign: TextAlign.center, style: theme.numPadNumberStyle),
+      onTap: () => _onNumButtonPressed(number),
     );
   }
 

--- a/lib/widgets/pin_code_widget.dart
+++ b/lib/widgets/pin_code_widget.dart
@@ -11,13 +11,12 @@ const PIN_CODE_LENGTH = 6;
 
 class PinCodeWidget extends StatefulWidget {
   final String label;
-  final bool dismissible;
   final Future Function(String pinEntered) onPinEntered;
   final Function(bool isValid) onFingerprintEntered;
   final UserProfileBloc userProfileBloc;
   final String localizedReason;
 
-  PinCodeWidget(this.label, this.dismissible, this.onPinEntered,
+  PinCodeWidget(this.label, this.onPinEntered,
       {this.onFingerprintEntered, this.userProfileBloc, this.localizedReason});
 
   @override


### PR DESCRIPTION
This PR addresses issue  https://github.com/breez/breezmobile/issues/183.

The rectangular buttons are replaced with circular buttons that cover a larger area, previous shape caused some hits not to register.