### PR TITLE
Remove border around deposit address QR image

### DIFF
--- a/lib/routes/user/add_funds/address_widget.dart
+++ b/lib/routes/user/add_funds/address_widget.dart
@@ -41,7 +41,6 @@ class AddressWidget extends StatelessWidget {
                   child: Container(
                     margin: const EdgeInsets.only(top: 32.0, bottom: 16.0),
                     padding: const EdgeInsets.all(8.6),
-                    decoration: theme.qrImageStyle,
                     child: Container(
                       color: Theme.of(context).accentColor,
                       child: CompactQRImage(

--- a/lib/theme_data.dart
+++ b/lib/theme_data.dart
@@ -391,9 +391,6 @@ final BoxDecoration boxDecoration = BoxDecoration(
         Border(bottom: BorderSide(color: BreezColors.white[500], width: 1.5)));
 final BoxDecoration autoCompleteBoxDecoration = BoxDecoration(
     color: BreezColors.white[500], borderRadius: BorderRadius.circular(3.0));
-final BoxDecoration qrImageStyle = BoxDecoration(
-    border: Border.all(color: BreezColors.blue[800], width: 1.0),
-    borderRadius: BorderRadius.circular(3.0));
 final Color whiteColor = BreezColors.white[500];
 final Color snackBarBackgroundColor = BreezColors.blue[300];
 final Color avatarBackgroundColor = BreezColors.blue[500];


### PR DESCRIPTION
The border around the QR image displayed in deposit address is removed.

![image](https://user-images.githubusercontent.com/4012752/71823823-39781a00-30a9-11ea-98dc-e8b7e4eaac2c.png)
