### PR TITLE
Get enrolled biometrics on device on demand

### DIFF
--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -19,7 +19,6 @@ import 'package:breez/services/injector.dart';
 import 'package:breez/services/notifications.dart';
 import 'package:connectivity/connectivity.dart';
 import 'package:fixnum/fixnum.dart';
-import 'package:flutter/services.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -639,16 +638,13 @@ class AccountBloc {
   _updateExchangeRates() {
     _getExchangeRate();
     _startExchangeRateTimer();
-    SystemChannels.lifecycle.setMessageHandler((msg) {
-      switch (msg) {
-        case "AppLifecycleState.resumed":
-          _getExchangeRate();
-          _startExchangeRateTimer();
-          break;
-        default:
-          // cancel timer when AppLifecycleState is paused, inactive or suspending
-          _exchangeRateTimer?.cancel();
-          break;
+    _device.eventStream.listen((e) {
+      if (e == NotificationType.RESUME) {
+        _getExchangeRate();
+        _startExchangeRateTimer();
+      } else {
+        // cancel timer when AppLifecycleState is paused, inactive or suspending
+        _exchangeRateTimer?.cancel();
       }
     });
   }

--- a/lib/bloc/user_profile/security_model.dart
+++ b/lib/bloc/user_profile/security_model.dart
@@ -5,13 +5,11 @@ class SecurityModel {
 
   final bool requiresPin;
   final bool isFingerprintEnabled;
-  final String enrolledBiometrics;
   final int automaticallyLockInterval;
 
   SecurityModel._(
       {this.requiresPin,
       this.isFingerprintEnabled,
-      this.enrolledBiometrics,
       this.automaticallyLockInterval});
 
   SecurityModel copyWith(
@@ -22,7 +20,6 @@ class SecurityModel {
     return SecurityModel._(
         requiresPin: requiresPin ?? this.requiresPin,
         isFingerprintEnabled: isFingerprintEnabled ?? this.isFingerprintEnabled,
-        enrolledBiometrics: enrolledBiometrics ?? this.enrolledBiometrics,
         automaticallyLockInterval:
             automaticallyLockInterval ?? this.automaticallyLockInterval);
   }
@@ -31,13 +28,11 @@ class SecurityModel {
       : this._(
             requiresPin: false,
             isFingerprintEnabled: false,
-            enrolledBiometrics: "",
             automaticallyLockInterval: _defaultLockInterval);
 
   SecurityModel.fromJson(Map<String, dynamic> json)
       : requiresPin = json['requiresPin'] ?? false,
         isFingerprintEnabled = json['isFingerprintEnabled'] ?? false,
-        enrolledBiometrics = "",
         automaticallyLockInterval =
             json['automaticallyLockInterval'] ?? _defaultLockInterval;
 

--- a/lib/bloc/user_profile/security_model.dart
+++ b/lib/bloc/user_profile/security_model.dart
@@ -15,7 +15,6 @@ class SecurityModel {
   SecurityModel copyWith(
       {bool requiresPin,
       bool isFingerprintEnabled,
-      String enrolledBiometrics,
       int automaticallyLockInterval}) {
     return SecurityModel._(
         requiresPin: requiresPin ?? this.requiresPin,

--- a/lib/bloc/user_profile/user_actions.dart
+++ b/lib/bloc/user_profile/user_actions.dart
@@ -34,6 +34,8 @@ class ValidateBiometrics extends AsyncAction {
   ValidateBiometrics({this.localizedReason});
 }
 
+class GetEnrolledBiometrics extends AsyncAction {}
+
 class SetLockState extends AsyncAction {
   final bool locked;
 

--- a/lib/bloc/user_profile/user_profile_bloc.dart
+++ b/lib/bloc/user_profile/user_profile_bloc.dart
@@ -105,8 +105,6 @@ class UserProfileBloc {
       //listen upload image requests
       _listenUploadImageRequests(injector);
 
-      _updateBiometricsSettings();
-
       startPINIntervalWatcher();
 
       _userStreamController.firstWhere((u) => u != null).then((user) {

--- a/lib/bloc/user_profile/user_profile_bloc.dart
+++ b/lib/bloc/user_profile/user_profile_bloc.dart
@@ -77,6 +77,7 @@ class UserProfileBloc {
       ValidatePinCode: _validatePinCode,
       ChangeTheme: _changeThemeAction,
       ValidateBiometrics: _validateBiometrics,
+      GetEnrolledBiometrics: _getEnrolledBiometrics,
       SetLockState: _setLockState,
     };
     print("UserProfileBloc started");
@@ -250,6 +251,10 @@ class UserProfileBloc {
   Future _validateBiometrics(ValidateBiometrics action) async {
     action.resolve(await _localAuthService.authenticate(
         localizedReason: action.localizedReason));
+  }
+
+  Future _getEnrolledBiometrics(GetEnrolledBiometrics action) async {
+    action.resolve(await _localAuthService.enrolledBiometrics);
   }
 
   void _listenRegistrationRequests(ServiceInjector injector) {

--- a/lib/bloc/user_profile/user_profile_bloc.dart
+++ b/lib/bloc/user_profile/user_profile_bloc.dart
@@ -157,31 +157,8 @@ class UserProfileBloc {
             color: randomName[0],
             animal: randomName[1]);
       }
-      String enrolledBiometrics = await _localAuthService.enrolledBiometrics;
-      bool isFingerprintEnabled = (user.securityModel.isFingerprintEnabled &&
-          enrolledBiometrics.isNotEmpty);
-      user = user.copyWith(
-          locked: user.securityModel.requiresPin,
-          securityModel: user.securityModel.copyWith(
-              isFingerprintEnabled: isFingerprintEnabled,
-              enrolledBiometrics: enrolledBiometrics));
+      user = user.copyWith(locked: user.securityModel.requiresPin);
       _publishUser(user);
-    });
-  }
-
-  _updateBiometricsSettings() {
-    _deviceService.eventStream.listen((e) async {
-      if (e == NotificationType.RESUME) {
-        String enrolledBiometrics = await _localAuthService.enrolledBiometrics;
-        bool isFingerprintEnabled =
-            _currentUser.securityModel.isFingerprintEnabled &&
-                enrolledBiometrics.isNotEmpty;
-        _updateSecurityModel(
-            UpdateSecurityModel(_currentUser.securityModel.copyWith(
-          isFingerprintEnabled: isFingerprintEnabled,
-          enrolledBiometrics: enrolledBiometrics,
-        )));
-      }
     });
   }
 
@@ -222,9 +199,7 @@ class UserProfileBloc {
 
   Future _resetSecurityModelAction(
       ResetSecurityModel resetSecurityModelAction) async {
-    var updateSecurityModelAction = UpdateSecurityModel(SecurityModel.initial()
-        .copyWith(
-            enrolledBiometrics: _currentUser.securityModel.enrolledBiometrics));
+    var updateSecurityModelAction = UpdateSecurityModel(SecurityModel.initial());
     resetSecurityModelAction
         .resolve(await _updateSecurityModel(updateSecurityModelAction));
   }

--- a/lib/routes/shared/security_pin/security_pin_page.dart
+++ b/lib/routes/shared/security_pin/security_pin_page.dart
@@ -39,6 +39,14 @@ class SecurityPageState extends State<SecurityPage> {
   AutoSizeGroup _autoSizeGroup = AutoSizeGroup();
   bool _screenLocked = true;
   int _renderIndex = 0;
+  String _enrolledBiometrics;
+
+  @override
+  void initState() {
+    super.initState();
+    _enrolledBiometrics = "";
+    _getEnrolledBiometrics();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -119,7 +127,7 @@ class SecurityPageState extends State<SecurityPage> {
         ..add(_buildPINIntervalTile(securityModel, backupSettings))
         ..add(Divider())
         ..add(_buildChangePINTile(securityModel, backupSettings));
-      if (securityModel.enrolledBiometrics.isNotEmpty) {
+      if (_enrolledBiometrics.isNotEmpty) {
         _tiles
           ..add(Divider())
           ..add(_buildEnableBiometricAuthTile(securityModel, backupSettings));
@@ -289,7 +297,7 @@ class SecurityPageState extends State<SecurityPage> {
       SecurityModel securityModel, BackupSettings backupSettings) {
     return ListTile(
       title: AutoSizeText(
-        "Enable ${securityModel.enrolledBiometrics}",
+        "Enable ${_enrolledBiometrics}",
         style: TextStyle(color: Colors.white),
         maxLines: 1,
         minFontSize: MinFontSize(context).minFontSize,
@@ -384,6 +392,16 @@ class SecurityPageState extends State<SecurityPage> {
               ));
         });
       }
+    });
+  }
+
+  Future _getEnrolledBiometrics() async {
+    var getEnrolledBiometricsAction = GetEnrolledBiometrics();
+    widget.userProfileBloc.userActionsSink.add(getEnrolledBiometricsAction);
+    return getEnrolledBiometricsAction.future.then((enrolledBiometrics) {
+      setState(() {
+        _enrolledBiometrics = enrolledBiometrics;
+      });
     });
   }
 

--- a/lib/routes/shared/security_pin/security_pin_page.dart
+++ b/lib/routes/shared/security_pin/security_pin_page.dart
@@ -35,7 +35,8 @@ class SecurityPage extends StatefulWidget {
   }
 }
 
-class SecurityPageState extends State<SecurityPage> {
+class SecurityPageState extends State<SecurityPage>
+    with WidgetsBindingObserver {
   AutoSizeGroup _autoSizeGroup = AutoSizeGroup();
   bool _screenLocked = true;
   int _renderIndex = 0;
@@ -44,8 +45,22 @@ class SecurityPageState extends State<SecurityPage> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _enrolledBiometrics = "";
     _getEnrolledBiometrics();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _getEnrolledBiometrics();
+    }
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    WidgetsBinding.instance.removeObserver(this);
   }
 
   @override

--- a/lib/routes/shared/security_pin/security_pin_page.dart
+++ b/lib/routes/shared/security_pin/security_pin_page.dart
@@ -59,8 +59,8 @@ class SecurityPageState extends State<SecurityPage>
 
   @override
   void dispose() {
-    super.dispose();
     WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
   }
 
   @override

--- a/lib/widgets/pin_code_widget.dart
+++ b/lib/widgets/pin_code_widget.dart
@@ -55,8 +55,8 @@ class PinCodeWidgetState extends State<PinCodeWidget>
 
   @override
   void dispose() {
-    super.dispose();
     WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
   }
 
   Future _promptBiometrics() async {

--- a/lib/widgets/pin_code_widget.dart
+++ b/lib/widgets/pin_code_widget.dart
@@ -46,10 +46,9 @@ class PinCodeWidgetState extends State<PinCodeWidget>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.resumed) {
-      if (widget.onFingerprintEntered != null) {
-        _promptBiometrics();
-      }
+    if (state == AppLifecycleState.resumed &&
+        widget.onFingerprintEntered != null) {
+      _promptBiometrics();
     }
   }
 

--- a/lib/widgets/pin_code_widget.dart
+++ b/lib/widgets/pin_code_widget.dart
@@ -26,7 +26,8 @@ class PinCodeWidget extends StatefulWidget {
   }
 }
 
-class PinCodeWidgetState extends State<PinCodeWidget> {
+class PinCodeWidgetState extends State<PinCodeWidget>
+    with WidgetsBindingObserver {
   String _enteredPinCode;
   String _errorMessage;
   String _enrolledBiometrics;
@@ -34,12 +35,28 @@ class PinCodeWidgetState extends State<PinCodeWidget> {
   @override
   initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _enteredPinCode = "";
     _errorMessage = "";
     _enrolledBiometrics = "";
     if (widget.onFingerprintEntered != null) {
       _promptBiometrics();
     }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      if (widget.onFingerprintEntered != null) {
+        _promptBiometrics();
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    WidgetsBinding.instance.removeObserver(this);
   }
 
   Future _promptBiometrics() async {


### PR DESCRIPTION
We retrieve enrolled biometrics on device on demand rather than once every start up and each on resume. This reduces load on computing overhead and ensures we have the latest information.

enrolledBiometrics is removed from SecurityModel and is now being updated on onResume, on UI level.