### PR TITLE
POS: Add fiat support 

### DIFF
--- a/lib/bloc/app_blocs.dart
+++ b/lib/bloc/app_blocs.dart
@@ -46,7 +46,7 @@ class AppBlocs {
     AccountBloc accountBloc =
         _registerBloc(AccountBloc(userProfileBloc.userStream), blocsByType);
     InvoiceBloc invoicesBloc =
-        _registerBloc(InvoiceBloc(userProfileBloc), blocsByType);
+        _registerBloc(InvoiceBloc(), blocsByType);
     ConnectPayBloc connectPayBloc = _registerBloc(
         ConnectPayBloc(userProfileBloc.userStream, accountBloc.accountStream,
             accountBloc.userActionsSink),

--- a/lib/bloc/invoice/actions.dart
+++ b/lib/bloc/invoice/actions.dart
@@ -1,0 +1,9 @@
+import 'package:breez/bloc/async_action.dart';
+
+import 'invoice_model.dart';
+
+class NewInvoice extends AsyncAction {
+  final InvoiceRequestModel request;
+
+  NewInvoice(this.request);
+}

--- a/lib/bloc/user_profile/currency.dart
+++ b/lib/bloc/user_profile/currency.dart
@@ -13,7 +13,7 @@ class Currency extends Object {
 
   const Currency._internal(this.symbol);
   factory Currency.fromSymbol(String symbol) {
-    return currencies.firstWhere((c) => c.symbol == (symbol == "sats" ? "Sat" : symbol), orElse: () => SAT);
+    return currencies.firstWhere((c) => c.symbol == symbol, orElse: () => null);
   }
 
   String format(Int64 sat,

--- a/lib/bloc/user_profile/currency.dart
+++ b/lib/bloc/user_profile/currency.dart
@@ -13,7 +13,7 @@ class Currency extends Object {
 
   const Currency._internal(this.symbol);
   factory Currency.fromSymbol(String symbol) {
-    return currencies.firstWhere((c) => c.symbol == symbol, orElse: () => SAT);
+    return currencies.firstWhere((c) => c.symbol == (symbol == "sats" ? "Sat" : symbol), orElse: () => SAT);
   }
 
   String format(Int64 sat,

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -43,6 +43,7 @@ class POSInvoiceState extends State<POSInvoice> {
   double itemWidth;
   int _currentAmount = 0;
   double _currentFiatAmount = 0;
+  String _totalSatAmount = "0";
   String _satAmount = "0";
   String _fiatAmount = "0";
   int _totalAmount = 0;
@@ -183,7 +184,7 @@ class POSInvoiceState extends State<POSInvoice> {
                               color: Theme.of(context).primaryColorLight,
                               padding: EdgeInsets.only(top: 14.0, bottom: 14.0),
                               child: Text(
-                                "Charge $_satAmount ${_currency.symbol}"
+                                "Charge $_totalSatAmount ${_currency.symbol}"
                                     .toUpperCase(),
                                 maxLines: 1,
                                 textAlign: TextAlign.center,
@@ -463,10 +464,10 @@ class POSInvoiceState extends State<POSInvoice> {
         _userProfileBloc.currencySink.add(currency);
       } else {
         _usingFiat = true;
-        _clearCurrentAmounts();
         _totalAmount = 0;
         _userProfileBloc.fiatConversionSink.add(value);
       }
+      _updateAmountControllers();
     });
   }
 
@@ -479,10 +480,16 @@ class POSInvoiceState extends State<POSInvoice> {
   }
 
   _updateAmountControllers() {
+    if (_usingFiat) {
+      _currentAmount =
+          _fiatCurrencyConversion.fiatToSat(_currentFiatAmount).toInt();
+    }
     _satAmount = _currency.format((Int64(_currentAmount)),
         fixedDecimals: true, includeSymbol: false);
     _fiatAmount = _currentFiatAmount
         .toStringAsFixed(_fiatCurrencyConversion.currencyData.fractionSize);
+    _totalSatAmount = _currency.format((Int64(_totalAmount + _currentAmount)),
+        fixedDecimals: true, includeSymbol: false);
   }
 
   onClear() {

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -33,8 +33,6 @@ class POSInvoice extends StatefulWidget {
 class POSInvoiceState extends State<POSInvoice> {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
-  TextEditingController _amountController = TextEditingController();
-  TextEditingController _chargeAmountController = TextEditingController();
   TextEditingController _invoiceDescriptionController = TextEditingController();
 
   BreezUserModel _userProfile;
@@ -45,6 +43,8 @@ class POSInvoiceState extends State<POSInvoice> {
   double itemWidth;
   int _currentAmount = 0;
   double _currentFiatAmount = 0;
+  String _satAmount = "0";
+  String _fiatAmount = "0";
   int _totalAmount = 0;
   Int64 _maxPaymentAmount;
   Int64 _maxAllowedToReceive;
@@ -183,7 +183,7 @@ class POSInvoiceState extends State<POSInvoice> {
                               color: Theme.of(context).primaryColorLight,
                               padding: EdgeInsets.only(top: 14.0, bottom: 14.0),
                               child: Text(
-                                "Charge ${_chargeAmountController.text}"
+                                "Charge $_satAmount ${_currency.symbol}"
                                     .toUpperCase(),
                                 maxLines: 1,
                                 textAlign: TextAlign.center,
@@ -242,11 +242,9 @@ class POSInvoiceState extends State<POSInvoice> {
                       Padding(
                         padding: EdgeInsets.only(left: 16.0, right: 16.0),
                         child: Row(children: <Widget>[
-                          Flexible(
-                              child: TextField(
-                            decoration: InputDecoration.collapsed(hintText: ''),
-                            enabled: false,
-                            controller: _amountController,
+                          Expanded(
+                              child: Text(
+                            _usingFiat ? _fiatAmount : _satAmount,
                             style: theme.invoiceAmountStyle.copyWith(
                                 color:
                                     Theme.of(context).textTheme.headline.color),
@@ -481,17 +479,10 @@ class POSInvoiceState extends State<POSInvoice> {
   }
 
   _updateAmountControllers() {
-    if (!_usingFiat) {
-      _amountController.text = _currency.format((Int64(_currentAmount)),
-          fixedDecimals: true, includeSymbol: false);
-    } else {
-      _amountController.text = _currentFiatAmount
-          .toStringAsFixed(_fiatCurrencyConversion.currencyData.fractionSize);
-    }
-    _chargeAmountController.text = _currency.format(
-        (Int64(_totalAmount + _currentAmount)),
-        fixedDecimals: true,
-        includeSymbol: true);
+    _satAmount = _currency.format((Int64(_currentAmount)),
+        fixedDecimals: true, includeSymbol: false);
+    _fiatAmount = _currentFiatAmount
+        .toStringAsFixed(_fiatCurrencyConversion.currencyData.fractionSize);
   }
 
   onClear() {

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -278,7 +278,7 @@ class POSInvoiceState extends State<POSInvoice> {
                                                       ? _fiatCurrencyConversion
                                                           .currencyData
                                                           .shortName
-                                                      : _currency.displayName,
+                                                      : _currency.symbol,
                                                   style: theme
                                                       .invoiceAmountStyle
                                                       .copyWith(
@@ -291,7 +291,7 @@ class POSInvoiceState extends State<POSInvoice> {
                                                       .map((Currency value) {
                                                     return DropdownMenuItem<
                                                         String>(
-                                                      value: value.displayName,
+                                                      value: value.symbol,
                                                       child: Text(
                                                         value.displayName,
                                                         textAlign:
@@ -454,21 +454,18 @@ class POSInvoiceState extends State<POSInvoice> {
 
   changeCurrency(value) {
     setState(() {
-      bool usingFiat = _fiatCurrencyConversion != null ? true : false;
-      Currency.currencies.forEach((currency) {
-        if (currency.displayName == value) {
-          usingFiat = false;
-          _currency = Currency.fromSymbol(value);
-          if (_usingFiat) {
-            // We are switching back from fiat
-            _usingFiat = false;
-            _clearCurrentAmounts();
-            _totalAmount = 0;
-          }
-          _userProfileBloc.currencySink
-              .add(Currency.currencies[Currency.currencies.indexOf(_currency)]);
+      bool usingFiat = true;
+      Currency currency = Currency.fromSymbol(value);
+      if (currency != null) {
+        usingFiat = false;
+        if (_usingFiat) {
+          // We are switching back from fiat
+          _usingFiat = false;
+          _clearCurrentAmounts();
+          _totalAmount = 0;
         }
-      });
+        _userProfileBloc.currencySink.add(currency);
+      }
 
       if (usingFiat) {
         _usingFiat = true;

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -454,10 +454,8 @@ class POSInvoiceState extends State<POSInvoice> {
 
   changeCurrency(value) {
     setState(() {
-      bool usingFiat = true;
       Currency currency = Currency.fromSymbol(value);
       if (currency != null) {
-        usingFiat = false;
         if (_usingFiat) {
           // We are switching back from fiat
           _usingFiat = false;
@@ -465,9 +463,7 @@ class POSInvoiceState extends State<POSInvoice> {
           _totalAmount = 0;
         }
         _userProfileBloc.currencySink.add(currency);
-      }
-
-      if (usingFiat) {
+      } else {
         _usingFiat = true;
         _clearCurrentAmounts();
         _totalAmount = 0;


### PR DESCRIPTION
Moved https://github.com/breez/breezmobile/pull/132 into this branch. (_because I messed up resolving conflicts and wanted to save time rather than resolve it on that branch_)

- Add fiat currencies to the dropdown list
- Show decimals depending on `currencyData.fractionSize`
- Convert to last used bitcoin unit and display on the charge button
- Refactor duplicate code into `updateAmountControllers` and `clearCurrentAmounts`

- Recognize "sats" as Sat currency using Currency.fromSymbol().