### PR TITLE
QR image visual changes in dark mode

### DIFF
--- a/lib/routes/add_funds/address_widget.dart
+++ b/lib/routes/add_funds/address_widget.dart
@@ -41,12 +41,9 @@ class AddressWidget extends StatelessWidget {
                   child: Container(
                     margin: const EdgeInsets.only(top: 32.0, bottom: 16.0),
                     padding: const EdgeInsets.all(8.6),
-                    child: Container(
-                      color: Theme.of(context).accentColor,
-                      child: CompactQRImage(
-                        data: "bitcoin:" + address,
-                        size: 180.0,
-                      ),
+                    child: CompactQRImage(
+                      data: "bitcoin:" + address,
+                      size: 180.0,
                     ),
                   ),
                   onLongPress: () => _showAlertDialog(context),

--- a/lib/routes/create_invoice/qr_code_dialog.dart
+++ b/lib/routes/create_invoice/qr_code_dialog.dart
@@ -161,7 +161,6 @@ class QrCodeDialogState extends State<QrCodeDialog>
                         Container(
                           width: 230.0,
                           height: 230.0,
-                          color: Colors.white,
                           child: CompactQRImage(
                             data: snapshot.data,
                           ),

--- a/lib/widgets/compact_qr_image.dart
+++ b/lib/widgets/compact_qr_image.dart
@@ -53,6 +53,7 @@ class CompactQRImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return QrImage(
+      backgroundColor: Colors.white,
       version: _calculateVersion(),
       data: data,
       size: this.size,

--- a/lib/widgets/pos_payment_dialog.dart
+++ b/lib/widgets/pos_payment_dialog.dart
@@ -1,10 +1,8 @@
 import 'dart:async';
 
 import 'package:breez/bloc/invoice/invoice_bloc.dart';
-import 'package:breez/bloc/invoice/invoice_model.dart';
 import 'package:breez/bloc/user_profile/breez_user_model.dart';
 import 'package:breez/services/countdown.dart';
-import 'package:breez/theme_data.dart' as theme;
 import 'package:breez/widgets/compact_qr_image.dart';
 import 'package:breez/widgets/flushbar.dart';
 import 'package:flutter/material.dart';
@@ -83,7 +81,7 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
       child: Text(
         'CANCEL PAYMENT',
         textAlign: TextAlign.center,
-        style: theme.cancelButtonStyle,
+        style: Theme.of(context).primaryTextTheme.button,
       ),
       onPressed: () {
         Navigator.of(context).pop(false);

--- a/lib/widgets/pos_payment_dialog.dart
+++ b/lib/widgets/pos_payment_dialog.dart
@@ -106,11 +106,9 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
                             child: Container(
                                 height: 230.0,
                                 width: 230.0,
-                                child: AspectRatio(
-                                    aspectRatio: 1.0,
-                                    child: CompactQRImage(
-                                      data: widget.paymentRequest,
-                                    ))))),
+                                child: CompactQRImage(
+                                  data: widget.paymentRequest,
+                                )))),
                     Padding(
                         padding: EdgeInsets.only(top: 15.0),
                         child: Text(_countdownString,


### PR DESCRIPTION
This PR addresses [POS-25](https://breeztech.atlassian.net/browse/POS-25)

QR Image is given a white background across the app.

Cancel Payment button style now matches other cancel buttons on Dark mode.