### PR TITLE
Pos consolidation regressions

### DIFF
--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -518,22 +518,18 @@ class POSInvoiceState extends State<POSInvoice> {
   }
 
   String _formattedCurrentCharge(AccountModel acc) {
-    return _formattedCharge(acc, currentAmount);
+    if (_useFiat) {
+      return (currentAmount)
+          .toStringAsFixed(acc.fiatCurrency.currencyData.fractionSize);
+    }
+    return acc.currency.format(Int64((currentAmount).toInt()),
+        fixedDecimals: true, includeSymbol: false);
   }
 
   String _currencySymbol(AccountModel accountModel) {
     return _useFiat
         ? accountModel.fiatCurrency.currencyData.shortName
         : accountModel.currency.symbol;
-  }
-
-  String _formattedCharge(AccountModel acc, double charge) {
-    if (_useFiat) {
-      return (charge)
-          .toStringAsFixed(acc.fiatCurrency.currencyData.fractionSize);
-    }
-    return acc.currency.format(Int64((charge).toInt()),
-        fixedDecimals: true, includeSymbol: false);
   }
 
   Int64 _satAmount(AccountModel acc, double nativeAmount) {

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -130,7 +130,7 @@ class POSInvoiceState extends State<POSInvoice> {
                                           padding: EdgeInsets.only(
                                               top: 14.0, bottom: 14.0),
                                           child: Text(
-                                            "Charge ${_formattedTotalCharge(accountModel)} ${_currencySymbol(accountModel)}"
+                                            "Charge ${_formattedTotalCharge(accountModel)}"
                                                 .toUpperCase(),
                                             maxLines: 1,
                                             textAlign: TextAlign.center,
@@ -510,7 +510,11 @@ class POSInvoiceState extends State<POSInvoice> {
   }
 
   String _formattedTotalCharge(AccountModel acc) {
-    return _formattedCharge(acc, amount + currentAmount);
+    var satoshies = Int64((amount + currentAmount).toInt());
+    if (_useFiat) {
+      satoshies = _satAmount(acc, amount + currentAmount);
+    }
+    return acc.currency.format(satoshies, includeSymbol: true);
   }
 
   String _formattedCurrentCharge(AccountModel acc) {

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+
 import 'package:breez/bloc/account/account_bloc.dart';
 import 'package:breez/bloc/account/account_model.dart';
 import 'package:breez/bloc/account/fiat_conversion.dart';
@@ -30,8 +31,6 @@ class POSInvoice extends StatefulWidget {
 }
 
 class POSInvoiceState extends State<POSInvoice> {
-  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
-
   TextEditingController _invoiceDescriptionController = TextEditingController();
   double itemHeight;
   double itemWidth;
@@ -518,11 +517,11 @@ class POSInvoiceState extends State<POSInvoice> {
   }
 
   String _formattedTotalCharge(AccountModel acc) {
-    return _formatedCharge(acc, amount + currentAmount);
+    return _formattedCharge(acc, amount + currentAmount);
   }
 
   String _formattedCurrentCharge(AccountModel acc) {
-    return _formatedCharge(acc, currentAmount);
+    return _formattedCharge(acc, currentAmount);
   }
 
   String _currencySymbol(AccountModel accountModel) {
@@ -531,7 +530,7 @@ class POSInvoiceState extends State<POSInvoice> {
         : accountModel.currency.symbol;
   }
 
-  String _formatedCharge(AccountModel acc, double charge) {
+  String _formattedCharge(AccountModel acc, double charge) {
     if (_useFiat) {
       return (charge)
           .toStringAsFixed(acc.fiatCurrency.currencyData.fractionSize);

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -416,16 +416,9 @@ class POSInvoiceState extends State<POSInvoice> {
       }
 
       bool flipFiat = _useFiat == (currency != null);
-      Int64 oldSatAmount = _satAmount(accountModel, amount);
-      Int64 oldCurrentSatAmount = _satAmount(accountModel, currentAmount);
       if (flipFiat) {
         _useFiat = !_useFiat;
-        currentAmount = oldCurrentSatAmount.toDouble();
-        amount = oldSatAmount.toDouble();
-        if (_useFiat) {
-          amount = accountModel.fiatCurrency.satToFiat(oldSatAmount);
-          currentAmount = accountModel.fiatCurrency.satToFiat(oldCurrentSatAmount);
-        }
+        _clearAmounts(clearTotal: true);
       }
     });
   }

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -44,6 +44,13 @@ class POSInvoiceState extends State<POSInvoice> {
   FocusNode _focusNode;
 
   @override
+  void initState() {
+    super.initState();
+    _focusNode = FocusNode();
+    _focusNode.addListener(_onOnFocusNodeEvent);
+  }
+
+  @override
   void didChangeDependencies() {
     itemHeight = (MediaQuery.of(context).size.height - kToolbarHeight - 16) / 4;
     itemWidth = (MediaQuery.of(context).size.width) / 2;
@@ -292,6 +299,12 @@ class POSInvoiceState extends State<POSInvoice> {
         }),
       ),
     );
+  }
+
+  _onOnFocusNodeEvent() {
+    setState(() {
+      _isButtonDisabled = true;
+    });
   }
 
   onInvoiceSubmitted(

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -330,7 +330,7 @@ class POSInvoiceState extends State<POSInvoice> {
               ),
               actions: <Widget>[
                 FlatButton(
-                  child: Text("Go to Settings", style: theme.buttonStyle),
+                  child: Text("Go to Settings", style: Theme.of(context).primaryTextTheme.button),
                   onPressed: () {
                     Navigator.of(context).pop();
                     Navigator.of(context).pushNamed("/settings");
@@ -451,13 +451,15 @@ class POSInvoiceState extends State<POSInvoice> {
         actions: <Widget>[
           FlatButton(
               onPressed: () => Navigator.pop(context),
-              child: Text("Cancel", style: theme.buttonStyle)),
+              child: Text("Cancel",
+                  style: Theme.of(context).primaryTextTheme.button)),
           FlatButton(
               onPressed: () {
                 Navigator.pop(context);
                 clearSale();
               },
-              child: Text("Clear", style: theme.buttonStyle))
+              child: Text("Clear",
+                  style: Theme.of(context).primaryTextTheme.button))
         ],
         shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.all(Radius.circular(12.0))),


### PR DESCRIPTION
This PR addresses regressions caused by #273

Regressions
- Disable charge button when entering invoice note.
- Do not convert currencies when flipping fiat vice versa.
- Show currency conversion of entered fiat amount on Charge button

Fixes
- Change 'SAT' to 'SATS' in the Charge [POS-28](https://breeztech.atlassian.net/browse/POS-28)
- Dark theme settings are applied to pos buttons.