### PR TITLE
POS Currency conversion

### DIFF
--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -389,12 +389,9 @@ class POSInvoiceState extends State<POSInvoice> {
       AccountModel accountModel, value, UserProfileBloc userProfileBloc) {
     setState(() {
       Currency currency = Currency.fromSymbol(value);
-      FiatConversion newFiatCurrency;
       if (currency != null) {
         userProfileBloc.currencySink.add(currency);
       } else {
-        newFiatCurrency = accountModel.fiatConversionList
-            .firstWhere((f) => f.currencyData.shortName == value);
         userProfileBloc.fiatConversionSink.add(value);
       }
 
@@ -405,7 +402,9 @@ class POSInvoiceState extends State<POSInvoice> {
         _clearAmounts();
       }
       amount = (flipFiat && _useFiat || _useFiat) // For Sat->Fiat or Fiat->Fiat
-          ? newFiatCurrency.satToFiat(oldSatAmount)
+          ? accountModel.fiatConversionList
+              .firstWhere((f) => f.currencyData.shortName == value)
+              .satToFiat(oldSatAmount)
           : accountModel.fiatCurrency.fiatToSat(amount).toDouble();
     });
   }

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -402,14 +402,11 @@ class POSInvoiceState extends State<POSInvoice> {
       Int64 oldSatAmount = _satAmount(accountModel, amount);
       if (flipFiat) {
         _useFiat = !_useFiat;
-        _clearAmounts(clearTotal: false);
-        amount = _useFiat
-            ? newFiatCurrency.satToFiat(oldSatAmount)
-            : accountModel.fiatCurrency.fiatToSat(amount).toDouble();
-      } else if (_useFiat) {
-        // Convert between fiat currencies
-        amount = newFiatCurrency.satToFiat(oldSatAmount);
+        _clearAmounts();
       }
+      amount = (flipFiat && _useFiat || _useFiat)
+          ? newFiatCurrency.satToFiat(oldSatAmount)
+          : accountModel.fiatCurrency.fiatToSat(amount).toDouble();
     });
   }
 
@@ -486,7 +483,7 @@ class POSInvoiceState extends State<POSInvoice> {
                   onLongPress: approveClear,
                   child: FlatButton(
                       onPressed: () {
-                        _clearAmounts(clearTotal: false);
+                        _clearAmounts();
                       },
                       child: Text("C", style: theme.numPadNumberStyle)))),
           _numberButton(accountModel, "0"),

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -404,7 +404,7 @@ class POSInvoiceState extends State<POSInvoice> {
         _useFiat = !_useFiat;
         _clearAmounts();
       }
-      amount = (flipFiat && _useFiat || _useFiat)
+      amount = (flipFiat && _useFiat || _useFiat) // For Sat->Fiat or Fiat->Fiat
           ? newFiatCurrency.satToFiat(oldSatAmount)
           : accountModel.fiatCurrency.fiatToSat(amount).toDouble();
     });

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -401,11 +401,14 @@ class POSInvoiceState extends State<POSInvoice> {
         _useFiat = !_useFiat;
         _clearAmounts();
       }
-      amount = (flipFiat && _useFiat || _useFiat) // For Sat->Fiat or Fiat->Fiat
-          ? accountModel.fiatConversionList
-              .firstWhere((f) => f.currencyData.shortName == value)
-              .satToFiat(oldSatAmount)
-          : accountModel.fiatCurrency.fiatToSat(amount).toDouble();
+      amount = oldSatAmount.toDouble();
+
+      // We need to convert only in case we use fiat.
+      if (_useFiat) {
+        amount = accountModel.fiatConversionList
+            .firstWhere((f) => f.currencyData.shortName == value)
+            .satToFiat(oldSatAmount);
+      }
     });
   }
 

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -398,18 +398,14 @@ class POSInvoiceState extends State<POSInvoice> {
       bool flipFiat = _useFiat == (currency != null);
       if (flipFiat) {
         _useFiat = !_useFiat;
-        _clearAmounts(clearTotal: true);
+        _clearAmounts(clearTotal: false);
       }
     });
   }
 
   _clearAmounts({bool clearTotal = false}) {
     setState(() {
-      if (clearTotal) {
-        amount = currentAmount = 0;
-      } else {
-        currentAmount = 0;
-      }
+      clearTotal ? amount = currentAmount = 0 : currentAmount = 0;
     });
   }
 


### PR DESCRIPTION
This PR addresses [POS-34](https://breeztech.atlassian.net/browse/POS-34)

Switching currencies clears the current input and charge amount is converted.

`accountModel.fiatConversionList.firstWhere((f) => f.currencyData.shortName == value)` is used when converting from fiat -> fiat and sat -> fiat because of the delay in `userProfileBloc.fiatConversionSink.add(value);` to be reflected to the account model. 