### PR TITLE
Avatar picker bug

### DIFF
--- a/lib/bloc/user_profile/user_actions.dart
+++ b/lib/bloc/user_profile/user_actions.dart
@@ -51,3 +51,9 @@ class SetPOSFlavor extends AsyncAction {
 
   SetPOSFlavor(this.isPos);
 }
+
+class UploadProfilePicture extends AsyncAction {
+  final List<int> bytes;
+
+  UploadProfilePicture(this.bytes);
+}

--- a/lib/bloc/user_profile/user_profile_bloc.dart
+++ b/lib/bloc/user_profile/user_profile_bloc.dart
@@ -4,9 +4,9 @@ import 'dart:io';
 
 import 'package:breez/bloc/async_action.dart';
 import 'package:breez/bloc/user_profile/breez_user_model.dart';
-import 'package:breez/bloc/user_profile/security_model.dart';
 import 'package:breez/bloc/user_profile/currency.dart';
 import 'package:breez/bloc/user_profile/default_profile_generator.dart';
+import 'package:breez/bloc/user_profile/security_model.dart';
 import 'package:breez/bloc/user_profile/user_actions.dart';
 import 'package:breez/logger.dart';
 import 'package:breez/services/breez_server/server.dart';
@@ -197,6 +197,7 @@ class UserProfileBloc {
         return _breezServer.uploadLogo(bytes).then((imageUrl) async {
           _userStreamPreviewController
               .add(_currentUser.copyWith(image: imageUrl));
+          return Future.value(null);
         });
       });
     } catch (error) {

--- a/lib/widgets/breez_avatar.dart
+++ b/lib/widgets/breez_avatar.dart
@@ -47,7 +47,7 @@ class BreezAvatar extends StatelessWidget {
         this.backgroundColor ?? theme.sessionAvatarBackgroundColor;
 
     if (avatarURL != null && avatarURL.isNotEmpty) {
-      if (avatarURL.startsWith("/data")) {
+      if (avatarURL.contains("/image_cropper")) {
         return _FileImageAvatar(radius, avatarURL);
       }
 

--- a/lib/widgets/breez_avatar.dart
+++ b/lib/widgets/breez_avatar.dart
@@ -1,8 +1,10 @@
-import 'package:flutter_advanced_networkimage/provider.dart';
-import 'package:flutter/material.dart';
-import 'package:breez/theme_data.dart' as theme;
+import 'dart:io';
+
 import 'package:breez/bloc/user_profile/default_profile_generator.dart'
     as generator;
+import 'package:breez/theme_data.dart' as theme;
+import 'package:flutter/material.dart';
+import 'package:flutter_advanced_networkimage/provider.dart';
 
 final _breezAvatarColors = {
   "salmon": Color(0xFFFA8072),
@@ -36,21 +38,19 @@ class BreezAvatar extends StatelessWidget {
   final String avatarURL;
   final double radius;
   final Color backgroundColor;
-  final List<int> bytes;
 
-  BreezAvatar(this.avatarURL,
-      {this.radius = 20.0, this.backgroundColor, this.bytes});
+  BreezAvatar(this.avatarURL, {this.radius = 20.0, this.backgroundColor});
 
   @override
   Widget build(BuildContext context) {
     Color avatarBgColor =
         this.backgroundColor ?? theme.sessionAvatarBackgroundColor;
 
-    if (bytes != null) {
-      return _MemoryImageAvatar(radius, bytes);
-    }
-
     if (avatarURL != null && avatarURL.isNotEmpty) {
+      if (avatarURL.startsWith("/data")) {
+        return _FileImageAvatar(radius, avatarURL);
+      }
+
       if (avatarURL.startsWith("breez://profile_image?")) {
         var queryParams = Uri.parse(avatarURL).queryParameters;
         return _GeneratedAvatar(
@@ -116,11 +116,11 @@ class _GeneratedAvatar extends StatelessWidget {
   }
 }
 
-class _MemoryImageAvatar extends StatelessWidget {
+class _FileImageAvatar extends StatelessWidget {
   final double radius;
-  final List<int> bytes;
+  final String filePath;
 
-  _MemoryImageAvatar(this.radius, this.bytes);
+  _FileImageAvatar(this.radius, this.filePath);
 
   @override
   Widget build(BuildContext context) {
@@ -130,7 +130,9 @@ class _MemoryImageAvatar extends StatelessWidget {
       decoration: new BoxDecoration(
         shape: BoxShape.circle,
         image: DecorationImage(
-          image: MemoryImage(bytes),
+          image: FileImage(
+            File(filePath),
+          ),
         ),
       ),
     );

--- a/lib/widgets/breez_avatar.dart
+++ b/lib/widgets/breez_avatar.dart
@@ -57,7 +57,7 @@ class BreezAvatar extends StatelessWidget {
         return _VendorAvatar(radius, avatarURL);
       }
 
-      if (Uri.parse(avatarURL).scheme.startsWith("http")) {
+      if (Uri.tryParse(avatarURL)?.scheme?.startsWith("http") ?? false) {
         return _NetworkImageAvatar(avatarURL, radius);
       }
 

--- a/lib/widgets/breez_avatar.dart
+++ b/lib/widgets/breez_avatar.dart
@@ -47,10 +47,6 @@ class BreezAvatar extends StatelessWidget {
         this.backgroundColor ?? theme.sessionAvatarBackgroundColor;
 
     if (avatarURL != null && avatarURL.isNotEmpty) {
-      if (avatarURL.contains("/image_cropper")) {
-        return _FileImageAvatar(radius, avatarURL);
-      }
-
       if (avatarURL.startsWith("breez://profile_image?")) {
         var queryParams = Uri.parse(avatarURL).queryParameters;
         return _GeneratedAvatar(
@@ -61,7 +57,11 @@ class BreezAvatar extends StatelessWidget {
         return _VendorAvatar(radius, avatarURL);
       }
 
-      return _NetworkImageAvatar(avatarURL, radius);
+      if (Uri.parse(avatarURL).scheme.startsWith("http")) {
+        return _NetworkImageAvatar(avatarURL, radius);
+      }
+
+      return _FileImageAvatar(radius, avatarURL);
     }
 
     return _UnknownAvatar(radius, avatarBgColor);

--- a/lib/widgets/breez_avatar.dart
+++ b/lib/widgets/breez_avatar.dart
@@ -36,13 +36,20 @@ class BreezAvatar extends StatelessWidget {
   final String avatarURL;
   final double radius;
   final Color backgroundColor;
+  final List<int> bytes;
 
-  BreezAvatar(this.avatarURL, {this.radius = 20.0, this.backgroundColor});
+  BreezAvatar(this.avatarURL,
+      {this.radius = 20.0, this.backgroundColor, this.bytes});
 
   @override
   Widget build(BuildContext context) {
     Color avatarBgColor =
         this.backgroundColor ?? theme.sessionAvatarBackgroundColor;
+
+    if (bytes != null) {
+      return _MemoryImageAvatar(radius, bytes);
+    }
+
     if (avatarURL != null && avatarURL.isNotEmpty) {
       if (avatarURL.startsWith("breez://profile_image?")) {
         var queryParams = Uri.parse(avatarURL).queryParameters;
@@ -106,6 +113,27 @@ class _GeneratedAvatar extends StatelessWidget {
               size: radius * 2 * 0.75,
               color: _breezAvatarColors[color.toLowerCase()]),
         ));
+  }
+}
+
+class _MemoryImageAvatar extends StatelessWidget {
+  final double radius;
+  final List<int> bytes;
+
+  _MemoryImageAvatar(this.radius, this.bytes);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: radius * 2,
+      width: radius * 2,
+      decoration: new BoxDecoration(
+        shape: BoxShape.circle,
+        image: DecorationImage(
+          image: MemoryImage(bytes),
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/widgets/breez_avatar_dialog.dart
+++ b/lib/widgets/breez_avatar_dialog.dart
@@ -25,10 +25,12 @@ Widget breezAvatarDialog(BuildContext context, UserProfileBloc userBloc) {
   bool _isUploading = false;
 
   final _nameInputController = TextEditingController();
-  userBloc.userPreviewStream.listen((user) {
-    _nameInputController.text = user.name;
-    _currentSettings = user;
-  });
+
+  userBloc.userPreviewStream
+      .firstWhere((u) => u != null)
+      .then((user) => _nameInputController.text = user.name);
+
+  userBloc.userPreviewStream.listen((user) => _currentSettings = user);
 
   Future<File> _pickImage() async {
     return ImagePicker.pickImage(source: ImageSource.gallery).then((file) {

--- a/lib/widgets/breez_avatar_dialog.dart
+++ b/lib/widgets/breez_avatar_dialog.dart
@@ -32,17 +32,11 @@ Widget breezAvatarDialog(BuildContext context, UserProfileBloc userBloc) {
   });
 
   Future<File> _pickImage() async {
-  return ImagePicker.pickImage(source: ImageSource.gallery).then((file) {
-    return ImageCropper.cropImage(
-        sourcePath: file.path,
-        aspectRatio: CropAspectRatio(ratioX: 1.0, ratioY: 1.0));
-  });
-}
-      });
-      return image;
-    } catch (e) {
-      throw e;
-    }
+    return ImagePicker.pickImage(source: ImageSource.gallery).then((file) {
+      return ImageCropper.cropImage(
+          sourcePath: file.path,
+          aspectRatio: CropAspectRatio(ratioX: 1.0, ratioY: 1.0));
+    });
   }
 
   return WillPopScope(

--- a/lib/widgets/breez_avatar_dialog.dart
+++ b/lib/widgets/breez_avatar_dialog.dart
@@ -2,10 +2,12 @@ import 'dart:async';
 
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez/bloc/user_profile/breez_user_model.dart';
+import 'package:breez/bloc/user_profile/user_actions.dart';
 import 'package:breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:breez/theme_data.dart' as theme;
 import 'package:breez/utils/min_font_size.dart';
 import 'package:breez/widgets/breez_avatar.dart';
+import 'package:breez/widgets/flushbar.dart';
 import 'package:flutter/material.dart';
 import 'package:image/image.dart' as DartImage;
 import 'package:image_cropper/image_cropper.dart';
@@ -17,6 +19,7 @@ var _transparentImage = DartImage.Image(scaledWidth, scaledWidth);
 Widget breezAvatarDialog(BuildContext context, UserProfileBloc userBloc) {
   AutoSizeGroup _autoSizeGroup = AutoSizeGroup();
   BreezUserModel _currentSettings;
+  List<int> _imageData;
 
   final _nameInputController = TextEditingController();
   userBloc.userPreviewStream.listen((user) {
@@ -24,7 +27,7 @@ Widget breezAvatarDialog(BuildContext context, UserProfileBloc userBloc) {
     _currentSettings = user;
   });
 
-  Future _pickImage(BuildContext context) async {
+  Future _pickImage(BuildContext context, setState) async {
     return ImagePicker.pickImage(source: ImageSource.gallery).then((file) {
       ImageCropper.cropImage(
         sourcePath: file.path,
@@ -32,126 +35,153 @@ Widget breezAvatarDialog(BuildContext context, UserProfileBloc userBloc) {
       ).then((file) {
         if (file != null) {
           file.readAsBytes().then(scaleAndFormatPNG).then((image) {
-            userBloc.uploadImageSink.add(image);
+            var action = UploadProfilePicture(image);
+            userBloc.userActionsSink.add(action);
+            action.future.then((_) async {
+              setState(() {
+                _imageData = image;
+              });
+            }, onError: (error) {
+              setState(() {
+                //_imageData = null;
+              });
+              return showFlushbar(
+                context,
+                message: "Failed to upload profile picture",
+              );
+            });
           });
         }
       });
     }).catchError((err) {});
   }
 
-  return AlertDialog(
-    titlePadding: EdgeInsets.all(0.0),
-    title: Stack(children: <Widget>[
-      Container(
-        height: 70.0,
-        decoration: ShapeDecoration(
-          shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.vertical(top: Radius.circular(12.0))),
-          color: theme.themeId == "BLUE"
-              ? Theme.of(context).primaryColorDark
-              : Theme.of(context).canvasColor,
-        ),
-      ),
-      Container(
-        width: MediaQuery.of(context).size.width,
-        height: 100.0,
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Expanded(
-              child: FlatButton(
-                padding: EdgeInsets.only(
-                  bottom: 20.0,
-                  top: 26.0,
-                ),
-                child: AutoSizeText(
-                  'RANDOM',
-                  style: theme.whiteButtonStyle,
-                  maxLines: 1,
-                  minFontSize: MinFontSize(context).minFontSize,
-                  stepGranularity: 0.1,
-                  group: _autoSizeGroup,
-                ),
-                onPressed: () {
-                  userBloc.randomizeSink.add(null);
-                  FocusScope.of(context).requestFocus(FocusNode());
-                },
-              ),
+  return StatefulBuilder(
+    builder: (context, setState) {
+      return AlertDialog(
+        titlePadding: EdgeInsets.all(0.0),
+        title: Stack(children: <Widget>[
+          Container(
+            height: 70.0,
+            decoration: ShapeDecoration(
+              shape: RoundedRectangleBorder(
+                  borderRadius:
+                      BorderRadius.vertical(top: Radius.circular(12.0))),
+              color: theme.themeId == "BLUE"
+                  ? Theme.of(context).primaryColorDark
+                  : Theme.of(context).canvasColor,
             ),
-            StreamBuilder<BreezUserModel>(
-                stream: userBloc.userPreviewStream,
-                builder: (context, snapshot) {
-                  if (!snapshot.hasData) {
-                    return Container();
-                  } else {
-                    return Padding(
-                      child: AspectRatio(
-                          aspectRatio: 1,
-                          child: BreezAvatar(snapshot.data.avatarURL,
-                              radius: 44.0)),
-                      padding: EdgeInsets.only(top: 26.0),
-                    );
-                  }
-                }),
-            Expanded(
-              child: FlatButton(
-                padding: EdgeInsets.only(
-                  bottom: 20.0,
-                  top: 26.0,
+          ),
+          Container(
+            width: MediaQuery.of(context).size.width,
+            height: 100.0,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Expanded(
+                  child: FlatButton(
+                    padding: EdgeInsets.only(
+                      bottom: 20.0,
+                      top: 26.0,
+                    ),
+                    child: AutoSizeText(
+                      'RANDOM',
+                      style: theme.whiteButtonStyle,
+                      maxLines: 1,
+                      minFontSize: MinFontSize(context).minFontSize,
+                      stepGranularity: 0.1,
+                      group: _autoSizeGroup,
+                    ),
+                    onPressed: () {
+                      userBloc.randomizeSink.add(null);
+                      _imageData = null;
+                      FocusScope.of(context).requestFocus(FocusNode());
+                    },
+                  ),
                 ),
-                child: AutoSizeText(
-                  'GALLERY',
-                  style: theme.whiteButtonStyle,
-                  maxLines: 1,
-                  minFontSize: MinFontSize(context).minFontSize,
-                  stepGranularity: 0.1,
-                  group: _autoSizeGroup,
+                StreamBuilder<BreezUserModel>(
+                  stream: userBloc.userPreviewStream,
+                  builder: (context, snapshot) {
+                    if (!snapshot.hasData) {
+                      return Container();
+                    } else {
+                      return Padding(
+                        child: AspectRatio(
+                            aspectRatio: 1,
+                            child: BreezAvatar(
+                              snapshot.data.avatarURL,
+                              radius: 36.0,
+                              bytes: _imageData,
+                            )),
+                        padding: EdgeInsets.only(top: 26.0),
+                      );
+                    }
+                  },
                 ),
-                onPressed: () {
-                  _pickImage(context);
-                },
-              ),
+                Expanded(
+                  child: FlatButton(
+                    padding: EdgeInsets.only(
+                      bottom: 20.0,
+                      top: 26.0,
+                    ),
+                    child: AutoSizeText(
+                      'GALLERY',
+                      style: theme.whiteButtonStyle,
+                      maxLines: 1,
+                      minFontSize: MinFontSize(context).minFontSize,
+                      stepGranularity: 0.1,
+                      group: _autoSizeGroup,
+                    ),
+                    onPressed: () {
+                      _pickImage(context, setState);
+                    },
+                  ),
+                ),
+              ],
             ),
-          ],
+          ),
+        ]),
+        content: SingleChildScrollView(
+          child: ListBody(
+            children: <Widget>[
+              Theme(
+                data: ThemeData(
+                    primaryColor:
+                        Theme.of(context).primaryTextTheme.body1.color,
+                    hintColor: Theme.of(context).primaryTextTheme.body1.color),
+                child: TextField(
+                    style: Theme.of(context).primaryTextTheme.body1,
+                    controller: _nameInputController,
+                    decoration: InputDecoration(hintText: 'Enter your name'),
+                    onSubmitted: (text) {}),
+              )
+            ],
+          ),
         ),
-      ),
-    ]),
-    content: SingleChildScrollView(
-      child: ListBody(
-        children: <Widget>[
-          Theme(
-            data: ThemeData(
-                primaryColor: Theme.of(context).primaryTextTheme.body1.color,
-                hintColor: Theme.of(context).primaryTextTheme.body1.color),
-            child: TextField(
-                style: Theme.of(context).primaryTextTheme.body1,
-                controller: _nameInputController,
-                decoration: InputDecoration(hintText: 'Enter your name'),
-                onSubmitted: (text) {}),
-          )
+        actions: <Widget>[
+          FlatButton(
+            child: Text('CANCEL',
+                style: Theme.of(context).primaryTextTheme.button),
+            onPressed: () {
+              Navigator.of(context).pop();
+            },
+          ),
+          FlatButton(
+            child:
+                Text('SAVE', style: Theme.of(context).primaryTextTheme.button),
+            onPressed: () async {
+              userBloc.userSink.add(
+                  _currentSettings.copyWith(name: _nameInputController.text));
+              Navigator.of(context).pop();
+            },
+          ),
         ],
-      ),
-    ),
-    actions: <Widget>[
-      FlatButton(
-        child: Text('CANCEL', style: Theme.of(context).primaryTextTheme.button),
-        onPressed: () {
-          Navigator.of(context).pop();
-        },
-      ),
-      FlatButton(
-        child: Text('SAVE', style: Theme.of(context).primaryTextTheme.button),
-        onPressed: () {
-          userBloc.userSink
-              .add(_currentSettings.copyWith(name: _nameInputController.text));
-          Navigator.of(context).pop();
-        },
-      ),
-    ],
-    shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(
-            bottom: Radius.circular(12.0), top: Radius.circular(13.0))),
+        shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.vertical(
+                bottom: Radius.circular(12.0), top: Radius.circular(13.0))),
+      );
+    },
   );
 }
 

--- a/lib/widgets/breez_avatar_dialog.dart
+++ b/lib/widgets/breez_avatar_dialog.dart
@@ -189,12 +189,11 @@ Widget breezAvatarDialog(BuildContext context, UserProfileBloc userBloc) {
                   style: Theme.of(context).primaryTextTheme.button),
               onPressed: _isUploading
                   ? null
-                  : () async {
+                  : () {
                       setState(() {
                         _isUploading = true;
                       });
-                      await _uploadImage(_pickedImage, userBloc)
-                          .then((uploaded) {
+                      _uploadImage(_pickedImage, userBloc).then((uploaded) {
                         setState(() {
                           _isUploading = false;
                           if (uploaded) {

--- a/lib/widgets/breez_avatar_dialog.dart
+++ b/lib/widgets/breez_avatar_dialog.dart
@@ -7,11 +7,12 @@ import 'package:breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:breez/theme_data.dart' as theme;
 import 'package:breez/utils/min_font_size.dart';
 import 'package:breez/widgets/breez_avatar.dart';
-import 'package:breez/widgets/flushbar.dart';
 import 'package:flutter/material.dart';
 import 'package:image/image.dart' as DartImage;
 import 'package:image_cropper/image_cropper.dart';
 import 'package:image_picker/image_picker.dart';
+
+import 'flushbar.dart';
 
 int scaledWidth = 200;
 var _transparentImage = DartImage.Image(scaledWidth, scaledWidth);
@@ -35,20 +36,8 @@ Widget breezAvatarDialog(BuildContext context, UserProfileBloc userBloc) {
       ).then((file) {
         if (file != null) {
           file.readAsBytes().then(scaleAndFormatPNG).then((image) {
-            var action = UploadProfilePicture(image);
-            userBloc.userActionsSink.add(action);
-            action.future.then((_) async {
-              setState(() {
-                _imageData = image;
-              });
-            }, onError: (error) {
-              setState(() {
-                //_imageData = null;
-              });
-              return showFlushbar(
-                context,
-                message: "Failed to upload profile picture",
-              );
+            setState(() {
+              _imageData = image;
             });
           });
         }
@@ -171,6 +160,21 @@ Widget breezAvatarDialog(BuildContext context, UserProfileBloc userBloc) {
             child:
                 Text('SAVE', style: Theme.of(context).primaryTextTheme.button),
             onPressed: () async {
+              if (_imageData != null) {
+                var action = UploadProfilePicture(_imageData);
+                userBloc.userActionsSink.add(action);
+                await action.future.then((_) async {
+                  Navigator.of(context).pop();
+                }, onError: (error) {
+                  setState(() {
+                    _imageData = null;
+                  });
+                  return showFlushbar(
+                    context,
+                    message: "Failed to upload profile picture",
+                  );
+                });
+              }
               userBloc.userSink.add(
                   _currentSettings.copyWith(name: _nameInputController.text));
               Navigator.of(context).pop();

--- a/lib/widgets/breez_avatar_dialog.dart
+++ b/lib/widgets/breez_avatar_dialog.dart
@@ -16,8 +16,10 @@ import 'flushbar.dart';
 
 int scaledWidth = 200;
 var _transparentImage = DartImage.Image(scaledWidth, scaledWidth);
+enum UPLOAD_STATE { UPLOAD_IN_PROGRESS }
 
 Widget breezAvatarDialog(BuildContext context, UserProfileBloc userBloc) {
+  UPLOAD_STATE _state;
   AutoSizeGroup _autoSizeGroup = AutoSizeGroup();
   BreezUserModel _currentSettings;
   List<int> _imageData;
@@ -45,148 +47,200 @@ Widget breezAvatarDialog(BuildContext context, UserProfileBloc userBloc) {
     }).catchError((err) {});
   }
 
-  return StatefulBuilder(
-    builder: (context, setState) {
-      return AlertDialog(
-        titlePadding: EdgeInsets.all(0.0),
-        title: Stack(children: <Widget>[
-          Container(
-            height: 70.0,
-            decoration: ShapeDecoration(
-              shape: RoundedRectangleBorder(
-                  borderRadius:
-                      BorderRadius.vertical(top: Radius.circular(12.0))),
-              color: theme.themeId == "BLUE"
-                  ? Theme.of(context).primaryColorDark
-                  : Theme.of(context).canvasColor,
+  return WillPopScope(
+    onWillPop: () => _onWillPop(_state),
+    child: StatefulBuilder(
+      builder: (context, setState) {
+        return AlertDialog(
+          titlePadding: EdgeInsets.all(0.0),
+          title: Stack(children: <Widget>[
+            Container(
+              height: 70.0,
+              decoration: ShapeDecoration(
+                shape: RoundedRectangleBorder(
+                    borderRadius:
+                        BorderRadius.vertical(top: Radius.circular(12.0))),
+                color: theme.themeId == "BLUE"
+                    ? Theme.of(context).primaryColorDark
+                    : Theme.of(context).canvasColor,
+              ),
             ),
-          ),
-          Container(
-            width: MediaQuery.of(context).size.width,
-            height: 100.0,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              crossAxisAlignment: CrossAxisAlignment.start,
+            Container(
+              width: MediaQuery.of(context).size.width,
+              height: 100.0,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Expanded(
+                    child: FlatButton(
+                      padding: EdgeInsets.only(
+                        bottom: 20.0,
+                        top: 26.0,
+                      ),
+                      child: AutoSizeText(
+                        'RANDOM',
+                        style: theme.whiteButtonStyle,
+                        maxLines: 1,
+                        minFontSize: MinFontSize(context).minFontSize,
+                        stepGranularity: 0.1,
+                        group: _autoSizeGroup,
+                      ),
+                      onPressed: () {
+                        userBloc.randomizeSink.add(null);
+                        _imageData = null;
+                        FocusScope.of(context).requestFocus(FocusNode());
+                      },
+                    ),
+                  ),
+                  StreamBuilder<BreezUserModel>(
+                    stream: userBloc.userPreviewStream,
+                    builder: (context, snapshot) {
+                      if (!snapshot.hasData) {
+                        return Container();
+                      } else {
+                        if (_state == UPLOAD_STATE.UPLOAD_IN_PROGRESS) {
+                          return Stack(
+                            children: [
+                              Padding(
+                                child: AspectRatio(
+                                  aspectRatio: 1,
+                                  child: CircularProgressIndicator(
+                                    valueColor: AlwaysStoppedAnimation<Color>(
+                                        Theme.of(context)
+                                            .primaryTextTheme
+                                            .button
+                                            .color),
+                                    backgroundColor:
+                                        Theme.of(context).backgroundColor,
+                                  ),
+                                ),
+                                padding: EdgeInsets.only(top: 26.0),
+                              ),
+                              Padding(
+                                child: AspectRatio(
+                                    aspectRatio: 1,
+                                    child: BreezAvatar(
+                                      snapshot.data.avatarURL,
+                                      radius: 36.0,
+                                      bytes: _imageData,
+                                    )),
+                                padding: EdgeInsets.only(top: 26.0),
+                              )
+                            ],
+                          );
+                        }
+                        return Padding(
+                          child: AspectRatio(
+                              aspectRatio: 1,
+                              child: BreezAvatar(
+                                snapshot.data.avatarURL,
+                                radius: 36.0,
+                                bytes: _imageData,
+                              )),
+                          padding: EdgeInsets.only(top: 26.0),
+                        );
+                      }
+                    },
+                  ),
+                  Expanded(
+                    child: FlatButton(
+                      padding: EdgeInsets.only(
+                        bottom: 20.0,
+                        top: 26.0,
+                      ),
+                      child: AutoSizeText(
+                        'GALLERY',
+                        style: theme.whiteButtonStyle,
+                        maxLines: 1,
+                        minFontSize: MinFontSize(context).minFontSize,
+                        stepGranularity: 0.1,
+                        group: _autoSizeGroup,
+                      ),
+                      onPressed: () {
+                        _pickImage(context, setState);
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ]),
+          content: SingleChildScrollView(
+            child: ListBody(
               children: <Widget>[
-                Expanded(
-                  child: FlatButton(
-                    padding: EdgeInsets.only(
-                      bottom: 20.0,
-                      top: 26.0,
-                    ),
-                    child: AutoSizeText(
-                      'RANDOM',
-                      style: theme.whiteButtonStyle,
-                      maxLines: 1,
-                      minFontSize: MinFontSize(context).minFontSize,
-                      stepGranularity: 0.1,
-                      group: _autoSizeGroup,
-                    ),
-                    onPressed: () {
-                      userBloc.randomizeSink.add(null);
-                      _imageData = null;
-                      FocusScope.of(context).requestFocus(FocusNode());
-                    },
-                  ),
-                ),
-                StreamBuilder<BreezUserModel>(
-                  stream: userBloc.userPreviewStream,
-                  builder: (context, snapshot) {
-                    if (!snapshot.hasData) {
-                      return Container();
-                    } else {
-                      return Padding(
-                        child: AspectRatio(
-                            aspectRatio: 1,
-                            child: BreezAvatar(
-                              snapshot.data.avatarURL,
-                              radius: 36.0,
-                              bytes: _imageData,
-                            )),
-                        padding: EdgeInsets.only(top: 26.0),
-                      );
-                    }
-                  },
-                ),
-                Expanded(
-                  child: FlatButton(
-                    padding: EdgeInsets.only(
-                      bottom: 20.0,
-                      top: 26.0,
-                    ),
-                    child: AutoSizeText(
-                      'GALLERY',
-                      style: theme.whiteButtonStyle,
-                      maxLines: 1,
-                      minFontSize: MinFontSize(context).minFontSize,
-                      stepGranularity: 0.1,
-                      group: _autoSizeGroup,
-                    ),
-                    onPressed: () {
-                      _pickImage(context, setState);
-                    },
-                  ),
-                ),
+                Theme(
+                  data: ThemeData(
+                      primaryColor:
+                          Theme.of(context).primaryTextTheme.body1.color,
+                      hintColor:
+                          Theme.of(context).primaryTextTheme.body1.color),
+                  child: TextField(
+                      style: Theme.of(context).primaryTextTheme.body1,
+                      controller: _nameInputController,
+                      decoration: InputDecoration(hintText: 'Enter your name'),
+                      onSubmitted: (text) {}),
+                )
               ],
             ),
           ),
-        ]),
-        content: SingleChildScrollView(
-          child: ListBody(
-            children: <Widget>[
-              Theme(
-                data: ThemeData(
-                    primaryColor:
-                        Theme.of(context).primaryTextTheme.body1.color,
-                    hintColor: Theme.of(context).primaryTextTheme.body1.color),
-                child: TextField(
-                    style: Theme.of(context).primaryTextTheme.body1,
-                    controller: _nameInputController,
-                    decoration: InputDecoration(hintText: 'Enter your name'),
-                    onSubmitted: (text) {}),
-              )
-            ],
-          ),
-        ),
-        actions: <Widget>[
-          FlatButton(
-            child: Text('CANCEL',
-                style: Theme.of(context).primaryTextTheme.button),
-            onPressed: () {
-              Navigator.of(context).pop();
-            },
-          ),
-          FlatButton(
-            child:
-                Text('SAVE', style: Theme.of(context).primaryTextTheme.button),
-            onPressed: () async {
-              if (_imageData != null) {
-                var action = UploadProfilePicture(_imageData);
-                userBloc.userActionsSink.add(action);
-                await action.future.then((_) async {
-                  Navigator.of(context).pop();
-                }, onError: (error) {
+          actions: <Widget>[
+            FlatButton(
+              child: Text('CANCEL',
+                  style: Theme.of(context).primaryTextTheme.button),
+              onPressed: _state == UPLOAD_STATE.UPLOAD_IN_PROGRESS
+                  ? null
+                  : () {
+                      Navigator.of(context).pop();
+                    },
+            ),
+            FlatButton(
+              child: Text('SAVE',
+                  style: Theme.of(context).primaryTextTheme.button),
+              onPressed: () async {
+                if (_imageData != null) {
+                  var action = UploadProfilePicture(_imageData);
+                  userBloc.userActionsSink.add(action);
                   setState(() {
-                    _imageData = null;
+                    _state = UPLOAD_STATE.UPLOAD_IN_PROGRESS;
                   });
-                  return showFlushbar(
-                    context,
-                    message: "Failed to upload profile picture",
-                  );
-                });
-              }
-              userBloc.userSink.add(
-                  _currentSettings.copyWith(name: _nameInputController.text));
-              Navigator.of(context).pop();
-            },
-          ),
-        ],
-        shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.vertical(
-                bottom: Radius.circular(12.0), top: Radius.circular(13.0))),
-      );
-    },
+                  await action.future.then((_) async {
+                    setState(() {
+                      _state = null;
+                    });
+                    Navigator.of(context).pop();
+                  }, onError: (error) {
+                    setState(() {
+                      _imageData = null;
+                      _state = null;
+                    });
+                    return showFlushbar(
+                      context,
+                      message: "Failed to upload profile picture",
+                    );
+                  });
+                }
+                userBloc.userSink.add(
+                    _currentSettings.copyWith(name: _nameInputController.text));
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+          shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.vertical(
+                  bottom: Radius.circular(12.0), top: Radius.circular(13.0))),
+        );
+      },
+    ),
   );
+}
+
+// Do not pop dialog if there's a upload in progress
+Future<bool> _onWillPop(UPLOAD_STATE _state) async {
+  if (_state == UPLOAD_STATE.UPLOAD_IN_PROGRESS) {
+    return false;
+  }
+  return true;
 }
 
 List<int> scaleAndFormatPNG(List<int> imageBytes) {

--- a/lib/widgets/breez_avatar_dialog.dart
+++ b/lib/widgets/breez_avatar_dialog.dart
@@ -221,7 +221,6 @@ Widget breezAvatarDialog(BuildContext context, UserProfileBloc userBloc) {
                       setState(() {
                         _state = null;
                       });
-                      Navigator.of(context).pop();
                     }, onError: (error) {
                       setState(() {
                         _pickedImage = null;

--- a/lib/widgets/breez_avatar_dialog.dart
+++ b/lib/widgets/breez_avatar_dialog.dart
@@ -187,27 +187,30 @@ Widget breezAvatarDialog(BuildContext context, UserProfileBloc userBloc) {
             FlatButton(
               child: Text('SAVE',
                   style: Theme.of(context).primaryTextTheme.button),
-              onPressed: () async {
-                setState(() {
-                  _isUploading = true;
-                });
-                await _uploadImage(_pickedImage, userBloc).then((uploaded) {
-                  setState(() {
-                    _isUploading = false;
-                    if (uploaded) {
-                      userBloc.userSink.add(_currentSettings.copyWith(
-                          name: _nameInputController.text));
-                      Navigator.of(context).pop();
-                    } else {
-                      _pickedImage = null;
-                      showFlushbar(
-                        context,
-                        message: "Failed to upload profile picture",
-                      );
-                    }
-                  });
-                });
-              },
+              onPressed: _isUploading
+                  ? null
+                  : () async {
+                      setState(() {
+                        _isUploading = true;
+                      });
+                      await _uploadImage(_pickedImage, userBloc)
+                          .then((uploaded) {
+                        setState(() {
+                          _isUploading = false;
+                          if (uploaded) {
+                            userBloc.userSink.add(_currentSettings.copyWith(
+                                name: _nameInputController.text));
+                            Navigator.of(context).pop();
+                          } else {
+                            _pickedImage = null;
+                            showFlushbar(
+                              context,
+                              message: "Failed to upload profile picture",
+                            );
+                          }
+                        });
+                      });
+                    },
             ),
           ],
           shape: RoundedRectangleBorder(

--- a/lib/widgets/breez_avatar_dialog.dart
+++ b/lib/widgets/breez_avatar_dialog.dart
@@ -32,18 +32,12 @@ Widget breezAvatarDialog(BuildContext context, UserProfileBloc userBloc) {
   });
 
   Future<File> _pickImage() async {
-    try {
-      File image;
-      await ImagePicker.pickImage(source: ImageSource.gallery)
-          .then((file) async {
-        await ImageCropper.cropImage(
-          sourcePath: file.path,
-          aspectRatio: CropAspectRatio(ratioX: 1.0, ratioY: 1.0),
-        ).then((file) {
-          if (file != null) {
-            image = file;
-          }
-        });
+  return ImagePicker.pickImage(source: ImageSource.gallery).then((file) {
+    return ImageCropper.cropImage(
+        sourcePath: file.path,
+        aspectRatio: CropAspectRatio(ratioX: 1.0, ratioY: 1.0));
+  });
+}
       });
       return image;
     } catch (e) {


### PR DESCRIPTION
This PR addresses [POS-38](https://breeztech.atlassian.net/browse/POS-38).

- Choosing a picture often doesn’t work
    - Out of scope. 
   This is the error related to this problem: ”gRPC Error (8, /breez.Pos/UploadLogo is rejected by ratelimit, please retry later.)”
- Choosing a custom picture causing the circle to look elliptic 
   - Set an aspect ratio of 1:1
- When you choose a picture and cancel, when you open a again, the cancelled data remains in the dialog
   - Profile picture now uploads to server when the user saves, not after selecting the image from gallery
- We need to add loader when choosing a custom picture
   - This is not needed anymore as we pass the preview images bytes directly to BreezAvatar