### PR TITLE
POS Items View - UI Fixes

### DIFF
--- a/lib/bloc/account/add_funds_bloc.dart
+++ b/lib/bloc/account/add_funds_bloc.dart
@@ -106,7 +106,7 @@ class AddFundsBloc extends Bloc {
       String walletAddress = response.address;
       String maxQuoteCurrencyAmount = Currency.BTC.format(
           response.maxAllowedDeposit,
-          includeSymbol: false,
+          includeDisplayName: false,
           fixedDecimals: false);
       moonpayUrl +=
           "&walletAddress=$walletAddress&maxQuoteCurrencyAmount=$maxQuoteCurrencyAmount";

--- a/lib/bloc/account/fiat_conversion.dart
+++ b/lib/bloc/account/fiat_conversion.dart
@@ -37,7 +37,8 @@ class FiatConversion {
     return formatFiat(fiatValue);
   }
 
-  String formatFiat(double fiatAmount, {bool addCurrencyPrefix = true}) {
+  String formatFiat(double fiatAmount,
+      {bool addCurrencyPrefix = true, bool removeTrailingZeros = false}) {
     int fractionSize = this.currencyData.fractionSize;
     double minimumAmount = 1 / (pow(10, fractionSize));
 
@@ -54,6 +55,10 @@ class FiatConversion {
     }
     if (addCurrencyPrefix) {
       formattedAmount = prefix + formattedAmount;
+    }
+    if (removeTrailingZeros) {
+      RegExp removeTrailingZeros = RegExp(r"([.]0*)(?!.*\d)");
+      formattedAmount.replaceAll(removeTrailingZeros, "");
     }
     return formattedAmount;
   }

--- a/lib/bloc/user_profile/currency.dart
+++ b/lib/bloc/user_profile/currency.dart
@@ -18,9 +18,13 @@ class Currency extends Object {
   }
 
   String format(Int64 sat,
-          {includeSymbol = true, fixedDecimals = true, userInput = false}) =>
+          {includeDisplayName = true,
+          fixedDecimals = true,
+          userInput = false,
+          bool useSymbol = false}) =>
       _CurrencyFormatter().format(sat, this,
-          addCurrencySuffix: includeSymbol,
+          addCurrencySuffix: includeDisplayName,
+          useSymbol: useSymbol,
           fixedDecimals: fixedDecimals,
           userInput: userInput);
 
@@ -59,6 +63,7 @@ class _CurrencyFormatter {
 
   String format(satoshies, Currency currency,
       {bool addCurrencySuffix = true,
+      bool useSymbol = false,
       fixedDecimals = true,
       userInput = false}) {
     String formattedAmount = formatter.format(satoshies);
@@ -75,7 +80,8 @@ class _CurrencyFormatter {
         break;
     }
     if (addCurrencySuffix) {
-      formattedAmount += ' ${currency.displayName}';
+      formattedAmount +=
+          ' ${useSymbol ? currency.symbol : currency.displayName}';
     }
 
     if (userInput) {

--- a/lib/bloc/user_profile/currency.dart
+++ b/lib/bloc/user_profile/currency.dart
@@ -32,7 +32,7 @@ class Currency extends Object {
 
   Int64 toSats(double amount) => _CurrencyFormatter().toSats(amount, this);
 
-  String get displayName => symbol == "Sat" ? "sats" : symbol;
+  String get displayName => symbol.toLowerCase() == "sat" ? "sats" : symbol;
 }
 
 class _CurrencyFormatter {

--- a/lib/bloc/user_profile/currency.dart
+++ b/lib/bloc/user_profile/currency.dart
@@ -8,13 +8,15 @@ enum CurrencyID { BTC, SAT }
 class Currency extends Object {
   final String symbol;
   static const Currency BTC = Currency._internal("BTC");
-  static const Currency SAT = Currency._internal("Sat");
+  static const Currency SAT = Currency._internal("SAT");
   static final List<Currency> currencies = List.unmodifiable([BTC, SAT]);
 
   const Currency._internal(this.symbol);
 
   factory Currency.fromSymbol(String symbol) {
-    return currencies.firstWhere((c) => c.symbol == symbol, orElse: () => null);
+    return currencies.firstWhere(
+        (c) => c.symbol.toUpperCase() == symbol.toUpperCase(),
+        orElse: () => null);
   }
 
   String format(Int64 sat,

--- a/lib/bloc/user_profile/currency.dart
+++ b/lib/bloc/user_profile/currency.dart
@@ -21,12 +21,14 @@ class Currency extends Object {
           {includeDisplayName = true,
           fixedDecimals = true,
           userInput = false,
-          bool useSymbol = false}) =>
+          bool useSymbol = false,
+          bool removeTrailingZeros = false}) =>
       _CurrencyFormatter().format(sat, this,
           addCurrencySuffix: includeDisplayName,
           useSymbol: useSymbol,
           fixedDecimals: fixedDecimals,
-          userInput: userInput);
+          userInput: userInput,
+          removeTrailingZeros: removeTrailingZeros);
 
   Int64 parse(String amountStr) => _CurrencyFormatter().parse(amountStr, this);
 
@@ -65,7 +67,8 @@ class _CurrencyFormatter {
       {bool addCurrencySuffix = true,
       bool useSymbol = false,
       fixedDecimals = true,
-      userInput = false}) {
+      userInput = false,
+      removeTrailingZeros = false}) {
     String formattedAmount = formatter.format(satoshies);
     switch (currency) {
       case Currency.BTC:
@@ -86,6 +89,11 @@ class _CurrencyFormatter {
 
     if (userInput) {
       return formattedAmount.replaceAll(RegExp(r"\s+\b|\b\s"), "");
+    }
+
+    if (removeTrailingZeros) {
+      RegExp removeTrailingZeros = RegExp(r"([.]0*)(?!.*\d)");
+      formattedAmount.replaceAll(removeTrailingZeros, "");
     }
 
     return formattedAmount;

--- a/lib/bloc/user_profile/currency.dart
+++ b/lib/bloc/user_profile/currency.dart
@@ -19,18 +19,18 @@ class Currency extends Object {
         orElse: () => null);
   }
 
-  String format(Int64 sat,
-          {includeDisplayName = true,
-          fixedDecimals = true,
-          userInput = false,
-          bool useSymbol = false,
-          bool removeTrailingZeros = false}) =>
+  String format(
+    Int64 sat, {
+    includeDisplayName = true,
+    fixedDecimals = true,
+    userInput = false,
+    bool useSymbol = false,
+  }) =>
       _CurrencyFormatter().format(sat, this,
           addCurrencySuffix: includeDisplayName,
           useSymbol: useSymbol,
           fixedDecimals: fixedDecimals,
-          userInput: userInput,
-          removeTrailingZeros: removeTrailingZeros);
+          userInput: userInput);
 
   Int64 parse(String amountStr) => _CurrencyFormatter().parse(amountStr, this);
 
@@ -69,15 +69,18 @@ class _CurrencyFormatter {
       {bool addCurrencySuffix = true,
       bool useSymbol = false,
       fixedDecimals = true,
-      userInput = false,
-      removeTrailingZeros = false}) {
+      userInput = false}) {
     String formattedAmount = formatter.format(satoshies);
     switch (currency) {
       case Currency.BTC:
+        double amountInBTC = (satoshies.toInt() / 100000000);
         if (fixedDecimals) {
-          formattedAmount = (satoshies.toInt() / 100000000).toStringAsFixed(8);
+          formattedAmount = amountInBTC.toStringAsFixed(8);
         } else {
-          formattedAmount = (satoshies.toInt() / 100000000).toString();
+          // #.0* should be displayed without trailing zeros
+          formattedAmount = amountInBTC.truncateToDouble() == amountInBTC
+              ? amountInBTC.toStringAsFixed(0)
+              : amountInBTC.toString();
         }
         break;
       case Currency.SAT:
@@ -91,11 +94,6 @@ class _CurrencyFormatter {
 
     if (userInput) {
       return formattedAmount.replaceAll(RegExp(r"\s+\b|\b\s"), "");
-    }
-
-    if (removeTrailingZeros) {
-      RegExp removeTrailingZeros = RegExp(r"([.]0*)(?!.*\d)");
-      formattedAmount.replaceAll(removeTrailingZeros, "");
     }
 
     return formattedAmount;

--- a/lib/routes/add_funds/deposit_to_btc_address_page.dart
+++ b/lib/routes/add_funds/deposit_to_btc_address_page.dart
@@ -134,7 +134,7 @@ class DepositToBTCAddressPageState extends State<DepositToBTCAddressPage> {
                     child: Text(
                       "Send up to " +
                           account.currency.format(response.maxAllowedDeposit,
-                              includeSymbol: true) +
+                              includeDisplayName: true) +
                           " to this address.",
                       style: Theme.of(context).textTheme.display1,
                       textAlign: TextAlign.center,

--- a/lib/routes/charge/items/catalog_item.dart
+++ b/lib/routes/charge/items/catalog_item.dart
@@ -25,7 +25,7 @@ class CatalogItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.all(8.0),
+      padding: const EdgeInsets.fromLTRB(0, 8, 8, 8),
       child: Stack(alignment: Alignment.bottomCenter, children: <Widget>[
         Slidable(
           actionPane: SlidableDrawerActionPane(),

--- a/lib/routes/charge/items/catalog_item.dart
+++ b/lib/routes/charge/items/catalog_item.dart
@@ -36,8 +36,7 @@ class CatalogItem extends StatelessWidget {
             onTap: () {
               DeleteItem deleteItem = DeleteItem(_itemInfo.id);
               posCatalogBloc.actionsSink.add(deleteItem);
-              deleteItem.future.then((_) {},
-                  onError: (err) => showFlushbar(context,
+              deleteItem.future.catchError((err) => showFlushbar(context,
                       message: "Failed to delete ${_itemInfo.name}"));
             },
           ),

--- a/lib/routes/charge/items/catalog_item.dart
+++ b/lib/routes/charge/items/catalog_item.dart
@@ -24,26 +24,27 @@ class CatalogItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(0, 8, 8, 8),
-      child: Stack(alignment: Alignment.bottomCenter, children: <Widget>[
-        Slidable(
-          actionPane: SlidableDrawerActionPane(),
-          actionExtentRatio: 0.25,
-          secondaryActions: <Widget>[
-            IconSlideAction(
-              color: Colors.red,
-              icon: Icons.delete_forever,
-              onTap: () {
-                DeleteItem deleteItem = DeleteItem(_itemInfo.id);
-                posCatalogBloc.actionsSink.add(deleteItem);
-                deleteItem.future.then((_) {},
-                    onError: (err) => showFlushbar(context,
-                        message: "Failed to delete ${_itemInfo.name}"));
-              },
-            ),
-          ],
-          key: Key(_itemInfo.id.toString()),
+    return Stack(alignment: Alignment.bottomCenter, children: <Widget>[
+      Slidable(
+        actionPane: SlidableDrawerActionPane(),
+        actionExtentRatio: 0.25,
+        secondaryActions: <Widget>[
+          IconSlideAction(
+            foregroundColor: Colors.white,
+            color: Theme.of(context).primaryColorLight,
+            icon: Icons.delete_forever,
+            onTap: () {
+              DeleteItem deleteItem = DeleteItem(_itemInfo.id);
+              posCatalogBloc.actionsSink.add(deleteItem);
+              deleteItem.future.then((_) {},
+                  onError: (err) => showFlushbar(context,
+                      message: "Failed to delete ${_itemInfo.name}"));
+            },
+          ),
+        ],
+        key: Key(_itemInfo.id.toString()),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(0, 8, 8, 8),
           child: ListTile(
             leading: _buildCatalogItemAvatar(),
             title: Text(
@@ -71,15 +72,15 @@ class CatalogItem extends StatelessWidget {
             },
           ),
         ),
-        Divider(
-          height: 0.0,
-          color: _lastItem
-              ? Color.fromRGBO(255, 255, 255, 0.0)
-              : Color.fromRGBO(255, 255, 255, 0.12),
-          indent: 72.0,
-        ),
-      ]),
-    );
+      ),
+      Divider(
+        height: 0.0,
+        color: _lastItem
+            ? Color.fromRGBO(255, 255, 255, 0.0)
+            : Color.fromRGBO(255, 255, 255, 0.12),
+        indent: 72.0,
+      ),
+    ]);
   }
 
   String _formattedPrice({bool userInput = false, bool includeSymbol = true}) {

--- a/lib/routes/charge/items/catalog_item.dart
+++ b/lib/routes/charge/items/catalog_item.dart
@@ -32,7 +32,6 @@ class CatalogItem extends StatelessWidget {
           actionExtentRatio: 0.25,
           secondaryActions: <Widget>[
             IconSlideAction(
-              caption: 'Delete',
               color: Colors.red,
               icon: Icons.delete_forever,
               onTap: () {

--- a/lib/routes/charge/items/catalog_item.dart
+++ b/lib/routes/charge/items/catalog_item.dart
@@ -86,7 +86,7 @@ class CatalogItem extends StatelessWidget {
     if (Currency.fromSymbol(_itemInfo.currency) != null) {
       var currency = Currency.fromSymbol(_itemInfo.currency);
       return currency.format(currency.toSats(_itemInfo.price),
-          fixedDecimals: false, useSymbol: true, removeTrailingZeros: true);
+          fixedDecimals: false, useSymbol: true);
     } else {
       return accountModel
           .getFiatCurrencyByShortName(_itemInfo.currency)

--- a/lib/routes/charge/items/catalog_item.dart
+++ b/lib/routes/charge/items/catalog_item.dart
@@ -24,60 +24,63 @@ class CatalogItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Stack(alignment: Alignment.bottomCenter, children: <Widget>[
-      Slidable(
-        actionPane: SlidableDrawerActionPane(),
-        actionExtentRatio: 0.25,
-        secondaryActions: <Widget>[
-          IconSlideAction(
-            caption: 'Delete',
-            color: Colors.red,
-            icon: Icons.delete_forever,
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Stack(alignment: Alignment.bottomCenter, children: <Widget>[
+        Slidable(
+          actionPane: SlidableDrawerActionPane(),
+          actionExtentRatio: 0.25,
+          secondaryActions: <Widget>[
+            IconSlideAction(
+              caption: 'Delete',
+              color: Colors.red,
+              icon: Icons.delete_forever,
+              onTap: () {
+                DeleteItem deleteItem = DeleteItem(_itemInfo.id);
+                posCatalogBloc.actionsSink.add(deleteItem);
+                deleteItem.future.then((_) {},
+                    onError: (err) => showFlushbar(context,
+                        message: "Failed to delete ${_itemInfo.name}"));
+              },
+            ),
+          ],
+          key: Key(_itemInfo.id.toString()),
+          child: ListTile(
+            leading: _buildCatalogItemAvatar(),
+            title: Text(
+              _itemInfo.name,
+              style: theme.transactionTitleStyle,
+              overflow: TextOverflow.ellipsis,
+            ),
+            trailing: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: <Widget>[
+                Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: <Widget>[
+                      Text(
+                        _formattedPrice(),
+                        style: theme.transactionAmountStyle,
+                      )
+                    ]),
+              ],
+            ),
             onTap: () {
-              DeleteItem deleteItem = DeleteItem(_itemInfo.id);
-              posCatalogBloc.actionsSink.add(deleteItem);
-              deleteItem.future.then((_) {},
-                  onError: (err) => showFlushbar(context,
-                      message: "Failed to delete ${_itemInfo.name}"));
+              _addItem(accountModel, _itemInfo.currency, _itemPriceInSat());
             },
           ),
-        ],
-        key: Key(_itemInfo.id.toString()),
-        child: ListTile(
-          leading: _buildCatalogItemAvatar(),
-          title: Text(
-            _itemInfo.name,
-            style: theme.transactionTitleStyle,
-            overflow: TextOverflow.ellipsis,
-          ),
-          trailing: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: <Widget>[
-              Row(
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: <Widget>[
-                    Text(
-                      _formattedPrice(),
-                      style: theme.transactionAmountStyle,
-                    )
-                  ]),
-            ],
-          ),
-          onTap: () {
-            _addItem(accountModel, _itemInfo.currency, _itemPriceInSat());
-          },
         ),
-      ),
-      Divider(
-        height: 0.0,
-        color: _lastItem
-            ? Color.fromRGBO(255, 255, 255, 0.0)
-            : Color.fromRGBO(255, 255, 255, 0.12),
-        indent: 72.0,
-      ),
-    ]);
+        Divider(
+          height: 0.0,
+          color: _lastItem
+              ? Color.fromRGBO(255, 255, 255, 0.0)
+              : Color.fromRGBO(255, 255, 255, 0.12),
+          indent: 72.0,
+        ),
+      ]),
+    );
   }
 
   String _formattedPrice({bool userInput = false, bool includeSymbol = true}) {

--- a/lib/routes/charge/items/catalog_item.dart
+++ b/lib/routes/charge/items/catalog_item.dart
@@ -85,7 +85,8 @@ class CatalogItem extends StatelessWidget {
     if (Currency.fromSymbol(_itemInfo.currency) != null) {
       var currency = Currency.fromSymbol(_itemInfo.currency);
       return currency
-          .format(currency.toSats(_itemInfo.price), fixedDecimals: false)
+          .format(currency.toSats(_itemInfo.price),
+              fixedDecimals: false, useSymbol: true)
           .replaceAll(removeTrailingZeros, "");
     } else {
       return accountModel

--- a/lib/routes/charge/items/catalog_item.dart
+++ b/lib/routes/charge/items/catalog_item.dart
@@ -81,13 +81,17 @@ class CatalogItem extends StatelessWidget {
   }
 
   String _formattedPrice({bool userInput = false, bool includeSymbol = true}) {
+    RegExp removeTrailingZeros = RegExp(r"([.]0*)(?!.*\d)");
     if (Currency.fromSymbol(_itemInfo.currency) != null) {
       var currency = Currency.fromSymbol(_itemInfo.currency);
-      return currency.format(currency.toSats(_itemInfo.price));
+      return currency
+          .format(currency.toSats(_itemInfo.price), fixedDecimals: false)
+          .replaceAll(removeTrailingZeros, "");
     } else {
       return accountModel
           .getFiatCurrencyByShortName(_itemInfo.currency)
-          .formatFiat(_itemInfo.price);
+          .formatFiat(_itemInfo.price)
+          .replaceAll(removeTrailingZeros, "");
     }
   }
 

--- a/lib/routes/charge/items/catalog_item.dart
+++ b/lib/routes/charge/items/catalog_item.dart
@@ -36,9 +36,7 @@ class CatalogItem extends StatelessWidget {
             onTap: () {
               DeleteItem deleteItem = DeleteItem(_itemInfo.id);
               posCatalogBloc.actionsSink.add(deleteItem);
-              deleteItem.future.then(
-                  (_) => showFlushbar(context,
-                      message: "${_itemInfo.name} is successfully deleted"),
+              deleteItem.future.then((_) {},
                   onError: (err) => showFlushbar(context,
                       message: "Failed to delete ${_itemInfo.name}"));
             },

--- a/lib/routes/charge/items/catalog_item.dart
+++ b/lib/routes/charge/items/catalog_item.dart
@@ -37,7 +37,7 @@ class CatalogItem extends StatelessWidget {
               DeleteItem deleteItem = DeleteItem(_itemInfo.id);
               posCatalogBloc.actionsSink.add(deleteItem);
               deleteItem.future.catchError((err) => showFlushbar(context,
-                      message: "Failed to delete ${_itemInfo.name}"));
+                  message: "Failed to delete ${_itemInfo.name}"));
             },
           ),
         ],
@@ -83,18 +83,14 @@ class CatalogItem extends StatelessWidget {
   }
 
   String _formattedPrice({bool userInput = false, bool includeSymbol = true}) {
-    RegExp removeTrailingZeros = RegExp(r"([.]0*)(?!.*\d)");
     if (Currency.fromSymbol(_itemInfo.currency) != null) {
       var currency = Currency.fromSymbol(_itemInfo.currency);
-      return currency
-          .format(currency.toSats(_itemInfo.price),
-              fixedDecimals: false, useSymbol: true)
-          .replaceAll(removeTrailingZeros, "");
+      return currency.format(currency.toSats(_itemInfo.price),
+          fixedDecimals: false, useSymbol: true, removeTrailingZeros: true);
     } else {
       return accountModel
           .getFiatCurrencyByShortName(_itemInfo.currency)
-          .formatFiat(_itemInfo.price)
-          .replaceAll(removeTrailingZeros, "");
+          .formatFiat(_itemInfo.price, removeTrailingZeros: true);
     }
   }
 

--- a/lib/routes/charge/items/create_item.dart
+++ b/lib/routes/charge/items/create_item.dart
@@ -160,7 +160,7 @@ class CreateItemPageState extends State<CreateItemPage> {
                                                 return DropdownMenuItem<String>(
                                                   value: value.symbol,
                                                   child: Text(
-                                                    value.symbol.toUpperCase(),
+                                                    value.symbol,
                                                     style: theme.FieldTextStyle
                                                         .textStyle
                                                         .copyWith(

--- a/lib/routes/charge/items/create_item.dart
+++ b/lib/routes/charge/items/create_item.dart
@@ -231,7 +231,8 @@ class CreateItemPageState extends State<CreateItemPage> {
         ? _selectedFiatCurrency.formatFiat(double.parse(_priceController.text),
             addCurrencyPrefix: false)
         : _selectedCurrency.format(
-            _selectedCurrency.parse(_priceController.text),
+            _selectedCurrency.toSats(double.parse(_priceController.text)),
+            fixedDecimals: false,
             includeDisplayName: false,
             userInput: true);
   }

--- a/lib/routes/charge/items/create_item.dart
+++ b/lib/routes/charge/items/create_item.dart
@@ -9,7 +9,6 @@ import 'package:breez/bloc/pos_catalog/model.dart';
 import 'package:breez/bloc/user_profile/currency.dart';
 import 'package:breez/theme_data.dart' as theme;
 import 'package:breez/widgets/back_button.dart' as backBtn;
-import 'package:breez/widgets/breez_dropdown.dart';
 import 'package:breez/widgets/flushbar.dart';
 import 'package:breez/widgets/single_button_bottom_bar.dart';
 import 'package:flutter/material.dart';
@@ -64,7 +63,7 @@ class CreateItemPageState extends State<CreateItemPage> {
       ListView(
         children: <Widget>[
           Padding(
-            padding: EdgeInsets.only(left: 16.0, right: 16.0),
+            padding: EdgeInsets.only(top: 16, left: 16.0, right: 16.0),
             child: Form(
               key: _formKey,
               child: Column(
@@ -75,7 +74,8 @@ class CreateItemPageState extends State<CreateItemPage> {
                       textCapitalization: TextCapitalization.words,
                       controller: _nameController,
                       decoration: InputDecoration(
-                          hintText: "Item Name",
+                          labelText: "Item Name",
+                          hintText: "Enter an item name",
                           border: UnderlineInputBorder()),
                       validator: (value) {
                         if (value.length == 0) {
@@ -114,7 +114,8 @@ class CreateItemPageState extends State<CreateItemPage> {
                                         ],
                               controller: _priceController,
                               decoration: InputDecoration(
-                                  hintText: "Item Price",
+                                  labelText: "Item Price",
+                                  hintText: "Enter an item price",
                                   border: UnderlineInputBorder()),
                               validator: (value) {
                                 if (value.length == 0) {
@@ -139,79 +140,56 @@ class CreateItemPageState extends State<CreateItemPage> {
                                           return Container();
                                         }
 
-                                        return DropdownButtonHideUnderline(
-                                          child: ButtonTheme(
-                                            alignedDropdown: true,
-                                            child: Expanded(
-                                              flex: 4,
-                                              child: InputDecorator(
-                                                decoration: InputDecoration(
-                                                  labelText: 'Currency',
-                                                  contentPadding:
-                                                      EdgeInsets.symmetric(
-                                                          vertical: 2.6),
-                                                ),
-                                                child: BreezDropdownButton(
-                                                    isDense: true,
-                                                    onChanged: (value) =>
-                                                        _changeCurrency(
-                                                            account, value),
-                                                    iconEnabledColor:
-                                                        Theme.of(context)
-                                                            .accentColor,
-                                                    value: _currencySymbol(),
+                                        return Expanded(
+                                          flex: 4,
+                                          child: DropdownButtonHideUnderline(
+                                            child: DropdownButtonFormField(
+                                              isDense: true,
+                                              decoration: InputDecoration(
+                                                labelText: 'Currency',
+                                                contentPadding:
+                                                    EdgeInsets.symmetric(
+                                                        vertical: 10.6),
+                                              ),
+                                              value: _currencySymbol(),
+                                              onChanged: (value) =>
+                                                  _changeCurrency(
+                                                      account, value),
+                                              items: Currency.currencies.map(
+                                                  (Currency value) {
+                                                return DropdownMenuItem<String>(
+                                                  value: value.symbol,
+                                                  child: Text(
+                                                    value.displayName,
                                                     style: theme.FieldTextStyle
                                                         .textStyle
                                                         .copyWith(
                                                             color: Theme.of(
                                                                     context)
                                                                 .accentColor),
-                                                    items: Currency.currencies
-                                                        .map((Currency value) {
-                                                      return DropdownMenuItem<
-                                                          String>(
-                                                        value: value.symbol,
-                                                        child: Text(
-                                                          value.displayName,
-                                                          textAlign:
-                                                              TextAlign.right,
-                                                          style: theme
-                                                              .FieldTextStyle
-                                                              .textStyle
-                                                              .copyWith(
-                                                                  color: Theme.of(
-                                                                          context)
-                                                                      .accentColor),
-                                                        ),
-                                                      );
-                                                    }).toList()
-                                                          ..addAll(
-                                                            account
-                                                                .fiatConversionList
-                                                                .map(
-                                                                    (FiatConversion
-                                                                        fiat) {
-                                                              return new DropdownMenuItem<
-                                                                  String>(
-                                                                value: fiat
-                                                                    .currencyData
-                                                                    .shortName,
-                                                                child: new Text(
-                                                                  fiat.currencyData
-                                                                      .shortName,
-                                                                  textAlign:
-                                                                      TextAlign
-                                                                          .right,
-                                                                  style: theme
-                                                                      .invoiceAmountStyle
-                                                                      .copyWith(
-                                                                          color:
-                                                                              Theme.of(context).accentColor),
-                                                                ),
-                                                              );
-                                                            }).toList(),
-                                                          )),
-                                              ),
+                                                  ),
+                                                );
+                                              }).toList()
+                                                ..addAll(account
+                                                    .fiatConversionList
+                                                    .map((FiatConversion fiat) {
+                                                  return new DropdownMenuItem<
+                                                      String>(
+                                                    value: fiat
+                                                        .currencyData.shortName,
+                                                    child: new Text(
+                                                      fiat.currencyData
+                                                          .shortName,
+                                                      style: theme
+                                                          .FieldTextStyle
+                                                          .textStyle
+                                                          .copyWith(
+                                                              color: Theme.of(
+                                                                      context)
+                                                                  .accentColor),
+                                                    ),
+                                                  );
+                                                }).toList()),
                                             ),
                                           ),
                                         );

--- a/lib/routes/charge/items/create_item.dart
+++ b/lib/routes/charge/items/create_item.dart
@@ -232,7 +232,7 @@ class CreateItemPageState extends State<CreateItemPage> {
             addCurrencyPrefix: false)
         : _selectedCurrency.format(
             _selectedCurrency.parse(_priceController.text),
-            includeSymbol: false,
+            includeDisplayName: false,
             userInput: true);
   }
 

--- a/lib/routes/charge/items/create_item.dart
+++ b/lib/routes/charge/items/create_item.dart
@@ -103,10 +103,10 @@ class CreateItemPageState extends State<CreateItemPage> {
                                               : RegExp(
                                                   "^\\d+\\.?\\d{0,${_selectedFiatCurrency.currencyData.fractionSize ?? 2}}"))
                                     ]
-                                  : _selectedCurrency != Currency.SAT
+                                  : _selectedCurrency == Currency.BTC
                                       ? [
                                           WhitelistingTextInputFormatter(
-                                              RegExp(r'\d+\.?\d*'))
+                                              RegExp("^\\d+\\.?\\d{0,8}"))
                                         ]
                                       : [
                                           WhitelistingTextInputFormatter

--- a/lib/routes/charge/items/create_item.dart
+++ b/lib/routes/charge/items/create_item.dart
@@ -237,7 +237,7 @@ class CreateItemPageState extends State<CreateItemPage> {
         backgroundColor: Theme.of(context).canvasColor,
         leading: backBtn.BackButton(),
         title: Text(
-          "Create Item",
+          "Add Item",
           style: Theme.of(context).appBarTheme.textTheme.title,
         ),
         actions: actions == null ? <Widget>[] : actions,

--- a/lib/routes/charge/items/create_item.dart
+++ b/lib/routes/charge/items/create_item.dart
@@ -160,7 +160,7 @@ class CreateItemPageState extends State<CreateItemPage> {
                                                 return DropdownMenuItem<String>(
                                                   value: value.symbol,
                                                   child: Text(
-                                                    value.displayName,
+                                                    value.symbol.toUpperCase(),
                                                     style: theme.FieldTextStyle
                                                         .textStyle
                                                         .copyWith(

--- a/lib/routes/charge/items/create_item.dart
+++ b/lib/routes/charge/items/create_item.dart
@@ -75,120 +75,150 @@ class CreateItemPageState extends State<CreateItemPage> {
                       textCapitalization: TextCapitalization.words,
                       controller: _nameController,
                       decoration: InputDecoration(
-                          hintText: "Name", border: UnderlineInputBorder()),
+                          hintText: "Item Name",
+                          border: UnderlineInputBorder()),
                       validator: (value) {
                         if (value.length == 0) {
-                          return "Name is required";
+                          return "Item Name is required";
                         }
                       }),
-                  Row(
-                    children: <Widget>[
-                      Expanded(
-                        child: TextFormField(
-                            keyboardType:
-                                TextInputType.numberWithOptions(decimal: true),
-                            inputFormatters: _isFiat
-                                ? [
-                                    WhitelistingTextInputFormatter(
-                                        _selectedFiatCurrency.currencyData
-                                                    .fractionSize ==
-                                                0
-                                            ? RegExp(r'\d+')
-                                            : RegExp(
-                                                "^\\d+\\.?\\d{0,${_selectedFiatCurrency.currencyData.fractionSize ?? 2}}"))
-                                  ]
-                                : _selectedCurrency != Currency.SAT
-                                    ? [
-                                        WhitelistingTextInputFormatter(
-                                            RegExp(r'\d+\.?\d*'))
-                                      ]
-                                    : [
-                                        WhitelistingTextInputFormatter
-                                            .digitsOnly
-                                      ],
-                            controller: _priceController,
-                            decoration: InputDecoration(
-                                hintText: "Price",
-                                border: UnderlineInputBorder()),
-                            validator: (value) {
-                              if (value.length == 0) {
-                                return "Price is required";
-                              }
-                            }),
-                      ),
-                      Theme(
-                          data: Theme.of(context).copyWith(
-                              canvasColor: Theme.of(context).canvasColor),
-                          child: new StreamBuilder<AccountSettings>(
-                              stream: _accountBloc.accountSettingsStream,
-                              builder: (settingCtx, settingSnapshot) {
-                                return StreamBuilder<AccountModel>(
-                                    stream: _accountBloc.accountStream,
-                                    builder: (context, snapshot) {
-                                      AccountModel account = snapshot.data;
-                                      if (!snapshot.hasData) {
-                                        return Container();
-                                      }
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8.0),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: <Widget>[
+                        Expanded(
+                          flex: 10,
+                          child: TextFormField(
+                              keyboardType: TextInputType.numberWithOptions(
+                                  decimal: true),
+                              inputFormatters: _isFiat
+                                  ? [
+                                      WhitelistingTextInputFormatter(
+                                          _selectedFiatCurrency.currencyData
+                                                      .fractionSize ==
+                                                  0
+                                              ? RegExp(r'\d+')
+                                              : RegExp(
+                                                  "^\\d+\\.?\\d{0,${_selectedFiatCurrency.currencyData.fractionSize ?? 2}}"))
+                                    ]
+                                  : _selectedCurrency != Currency.SAT
+                                      ? [
+                                          WhitelistingTextInputFormatter(
+                                              RegExp(r'\d+\.?\d*'))
+                                        ]
+                                      : [
+                                          WhitelistingTextInputFormatter
+                                              .digitsOnly
+                                        ],
+                              controller: _priceController,
+                              decoration: InputDecoration(
+                                  hintText: "Item Price",
+                                  border: UnderlineInputBorder()),
+                              validator: (value) {
+                                if (value.length == 0) {
+                                  return "Item Price is required";
+                                }
+                              }),
+                        ),
+                        SizedBox(
+                          width: 8.0,
+                        ),
+                        Theme(
+                            data: Theme.of(context).copyWith(
+                                canvasColor: Theme.of(context).canvasColor),
+                            child: new StreamBuilder<AccountSettings>(
+                                stream: _accountBloc.accountSettingsStream,
+                                builder: (settingCtx, settingSnapshot) {
+                                  return StreamBuilder<AccountModel>(
+                                      stream: _accountBloc.accountStream,
+                                      builder: (context, snapshot) {
+                                        AccountModel account = snapshot.data;
+                                        if (!snapshot.hasData) {
+                                          return Container();
+                                        }
 
-                                      return DropdownButtonHideUnderline(
-                                        child: ButtonTheme(
-                                          alignedDropdown: true,
-                                          child: BreezDropdownButton(
-                                              onChanged: (value) =>
-                                                  _changeCurrency(
-                                                      account, value),
-                                              iconEnabledColor:
-                                                  Theme.of(context).accentColor,
-                                              value: _currencySymbol(),
-                                              style: theme.invoiceAmountStyle
-                                                  .copyWith(
-                                                      color: Theme.of(context)
-                                                          .accentColor),
-                                              items: Currency.currencies
-                                                  .map((Currency value) {
-                                                return DropdownMenuItem<String>(
-                                                  value: value.symbol,
-                                                  child: Text(
-                                                    value.displayName,
-                                                    textAlign: TextAlign.right,
-                                                    style: theme
-                                                        .invoiceAmountStyle
+                                        return DropdownButtonHideUnderline(
+                                          child: ButtonTheme(
+                                            alignedDropdown: true,
+                                            child: Expanded(
+                                              flex: 4,
+                                              child: InputDecorator(
+                                                decoration: InputDecoration(
+                                                  labelText: 'Currency',
+                                                  contentPadding:
+                                                      EdgeInsets.symmetric(
+                                                          vertical: 2.6),
+                                                ),
+                                                child: BreezDropdownButton(
+                                                    isDense: true,
+                                                    onChanged: (value) =>
+                                                        _changeCurrency(
+                                                            account, value),
+                                                    iconEnabledColor:
+                                                        Theme.of(context)
+                                                            .accentColor,
+                                                    value: _currencySymbol(),
+                                                    style: theme.FieldTextStyle
+                                                        .textStyle
                                                         .copyWith(
                                                             color: Theme.of(
                                                                     context)
                                                                 .accentColor),
-                                                  ),
-                                                );
-                                              }).toList()
-                                                    ..addAll(
-                                                      account.fiatConversionList
-                                                          .map((FiatConversion
-                                                              fiat) {
-                                                        return new DropdownMenuItem<
-                                                            String>(
-                                                          value: fiat
-                                                              .currencyData
-                                                              .shortName,
-                                                          child: new Text(
-                                                            fiat.currencyData
-                                                                .shortName,
-                                                            textAlign:
-                                                                TextAlign.right,
-                                                            style: theme
-                                                                .invoiceAmountStyle
-                                                                .copyWith(
-                                                                    color: Theme.of(
-                                                                            context)
-                                                                        .accentColor),
-                                                          ),
-                                                        );
-                                                      }).toList(),
-                                                    )),
-                                        ),
-                                      );
-                                    });
-                              })),
-                    ],
+                                                    items: Currency.currencies
+                                                        .map((Currency value) {
+                                                      return DropdownMenuItem<
+                                                          String>(
+                                                        value: value.symbol,
+                                                        child: Text(
+                                                          value.displayName,
+                                                          textAlign:
+                                                              TextAlign.right,
+                                                          style: theme
+                                                              .FieldTextStyle
+                                                              .textStyle
+                                                              .copyWith(
+                                                                  color: Theme.of(
+                                                                          context)
+                                                                      .accentColor),
+                                                        ),
+                                                      );
+                                                    }).toList()
+                                                          ..addAll(
+                                                            account
+                                                                .fiatConversionList
+                                                                .map(
+                                                                    (FiatConversion
+                                                                        fiat) {
+                                                              return new DropdownMenuItem<
+                                                                  String>(
+                                                                value: fiat
+                                                                    .currencyData
+                                                                    .shortName,
+                                                                child: new Text(
+                                                                  fiat.currencyData
+                                                                      .shortName,
+                                                                  textAlign:
+                                                                      TextAlign
+                                                                          .right,
+                                                                  style: theme
+                                                                      .invoiceAmountStyle
+                                                                      .copyWith(
+                                                                          color:
+                                                                              Theme.of(context).accentColor),
+                                                                ),
+                                                              );
+                                                            }).toList(),
+                                                          )),
+                                              ),
+                                            ),
+                                          ),
+                                        );
+                                      });
+                                })),
+                      ],
+                    ),
                   ),
                 ],
               ),

--- a/lib/routes/charge/items/item_avatar.dart
+++ b/lib/routes/charge/items/item_avatar.dart
@@ -32,13 +32,8 @@ class _UnknownAvatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-        decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.all(Radius.circular(16.0))),
-        width: radius * 2,
-        height: radius * 2,
-        child: Icon(Icons.close, color: Theme.of(context).primaryColorDark));
+    return Icon(Icons.image,
+        size: radius * 2, color: Theme.of(context).accentColor);
   }
 }
 

--- a/lib/routes/charge/items/item_avatar.dart
+++ b/lib/routes/charge/items/item_avatar.dart
@@ -32,7 +32,7 @@ class _UnknownAvatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Icon(Icons.image,
+    return Icon(Icons.airplanemode_active,
         size: radius * 2, color: Theme.of(context).accentColor);
   }
 }

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -498,7 +498,7 @@ class POSInvoiceState extends State<POSInvoice> {
             context,
             "You don't have the capacity to receive such payment.",
             Text(
-                "Maximum payment size you can receive is ${account.currency.format(account.maxAllowedToReceive, includeSymbol: true)}. Please enter a smaller value.",
+                "Maximum payment size you can receive is ${account.currency.format(account.maxAllowedToReceive, includeDisplayName: true)}. Please enter a smaller value.",
                 style: Theme.of(context).dialogTheme.contentTextStyle));
         return;
       }
@@ -508,7 +508,7 @@ class POSInvoiceState extends State<POSInvoice> {
             context,
             "You have exceeded the maximum payment size.",
             Text(
-                "Maximum payment size on the Lightning Network is ${account.currency.format(account.maxPaymentAmount, includeSymbol: true)}. Please enter a smaller value or complete the payment in multiple transactions.",
+                "Maximum payment size on the Lightning Network is ${account.currency.format(account.maxPaymentAmount, includeDisplayName: true)}. Please enter a smaller value or complete the payment in multiple transactions.",
                 style: Theme.of(context).dialogTheme.contentTextStyle));
         return;
       }
@@ -688,7 +688,7 @@ class POSInvoiceState extends State<POSInvoice> {
         ? (nativeAmount)
             .toStringAsFixed(acc.fiatCurrency.currencyData.fractionSize)
         : acc.currency.format(Int64((nativeAmount).toInt()),
-            includeSymbol: false, userInput: userInput);
+            includeDisplayName: false, userInput: userInput);
   }
 
   String _currencySymbol(AccountModel accountModel,

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -105,7 +105,10 @@ class POSInvoiceState extends State<POSInvoice> {
                                       }),
                                   Padding(
                                     padding: EdgeInsets.only(
-                                        top: 0.0, left: 16.0, right: 16.0),
+                                        top: 0.0,
+                                        left: 16.0,
+                                        right: 16.0,
+                                        bottom: 24.0),
                                     child: ConstrainedBox(
                                       constraints: const BoxConstraints(
                                           minWidth: double.infinity),
@@ -179,7 +182,10 @@ class POSInvoiceState extends State<POSInvoice> {
                                       ),
                                     ),
                                   ),*/
-                                  _buildViewSwitch(context),
+                                  Padding(
+                                    padding: const EdgeInsets.only(bottom: 24),
+                                    child: _buildViewSwitch(context),
+                                  ),
                                   Padding(
                                     padding:
                                         EdgeInsets.only(left: 0.0, right: 16.0),

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez/bloc/account/account_bloc.dart';
 import 'package:breez/bloc/account/account_model.dart';
 import 'package:breez/bloc/account/fiat_conversion.dart';
@@ -13,6 +14,7 @@ import 'package:breez/bloc/user_profile/breez_user_model.dart';
 import 'package:breez/bloc/user_profile/currency.dart';
 import 'package:breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:breez/theme_data.dart' as theme;
+import 'package:breez/utils/min_font_size.dart';
 import 'package:breez/widgets/breez_dropdown.dart';
 import 'package:breez/widgets/error_dialog.dart';
 import 'package:breez/widgets/flushbar.dart';
@@ -445,12 +447,16 @@ class POSInvoiceState extends State<POSInvoice> {
                 border: UnderlineInputBorder()),
           ),*/
           catalogItems?.length == 0
-              ? Center(
-                  child: Padding(
-                  padding: const EdgeInsets.only(top: 160.0),
-                  child: Text(
-                      "No items to display. Add items to this view using the '+' button."),
-                ))
+              ? Padding(
+                  padding: const EdgeInsets.only(
+                      top: 180.0, left: 40.0, right: 40.0),
+                  child: AutoSizeText(
+                    "No items to display. Add items to this view using the '+' button.",
+                    textAlign: TextAlign.center,
+                    minFontSize: MinFontSize(context).minFontSize,
+                    stepGranularity: 0.1,
+                  ),
+                )
               : ItemsList(accountModel, posCatalogBloc, catalogItems, _addItem)
         ],
       ),

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -442,7 +442,8 @@ class POSInvoiceState extends State<POSInvoice> {
               ? Center(
                   child: Padding(
                   padding: const EdgeInsets.only(top: 160.0),
-                  child: Text("Please add items to use catalog"),
+                  child: Text(
+                      "No items to display. Add items to this view using the '+' button."),
                 ))
               : ItemsList(accountModel, posCatalogBloc, catalogItems, _addItem)
         ],

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -317,6 +317,7 @@ class POSInvoiceState extends State<POSInvoice> {
           child: Align(
             alignment: Alignment.centerRight,
             child: GestureDetector(
+                behavior: HitTestBehavior.translucent,
                 onTap: () => _changeView(true),
                 child: Padding(
                   padding: EdgeInsets.only(right: itemWidth / 4),
@@ -358,6 +359,7 @@ class POSInvoiceState extends State<POSInvoice> {
           child: Align(
             alignment: Alignment.centerLeft,
             child: GestureDetector(
+                behavior: HitTestBehavior.translucent,
                 onTap: () => _changeView(false),
                 child: Padding(
                   padding: EdgeInsets.only(left: itemWidth / 4),

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -331,7 +331,7 @@ class POSInvoiceState extends State<POSInvoice> {
               height: 20,
               width: 8,
               child: VerticalDivider(
-                color: Theme.of(context).canvasColor,
+                color: Theme.of(context).primaryTextTheme.button.color,
               ),
             ),
             Expanded(

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -117,10 +117,8 @@ class POSInvoiceState extends State<POSInvoice> {
                                           padding: EdgeInsets.only(
                                               top: 14.0, bottom: 14.0),
                                           child: Text(
-                                            "Charge ${_formattedCharge(accountModel, amount + currentAmount)} "
-                                                    .toUpperCase() +
-                                                _currencySymbol(accountModel,
-                                                    showDisplayName: true),
+                                            "Charge ${_formattedCharge(accountModel, amount + currentAmount)} ${_currencySymbol(accountModel)}"
+                                                .toUpperCase(),
                                             maxLines: 1,
                                             textAlign: TextAlign.center,
                                             style:
@@ -262,7 +260,7 @@ class POSInvoiceState extends State<POSInvoice> {
                                                                               value.symbol,
                                                                           child:
                                                                               Text(
-                                                                            value.displayName,
+                                                                            value.symbol.toUpperCase(),
                                                                             textAlign:
                                                                                 TextAlign.right,
                                                                             style:
@@ -691,13 +689,10 @@ class POSInvoiceState extends State<POSInvoice> {
             includeDisplayName: false, userInput: userInput);
   }
 
-  String _currencySymbol(AccountModel accountModel,
-      {bool showDisplayName = false}) {
+  String _currencySymbol(AccountModel accountModel) {
     return _useFiat
         ? accountModel.fiatCurrency.currencyData.shortName
-        : showDisplayName
-            ? accountModel.currency.displayName
-            : accountModel.currency.symbol;
+        : accountModel.currency.symbol;
   }
 
   Int64 _satAmount(AccountModel acc, double nativeAmount) {

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -181,11 +181,11 @@ class POSInvoiceState extends State<POSInvoice> {
                                       ),
                                     ),
                                   ),*/
+                                  _buildViewSwitch(context),
                                   Padding(
                                     padding:
                                         EdgeInsets.only(left: 0.0, right: 16.0),
                                     child: Row(children: <Widget>[
-                                      _buildViewSwitch(context),
                                       Expanded(
                                         child: Align(
                                           alignment: Alignment.centerRight,
@@ -305,55 +305,95 @@ class POSInvoiceState extends State<POSInvoice> {
     );
   }
 
-  GestureDetector _buildViewSwitch(BuildContext context) {
-    return GestureDetector(
-      onTap: _changeView,
-      child: Container(
-        padding: EdgeInsets.zero,
-        width: itemWidth / 1.5,
-        color: Theme.of(context).backgroundColor,
-        child: Row(
-          mainAxisSize: MainAxisSize.max,
-          mainAxisAlignment: MainAxisAlignment.spaceAround,
-          children: <Widget>[
-            Expanded(
-              child: IconButton(
-                padding: EdgeInsets.zero,
-                icon: Icon(Icons.dialpad,
-                    color: Theme.of(context)
-                        .primaryTextTheme
-                        .button
-                        .color
-                        .withOpacity(_isKeypadView ? 1 : 0.5)),
-              ),
-            ),
-            Container(
-              height: 20,
-              width: 8,
-              child: VerticalDivider(
-                color: Theme.of(context).primaryTextTheme.button.color,
-              ),
-            ),
-            Expanded(
-              child: IconButton(
-                padding: EdgeInsets.zero,
-                icon: Icon(Icons.playlist_add,
-                    color: Theme.of(context)
-                        .primaryTextTheme
-                        .button
-                        .color
-                        .withOpacity(_isKeypadView ? 0.5 : 1)),
-              ),
-            ),
-          ],
+  Widget _buildViewSwitch(BuildContext context) {
+    // This method is a work-around to center align the buttons
+    // Use Align to stick items to center and set padding to give equal distance
+    return Row(
+      mainAxisSize: MainAxisSize.max,
+      children: <Widget>[
+        Flexible(
+          flex: 1,
+          child: Align(
+            alignment: Alignment.centerRight,
+            child: GestureDetector(
+                onTap: () => _changeView(true),
+                child: Padding(
+                  padding: EdgeInsets.only(right: itemWidth / 4),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      Padding(
+                        padding: const EdgeInsets.only(right: 8.0),
+                        child: Icon(Icons.dialpad,
+                            color: Theme.of(context)
+                                .primaryTextTheme
+                                .button
+                                .color
+                                .withOpacity(_isKeypadView ? 1 : 0.5)),
+                      ),
+                      Text(
+                        "Keypad",
+                        style: Theme.of(context).textTheme.button.copyWith(
+                            color: Theme.of(context)
+                                .textTheme
+                                .button
+                                .color
+                                .withOpacity(_isKeypadView ? 1 : 0.5)),
+                      )
+                    ],
+                  ),
+                )),
+          ),
         ),
-      ),
+        Container(
+          height: 20,
+          child: VerticalDivider(
+            color: Theme.of(context).primaryTextTheme.button.color,
+          ),
+        ),
+        Flexible(
+          flex: 1,
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: GestureDetector(
+                onTap: () => _changeView(false),
+                child: Padding(
+                  padding: EdgeInsets.only(left: itemWidth / 4),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      Padding(
+                        padding: const EdgeInsets.only(right: 8.0),
+                        child: Icon(Icons.playlist_add,
+                            color: Theme.of(context)
+                                .primaryTextTheme
+                                .button
+                                .color
+                                .withOpacity(!_isKeypadView ? 1 : 0.5)),
+                      ),
+                      Text(
+                        "Items",
+                        style: Theme.of(context).textTheme.button.copyWith(
+                            color: Theme.of(context)
+                                .textTheme
+                                .button
+                                .color
+                                .withOpacity(!_isKeypadView ? 1 : 0.5)),
+                      )
+                    ],
+                  ),
+                )),
+          ),
+        ),
+      ],
     );
   }
 
-  _changeView() {
+  _changeView(bool isKeypadView) {
     setState(() {
-      _isKeypadView = !_isKeypadView;
+      _isKeypadView = isKeypadView;
     });
   }
 

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -195,8 +195,11 @@ class POSInvoiceState extends State<POSInvoice> {
                                               padding:
                                                   EdgeInsets.only(left: 8.0),
                                               child: Text(
-                                                _formattedCharge(accountModel,
-                                                    currentAmount),
+                                                _isKeypadView
+                                                    ? _formattedCharge(
+                                                        accountModel,
+                                                        currentAmount)
+                                                    : "",
                                                 maxLines: 1,
                                                 style: theme.invoiceAmountStyle
                                                     .copyWith(

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -268,7 +268,7 @@ class POSInvoiceState extends State<POSInvoice> {
                                                                               value.symbol,
                                                                           child:
                                                                               Text(
-                                                                            value.symbol.toUpperCase(),
+                                                                            value.symbol,
                                                                             textAlign:
                                                                                 TextAlign.right,
                                                                             style:

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -134,7 +134,7 @@ class POSInvoiceState extends State<POSInvoice> {
                                       ),
                                     ),
                                   ),
-                                  Container(
+                                  /*Container(
                                     height: 80.0,
                                     child: Padding(
                                       padding: EdgeInsets.only(
@@ -180,7 +180,7 @@ class POSInvoiceState extends State<POSInvoice> {
                                                 .color),
                                       ),
                                     ),
-                                  ),
+                                  ),*/
                                   Padding(
                                     padding:
                                         EdgeInsets.only(left: 0.0, right: 16.0),

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -263,7 +263,7 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
       ),
       onTap: () => _amountController.text = acc.currency.format(
           acc.maxAllowedToReceive,
-          includeSymbol: false,
+          includeDisplayName: false,
           userInput: true),
     );
   }
@@ -316,7 +316,7 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
     _withdrawFetchResponse = response;
     _descriptionController.text = response.defaultDescription;
     _amountController.text = account.currency
-        .format(response.maxAmount, includeSymbol: false, userInput: true);
+        .format(response.maxAmount, includeDisplayName: false, userInput: true);
   }
 
   Future _createInvoice(InvoiceBloc invoiceBloc, AccountBloc accountBloc,

--- a/lib/routes/home/payment_item.dart
+++ b/lib/routes/home/payment_item.dart
@@ -58,7 +58,7 @@ class PaymentItem extends StatelessWidget {
                             ? "- "
                             : "+ ") +
                         _paymentInfo.currency
-                            .format(_paymentInfo.amount, includeSymbol: false),
+                            .format(_paymentInfo.amount, includeDisplayName: false),
                     style: theme.transactionAmountStyle,
                   )
                 ]),
@@ -71,7 +71,7 @@ class PaymentItem extends StatelessWidget {
                       : Text(
                           "FEE " +
                               _paymentInfo.currency.format(_paymentInfo.fee,
-                                  includeSymbol: false),
+                                  includeDisplayName: false),
                           style: theme.transactionSubtitleStyle)
                 ]),
           ],

--- a/lib/routes/transactions/pos_payment_item.dart
+++ b/lib/routes/transactions/pos_payment_item.dart
@@ -34,7 +34,7 @@ class PosPaymentItem extends StatelessWidget {
                             ? "- "
                             : "") +
                         _paymentInfo.currency
-                            .format(_paymentInfo.amount, includeSymbol: false),
+                            .format(_paymentInfo.amount, includeDisplayName: false),
                     style: _paymentInfo.type == PaymentType.SENT
                         ? theme.posWithdrawalTransactionAmountStyle
                         : theme.transactionAmountStyle),

--- a/lib/routes/withdraw_funds/reverse_swap_page.dart
+++ b/lib/routes/withdraw_funds/reverse_swap_page.dart
@@ -128,7 +128,7 @@ class ReverseSwapPageState extends State<ReverseSwapPage> {
                                   initialAmount = accSnapshot.data.currency
                                       .format(currentSwap.amount,
                                           userInput: true,
-                                          includeSymbol: false);
+                                          includeDisplayName: false);
                                 }
 
                                 return PageView(

--- a/lib/routes/withdraw_funds/unexpected_funds.dart
+++ b/lib/routes/withdraw_funds/unexpected_funds.dart
@@ -62,7 +62,7 @@ class UnexpectedFundsState extends State<UnexpectedFunds> {
                       initialAmount: accSnapshot.data.currency.format(
                           accSnapshot.data.walletBalance,
                           userInput: true,
-                          includeSymbol: false),
+                          includeDisplayName: false),
                       onNext: (amount, address) {
                         setState(() {
                           this._destAddress = address;

--- a/lib/theme_data.dart
+++ b/lib/theme_data.dart
@@ -325,7 +325,7 @@ final TextStyle invoiceChargeAmountStyle = TextStyle(
     letterSpacing: 1.25);
 final TextStyle invoiceAmountStyle = TextStyle(
     color: BreezColors.grey[600],
-    fontSize: 22.0,
+    fontSize: 18.0,
     height: 1.32,
     letterSpacing: 0.2);
 final TextStyle currencyDropdownStyle = TextStyle(

--- a/lib/widgets/currency_converter_dialog.dart
+++ b/lib/widgets/currency_converter_dialog.dart
@@ -256,7 +256,7 @@ class CurrencyConverterDialogState extends State<CurrencyConverterDialog>
                   child: Column(
                     children: <Widget>[
                       Text(
-                          "${_fiatAmountController.text.isNotEmpty ? account.currency.format(_convertedSatoshies(account), includeSymbol: false) : 0} ${account.currency.symbol}",
+                          "${_fiatAmountController.text.isNotEmpty ? account.currency.format(_convertedSatoshies(account), includeDisplayName: false) : 0} ${account.currency.symbol}",
                           style: Theme.of(context)
                               .textTheme
                               .headline
@@ -288,7 +288,7 @@ class CurrencyConverterDialogState extends State<CurrencyConverterDialog>
             if (_formKey.currentState.validate()) {
               widget._onConvert(account.currency.format(
                   _convertedSatoshies(account),
-                  includeSymbol: false,
+                  includeDisplayName: false,
                   userInput: true));
               Navigator.pop(context);
             }


### PR DESCRIPTION
This PR follows up on #289 and addresses the feedbacks given in  [POS-48](https://breeztech.atlassian.net/browse/POS-48)
## UI Changes

**Dashboard:**

- Remove the 'Add Note' (till the minimize task)
- Move the switcher button under the Charge button and add captions 'Keypad | Items'. Take the entire row, align to center. Make it behave like two buttons (only click on the inactive view switches view).

**Catalog View:**
- “No items to display. Add items to this view using the '+' button.”
- Remove the current amount (right to the switcher) in catalog view
- Use a regular icon for an item (as a reference)

**Slidable:**
- No need for the ‘Delete’ caption, icon is enough
- Background color of the slide should be the same as a button color. Foreground color should be white.

**Create Item Page:**
- Change the fields to ‘Item Name’/'Item Price' and currency should look like currency field in ‘Redeem Voucher’. 
- The Add Item form should look like  ‘Redeem Voucher’ in terms of style. The padding, fonts look much better in the redeem form. 

## UI Fixes:
- No visible separator in dark mode in keypad-items switcher. 
- Change ‘Create Item’ to ‘Add Item’
- Remove the flushbar when deleting an item.
- Items price should be displayed w/o trailing zeros
- Use only currency symbols in catalog
- Add more padding between the items
- Change 'sats' back to 'SAT'
- Make the switch buttons easier to click
- Change alignment of charge button and viewswitch
#

 - _Add 'Item SKU' optional field to the Add Item form._ Part of another PR
