### PR TITLE
POS currency persistence

### DIFF
--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -401,12 +401,10 @@ class AccountBloc {
       _currentUser = user;
       log.info("account: got new user $user");
       //convert currency.
-      _accountController
-          .add(_accountController.value.copyWith(currency: user.currency));
-      _accountController.add(
-          _accountController.value.copyWith(fiatShortName: user.fiatCurrency));
-      _accountController.add(
-          _accountController.value.copyWith(posCurrencyShortName: user.posCurrencyShortName));
+      _accountController.add(_accountController.value.copyWith(
+          currency: user.currency,
+          fiatShortName: user.fiatCurrency,
+          posCurrencyShortName: user.posCurrencyShortName));
       var updatedPayments = _paymentsController.value.copyWith(
         nonFilteredItems: _paymentsController.value.nonFilteredItems
             .map((p) => p.copyWith(_accountController.value))

--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -62,9 +62,6 @@ class AccountBloc {
   Sink<AccountSettings> get accountSettingsSink =>
       _accountSettingsController.sink;
 
-  final _posCurrencyController = BehaviorSubject<String>();
-  Sink<String> get posCurrencySink => _posCurrencyController.sink;
-
   final _routingNodeConnectionController = BehaviorSubject<bool>();
   Stream<bool> get routingNodeConnectionStream =>
       _routingNodeConnectionController.stream;
@@ -160,7 +157,6 @@ class AccountBloc {
       //listen streams
       _listenAccountActions();
       _hanleAccountSettings();
-      _listenPosCurrencyChanges();
       _listenUserChanges(userProfileStream);
       _listenFilterChanges();
       _listenAccountChanges();
@@ -395,13 +391,6 @@ class AccountBloc {
     });
   }
 
-  _listenPosCurrencyChanges() {
-    _posCurrencyController.listen((shortName) {
-      _accountController
-          .add(_accountController.value.copyWith(posCurrencyShortName: shortName));
-    });
-  }
-
   _listenUserChanges(Stream<BreezUserModel> userProfileStream) {
     userProfileStream.listen((user) async {
       if (user.token != null && user.token != _currentUser?.token) {
@@ -416,6 +405,8 @@ class AccountBloc {
           .add(_accountController.value.copyWith(currency: user.currency));
       _accountController.add(
           _accountController.value.copyWith(fiatShortName: user.fiatCurrency));
+      _accountController.add(
+          _accountController.value.copyWith(posCurrencyShortName: user.posCurrencyShortName));
       var updatedPayments = _paymentsController.value.copyWith(
         nonFilteredItems: _paymentsController.value.nonFilteredItems
             .map((p) => p.copyWith(_accountController.value))
@@ -689,7 +680,6 @@ class AccountBloc {
   }
 
   close() {
-    _posCurrencyController.close();
     _accountEnableController.close();
     _paymentsController.close();
     _accountNotificationsController.close();

--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -62,6 +62,9 @@ class AccountBloc {
   Sink<AccountSettings> get accountSettingsSink =>
       _accountSettingsController.sink;
 
+  final _posCurrencyController = BehaviorSubject<String>();
+  Sink<String> get posCurrencySink => _posCurrencyController.sink;
+
   final _routingNodeConnectionController = BehaviorSubject<bool>();
   Stream<bool> get routingNodeConnectionStream =>
       _routingNodeConnectionController.stream;
@@ -157,6 +160,7 @@ class AccountBloc {
       //listen streams
       _listenAccountActions();
       _hanleAccountSettings();
+      _listenPosCurrencyChanges();
       _listenUserChanges(userProfileStream);
       _listenFilterChanges();
       _listenAccountChanges();
@@ -388,6 +392,13 @@ class AccountBloc {
     _device.eventStream.where((e) => e == NotificationType.RESUME).listen((e) {
       log.info("App Resumed - flutter resume called, adding reconnect request");
       _reconnectSink.add(null);
+    });
+  }
+
+  _listenPosCurrencyChanges() {
+    _posCurrencyController.listen((shortName) {
+      _accountController
+          .add(_accountController.value.copyWith(posCurrencyShortName: shortName));
     });
   }
 
@@ -678,6 +689,7 @@ class AccountBloc {
   }
 
   close() {
+    _posCurrencyController.close();
     _accountEnableController.close();
     _paymentsController.close();
     _accountNotificationsController.close();

--- a/lib/bloc/account/account_model.dart
+++ b/lib/bloc/account/account_model.dart
@@ -225,7 +225,6 @@ class AccountModel {
       orElse: () => null);
   List<FiatConversion> get fiatConversionList => _fiatConversionList;
   String get posCurrencyShortName => _posCurrencyShortName;
-  CurrencyWrapper get posCurrency => CurrencyWrapper.fromShortName(_posCurrencyShortName, this);
   Int64 get maxAllowedToReceive => _accountResponse.maxAllowedToReceive;
   Int64 get maxAllowedToPay => Int64(min(
       _accountResponse.maxAllowedToPay.toInt(),

--- a/lib/bloc/account/account_model.dart
+++ b/lib/bloc/account/account_model.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:breez/bloc/account/fiat_conversion.dart';
 import 'package:breez/bloc/user_profile/currency.dart';
+import 'package:breez/routes/charge/currency_wrapper.dart';
 import 'package:breez/services/breezlib/data/rpc.pb.dart';
 import 'package:fixnum/fixnum.dart';
 
@@ -136,6 +137,7 @@ class AccountModel {
   final String _fiatShortName;
   final FiatConversion _fiatCurrency;
   final List<FiatConversion> _fiatConversionList;
+  final String _posCurrencyShortName;
   final FundStatusReply addedFundsReply;
   final Int64 onChainFeeRate;
   final bool initial;
@@ -145,7 +147,7 @@ class AccountModel {
   final SyncUIState syncUIState;
 
   AccountModel(this._accountResponse, this._currency, this._fiatShortName,
-      this._fiatCurrency, this._fiatConversionList,
+      this._fiatCurrency, this._fiatConversionList, this._posCurrencyShortName,
       {this.initial = true,
       this.addedFundsReply,
       this.onChainFeeRate,
@@ -167,13 +169,16 @@ class AccountModel {
             "USD",
             null,
             List(),
+            "BTC",
             initial: true);
+
   AccountModel copyWith(
       {Account accountResponse,
       Currency currency,
       String fiatShortName,
       FiatConversion fiatCurrency,
       List<FiatConversion> fiatConversionList,
+      String posCurrencyShortName,
       FundStatusReply addedFundsReply,
       Int64 onChainFeeRate,
       bool enableInProgress,
@@ -187,6 +192,7 @@ class AccountModel {
         fiatShortName ?? this._fiatShortName,
         fiatCurrency ?? this._fiatCurrency,
         fiatConversionList ?? this._fiatConversionList,
+        posCurrencyShortName ?? this._posCurrencyShortName,
         addedFundsReply: addedFundsReply ?? this.addedFundsReply,
         onChainFeeRate: onChainFeeRate ?? this.onChainFeeRate,
         enableInProgress: enableInProgress ?? this.enableInProgress,
@@ -218,6 +224,8 @@ class AccountModel {
       (f) => f.currencyData.shortName == _fiatShortName,
       orElse: () => null);
   List<FiatConversion> get fiatConversionList => _fiatConversionList;
+  String get posCurrencyShortName => _posCurrencyShortName;
+  CurrencyWrapper get posCurrency => CurrencyWrapper.fromShortName(_posCurrencyShortName, this);
   Int64 get maxAllowedToReceive => _accountResponse.maxAllowedToReceive;
   Int64 get maxAllowedToPay => Int64(min(
       _accountResponse.maxAllowedToPay.toInt(),

--- a/lib/bloc/user_profile/breez_user_model.dart
+++ b/lib/bloc/user_profile/breez_user_model.dart
@@ -17,6 +17,7 @@ class BreezUserModel {
   final bool isPOS;
   final double cancellationTimeoutValue;
   final bool hasAdminPassword;
+  final String posCurrencyShortName;
 
   BreezUserModel._(this.userID, this.name, this.color, this.animal,
       {this.currency = Currency.SAT,
@@ -29,7 +30,8 @@ class BreezUserModel {
       this.registrationRequested = false,
       this.isPOS = false,
       this.cancellationTimeoutValue = 90.0,
-      this.hasAdminPassword = false});
+      this.hasAdminPassword = false,
+      this.posCurrencyShortName});
 
   BreezUserModel copyWith(
       {String name,
@@ -46,7 +48,8 @@ class BreezUserModel {
       bool registrationRequested,
       bool isPOS,
       double cancellationTimeoutValue,
-      bool hasAdminPassword}) {
+      bool hasAdminPassword,
+      String posCurrencyShortName}) {
     return BreezUserModel._(userID ?? this.userID, name ?? this.name,
         color ?? this.color, animal ?? this.animal,
         currency: currency ?? this.currency,
@@ -61,7 +64,8 @@ class BreezUserModel {
         isPOS: isPOS ?? this.isPOS,
         cancellationTimeoutValue:
             cancellationTimeoutValue ?? this.cancellationTimeoutValue,
-        hasAdminPassword: hasAdminPassword ?? this.hasAdminPassword);
+        hasAdminPassword: hasAdminPassword ?? this.hasAdminPassword,
+        posCurrencyShortName: posCurrencyShortName ?? this.posCurrencyShortName);
   }
 
   bool get registered {
@@ -97,7 +101,8 @@ class BreezUserModel {
         cancellationTimeoutValue = json['cancellationTimeoutValue'] == null
             ? 90.0
             : json['cancellationTimeoutValue'],
-        hasAdminPassword = json['hasAdminPassword'] ?? false;
+        hasAdminPassword = json['hasAdminPassword'] ?? false,
+        posCurrencyShortName = json['posCurrencyShortName'] ?? "BTC";
 
   Map<String, dynamic> toJson() => {
         'userID': userID,
@@ -114,5 +119,6 @@ class BreezUserModel {
         'cancellationTimeoutValue': cancellationTimeoutValue,
         'isPOS': isPOS,
         'hasAdminPassword': hasAdminPassword,
+        'posCurrencyShortName': posCurrencyShortName,
       };
 }

--- a/lib/bloc/user_profile/user_actions.dart
+++ b/lib/bloc/user_profile/user_actions.dart
@@ -69,3 +69,9 @@ class UploadProfilePicture extends AsyncAction {
 
   UploadProfilePicture(this.bytes);
 }
+
+class SetPOSCurrency extends AsyncAction {
+  final String shortName;
+
+  SetPOSCurrency(this.shortName);
+}

--- a/lib/bloc/user_profile/user_profile_bloc.dart
+++ b/lib/bloc/user_profile/user_profile_bloc.dart
@@ -59,6 +59,9 @@ class UserProfileBloc {
   final _fiatConversionController = BehaviorSubject<String>();
   Sink<String> get fiatConversionSink => _fiatConversionController.sink;
 
+  final _posCurrencyController = BehaviorSubject<String>();
+  Sink<String> get posCurrencySink => _posCurrencyController.sink;
+
   final _userController = BehaviorSubject<BreezUserModel>();
   Sink<BreezUserModel> get userSink => _userController.sink;
 
@@ -105,6 +108,7 @@ class UserProfileBloc {
       //listen to changes in user preferences
       _listenCurrencyChange(injector);
       _listenFiatCurrencyChange(injector);
+      _listenPosCurrencyChanges(injector);
 
       //listen to changes in user avatar
       _listenUserChange(injector);
@@ -329,6 +333,14 @@ class UserProfileBloc {
     });
   }
 
+  _listenPosCurrencyChanges(ServiceInjector injector) {
+    _posCurrencyController.listen((shortName) async {
+      var preferences = await injector.sharedPreferences;
+      await _saveChanges(
+          preferences, _currentUser.copyWith(posCurrencyShortName: shortName));
+    });
+  }
+
   void _listenUserChange(ServiceInjector injector) {
     _userController.stream.listen((userData) async {
       var preferences = await injector.sharedPreferences;
@@ -387,6 +399,7 @@ class UserProfileBloc {
     _registrationController.close();
     _currencyController.close();
     _fiatConversionController.close();
+    _posCurrencyController.close();
     _userActionsController.close();
     _userController.close();
     _randomizeController.close();

--- a/lib/bloc/user_profile/user_profile_bloc.dart
+++ b/lib/bloc/user_profile/user_profile_bloc.dart
@@ -59,9 +59,6 @@ class UserProfileBloc {
   final _fiatConversionController = BehaviorSubject<String>();
   Sink<String> get fiatConversionSink => _fiatConversionController.sink;
 
-  final _posCurrencyController = BehaviorSubject<String>();
-  Sink<String> get posCurrencySink => _posCurrencyController.sink;
-
   final _userController = BehaviorSubject<BreezUserModel>();
   Sink<BreezUserModel> get userSink => _userController.sink;
 
@@ -92,6 +89,7 @@ class UserProfileBloc {
       SetAdminPassword: _setAdminPassword,
       VerifyAdminPassword: _verifyAdminPassword,
       UploadProfilePicture: _uploadProfilePicture,
+      SetPOSCurrency: _setPOSCurrency,
     };
     print("UserProfileBloc started");
 
@@ -108,7 +106,6 @@ class UserProfileBloc {
       //listen to changes in user preferences
       _listenCurrencyChange(injector);
       _listenFiatCurrencyChange(injector);
-      _listenPosCurrencyChanges(injector);
 
       //listen to changes in user avatar
       _listenUserChange(injector);
@@ -194,6 +191,12 @@ class UserProfileBloc {
     _saveChanges(
         await _preferences, _currentUser.copyWith(isPOS: action.isPos));
     action.resolve(action.isPos);
+  }
+
+  Future _setPOSCurrency(SetPOSCurrency action) async {
+    _saveChanges(await _preferences,
+        _currentUser.copyWith(posCurrencyShortName: action.shortName));
+    action.resolve(action.shortName);
   }
 
   Future _uploadProfilePicture(UploadProfilePicture action) async {
@@ -333,14 +336,6 @@ class UserProfileBloc {
     });
   }
 
-  _listenPosCurrencyChanges(ServiceInjector injector) {
-    _posCurrencyController.listen((shortName) async {
-      var preferences = await injector.sharedPreferences;
-      await _saveChanges(
-          preferences, _currentUser.copyWith(posCurrencyShortName: shortName));
-    });
-  }
-
   void _listenUserChange(ServiceInjector injector) {
     _userController.stream.listen((userData) async {
       var preferences = await injector.sharedPreferences;
@@ -399,7 +394,6 @@ class UserProfileBloc {
     _registrationController.close();
     _currencyController.close();
     _fiatConversionController.close();
-    _posCurrencyController.close();
     _userActionsController.close();
     _userController.close();
     _randomizeController.close();

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -51,6 +51,7 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
 
   double itemHeight;
   double itemWidth;
+  bool _useFiat = false;
   CurrencyWrapper currentCurrency;
   bool _isKeypadView = true;
   SaleLine currentPendingItem;
@@ -862,13 +863,17 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
   changeCurrency(Sale currentSale, String value,
       UserProfileBloc userProfileBloc, AccountModel accountModel) {
     setState(() {
-      CurrencyWrapper currency =
-          CurrencyWrapper.fromShortName(value, accountModel);
+      Currency currency = Currency.fromTickerSymbol(value);
+
+      bool flipFiat = _useFiat == (currency != null);
+      if (flipFiat) {
+        _useFiat = !_useFiat;
+      }
       _clearAmounts(currentSale);
 
-      if (currency.btc != null) {
-        userProfileBloc.currencySink.add(currency.btc);
-        userProfileBloc.posCurrencySink.add(currency.btc.tickerSymbol);
+      if (currency != null) {
+        userProfileBloc.currencySink.add(currency);
+        userProfileBloc.posCurrencySink.add(currency.tickerSymbol);
       } else {
         userProfileBloc.fiatConversionSink.add(value);
         userProfileBloc.posCurrencySink.add(value);

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -60,7 +60,7 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
   Animation<double> _scaleTransition;
   Animation<double> _opacityTransition;
   Item _itemInTransition;
-  bool bypassExchangeRateLock = true;
+  bool bypassExchangeRateLock = false;
 
   double get currentAmount => currentPendingItem?.total ?? 0;
 
@@ -74,16 +74,15 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
       AccountBloc accountBloc = AppBlocsProvider.of<AccountBloc>(context);
       accountSubscription = accountBloc.accountStream.listen((acc) {
         currentCurrency =
-            CurrencyWrapper.fromShortName(acc.posCurrencyShortName, acc) ?? CurrencyWrapper.fromBTC(Currency.BTC);
+            CurrencyWrapper.fromShortName(acc.posCurrencyShortName, acc) ??
+                CurrencyWrapper.fromBTC(Currency.BTC);
       });
       FetchRates fetchRatesAction = FetchRates();
       accountBloc.userActionsSink.add(fetchRatesAction);
       fetchRatesAction.future.catchError((err) {
         if (this.mounted) {
-          UserProfileBloc userProfileBloc =
-              AppBlocsProvider.of<UserProfileBloc>(context);
           setState(() {
-            bypassExchangeRateLock = false;
+            bypassExchangeRateLock = true;
             showFlushbar(context,
                 message: "Failed to retrieve fiat exchange rates.");
           });
@@ -158,7 +157,8 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
                               return Container();
                             }
 
-                            if (bypassExchangeRateLock && accountModel.fiatConversionList.isEmpty) {
+                            if (!bypassExchangeRateLock &&
+                                accountModel.fiatConversionList.isEmpty) {
                               return Center(child: Loader());
                             }
 
@@ -398,12 +398,12 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
                                                                                 value.tickerSymbol,
                                                                             child:
                                                                                 Material(
-                                                                                  child: Text(
-                                                                              value.tickerSymbol.toUpperCase(),
-                                                                              textAlign: TextAlign.right,
-                                                                              style: theme.invoiceAmountStyle.copyWith(color: Theme.of(context).textTheme.headline.color),
+                                                                              child: Text(
+                                                                                value.tickerSymbol.toUpperCase(),
+                                                                                textAlign: TextAlign.right,
+                                                                                style: theme.invoiceAmountStyle.copyWith(color: Theme.of(context).textTheme.headline.color),
+                                                                              ),
                                                                             ),
-                                                                                ),
                                                                           );
                                                                         }).toList()
                                                                           ..addAll(

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -74,7 +74,19 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
       accountSubscription = accountBloc.accountStream.listen((acc) {
         currentCurrency = acc.posCurrency;
       });
-
+      FetchRates fetchRatesAction = FetchRates();
+      accountBloc.userActionsSink.add(fetchRatesAction);
+      fetchRatesAction.future.catchError((err) {
+        if (this.mounted) {
+          UserProfileBloc userProfileBloc =
+              AppBlocsProvider.of<UserProfileBloc>(context);
+          setState(() {
+            userProfileBloc.posCurrencySink.add("BTC");
+            showFlushbar(context,
+                message: "Failed to retrieve fiat exchange rates.");
+          });
+        }
+      });
       _itemFilterController.addListener(
         () {
           FilterItems filterItems = FilterItems(_itemFilterController.text);

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -82,9 +82,7 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
 
       FetchRates fetchRatesAction = FetchRates();
       accountBloc.userActionsSink.add(fetchRatesAction);
-      setState(() {
-        _fetchRatesActionFuture = fetchRatesAction.future;
-      });
+      _fetchRatesActionFuture = fetchRatesAction.future;
       _fetchRatesActionFuture.catchError((err) {
         if (this.mounted) {
           setState(() {
@@ -394,7 +392,7 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
                                                                         alignedDropdown:
                                                                             true,
                                                                         child: BreezDropdownButton(
-                                                                            onChanged: (value) => changeCurrency(currentSale, value, userProfileBloc, accountModel),
+                                                                            onChanged: (value) => changeCurrency(currentSale, value, userProfileBloc),
                                                                             iconEnabledColor: Theme.of(context).textTheme.headline.color,
                                                                             value: currentCurrency.shortName,
                                                                             style: theme.invoiceAmountStyle.copyWith(color: Theme.of(context).textTheme.headline.color),
@@ -869,8 +867,8 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
     });
   }
 
-  changeCurrency(Sale currentSale, String value,
-      UserProfileBloc userProfileBloc, AccountModel accountModel) {
+  changeCurrency(
+      Sale currentSale, String value, UserProfileBloc userProfileBloc) {
     setState(() {
       Currency currency = Currency.fromTickerSymbol(value);
 

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:badges/badges.dart';
+import 'package:breez/bloc/account/account_actions.dart';
 import 'package:breez/bloc/account/account_bloc.dart';
 import 'package:breez/bloc/account/account_model.dart';
 import 'package:breez/bloc/account/fiat_conversion.dart';
@@ -50,7 +51,6 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
 
   double itemHeight;
   double itemWidth;
-  bool _useFiat = false;
   CurrencyWrapper currentCurrency;
   bool _isKeypadView = true;
   SaleLine currentPendingItem;
@@ -245,7 +245,6 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
                                                                                   onInvoiceSubmitted(sale, invoiceBloc, userProfile, accModel);
                                                                                 },
                                                                                 onDeleteSale: () => approveClear(currentSale),
-                                                                                useFiat: _useFiat,
                                                                               ));
                                                               Navigator.of(
                                                                       context)
@@ -374,7 +373,7 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
                                                                     alignedDropdown:
                                                                         true,
                                                                     child: BreezDropdownButton(
-                                                                        onChanged: (value) => changeCurrency(currentSale, value, userProfileBloc, accountBloc),
+                                                                        onChanged: (value) => changeCurrency(currentSale, value, userProfileBloc, accountModel),
                                                                         iconEnabledColor: Theme.of(context).textTheme.headline.color,
                                                                         value: currentCurrency.shortName,
                                                                         style: theme.invoiceAmountStyle.copyWith(color: Theme.of(context).textTheme.headline.color),
@@ -843,19 +842,15 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
   }
 
   changeCurrency(Sale currentSale, String value,
-      UserProfileBloc userProfileBloc, AccountBloc accountBloc) {
+      UserProfileBloc userProfileBloc, AccountModel accountModel) {
     setState(() {
-      Currency currency = Currency.fromTickerSymbol(value);
-
-      bool flipFiat = _useFiat == (currency != null);
-      if (flipFiat) {
-        _useFiat = !_useFiat;
-      }
+      CurrencyWrapper currency =
+          CurrencyWrapper.fromShortName(value, accountModel);
       _clearAmounts(currentSale);
 
-      if (currency != null) {
-        userProfileBloc.currencySink.add(currency);
-        userProfileBloc.posCurrencySink.add(currency.tickerSymbol);
+      if (currency.btc != null) {
+        userProfileBloc.currencySink.add(currency.btc);
+        userProfileBloc.posCurrencySink.add(currency.btc.tickerSymbol);
       } else {
         userProfileBloc.fiatConversionSink.add(value);
         userProfileBloc.posCurrencySink.add(value);

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -73,7 +73,8 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
     if (accountSubscription == null) {
       AccountBloc accountBloc = AppBlocsProvider.of<AccountBloc>(context);
       accountSubscription = accountBloc.accountStream.listen((acc) {
-        currentCurrency = acc.posCurrency;
+        currentCurrency =
+            CurrencyWrapper.fromShortName(acc.posCurrencyShortName, acc);
       });
       FetchRates fetchRatesAction = FetchRates();
       accountBloc.userActionsSink.add(fetchRatesAction);

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -83,7 +83,7 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
           UserProfileBloc userProfileBloc =
               AppBlocsProvider.of<UserProfileBloc>(context);
           setState(() {
-            userProfileBloc.posCurrencySink.add("BTC");
+            currentCurrency = CurrencyWrapper.fromBTC(Currency.BTC);
             bypassExchangeRateLock = false;
             showFlushbar(context,
                 message: "Failed to retrieve fiat exchange rates.");

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -62,7 +62,7 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
   Animation<double> _scaleTransition;
   Animation<double> _opacityTransition;
   Item _itemInTransition;
-  bool bypassExchangeRateLock = false;
+  Future _fetchRatesActionFuture;
 
   double get currentAmount => currentPendingItem?.total ?? 0;
 
@@ -79,17 +79,21 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
             CurrencyWrapper.fromShortName(acc.posCurrencyShortName, acc) ??
                 CurrencyWrapper.fromBTC(Currency.BTC);
       });
+
       FetchRates fetchRatesAction = FetchRates();
       accountBloc.userActionsSink.add(fetchRatesAction);
-      fetchRatesAction.future.catchError((err) {
+      setState(() {
+        _fetchRatesActionFuture = fetchRatesAction.future;
+      });
+      _fetchRatesActionFuture.catchError((err) {
         if (this.mounted) {
           setState(() {
-            bypassExchangeRateLock = true;
             showFlushbar(context,
                 message: "Failed to retrieve fiat exchange rates.");
           });
         }
       });
+
       _itemFilterController.addListener(
         () {
           FilterItems filterItems = FilterItems(_itemFilterController.text);
@@ -159,307 +163,310 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
                               return Container();
                             }
 
-                            if (!bypassExchangeRateLock &&
-                                accountModel.fiatConversionList.isEmpty) {
-                              return Center(child: Loader());
-                            }
+                            return FutureBuilder(
+                              initialData: "Loading",
+                              future: _fetchRatesActionFuture,
+                              builder: (context, snapshot) {
+                                if (snapshot.data == "Loading") {
+                                  return Center(child: Loader());
+                                }
 
-                            double totalAmount = currentSale.totalChargeSat /
-                                currentCurrency.satConversionRate;
-                            return Stack(
-                              children: [
-                                Column(
-                                  mainAxisSize: MainAxisSize.max,
-                                  children: <Widget>[
-                                    Container(
-                                        child: Column(
-                                          mainAxisAlignment:
-                                              MainAxisAlignment.spaceBetween,
-                                          children: <Widget>[
-                                            StreamBuilder<AccountSettings>(
-                                                stream: accountBloc
-                                                    .accountSettingsStream,
-                                                builder: (settingCtx,
-                                                    settingSnapshot) {
-                                                  AccountSettings settings =
-                                                      settingSnapshot.data;
-                                                  if (settings?.showConnectProgress ==
-                                                          true ||
-                                                      accountModel
-                                                              .isInitialBootstrap ==
-                                                          true) {
-                                                    return StatusIndicator(
-                                                        context, snapshot.data);
-                                                  }
-                                                  return SizedBox();
-                                                }),
-                                            Padding(
-                                              padding: EdgeInsets.only(
-                                                  top: 0.0,
-                                                  left: 16.0,
-                                                  right: 16.0,
-                                                  bottom: 24.0),
-                                              child: ConstrainedBox(
-                                                constraints:
-                                                    const BoxConstraints(
-                                                        minWidth:
-                                                            double.infinity),
-                                                child: IgnorePointer(
-                                                  ignoring: false,
-                                                  child: RaisedButton(
-                                                    color: Theme.of(context)
-                                                        .primaryColorLight,
-                                                    padding: EdgeInsets.only(
-                                                        top: 14.0,
-                                                        bottom: 14.0),
-                                                    child: Text(
-                                                      "Charge ${currentCurrency.format(totalAmount)} ${currentCurrency.shortName}"
-                                                          .toUpperCase(),
-                                                      maxLines: 1,
-                                                      textAlign:
-                                                          TextAlign.center,
-                                                      style: theme
-                                                          .invoiceChargeAmountStyle,
+                                double totalAmount =
+                                    currentSale.totalChargeSat /
+                                        currentCurrency.satConversionRate;
+                                return Stack(
+                                  children: [
+                                    Column(
+                                      mainAxisSize: MainAxisSize.max,
+                                      children: <Widget>[
+                                        Container(
+                                            child: Column(
+                                              mainAxisAlignment:
+                                                  MainAxisAlignment
+                                                      .spaceBetween,
+                                              children: <Widget>[
+                                                StreamBuilder<AccountSettings>(
+                                                    stream: accountBloc
+                                                        .accountSettingsStream,
+                                                    builder: (settingCtx,
+                                                        settingSnapshot) {
+                                                      AccountSettings settings =
+                                                          settingSnapshot.data;
+                                                      if (settings?.showConnectProgress ==
+                                                              true ||
+                                                          accountModel
+                                                                  .isInitialBootstrap ==
+                                                              true) {
+                                                        return StatusIndicator(
+                                                            context,
+                                                            snapshot.data);
+                                                      }
+                                                      return SizedBox();
+                                                    }),
+                                                Padding(
+                                                  padding: EdgeInsets.only(
+                                                      top: 0.0,
+                                                      left: 16.0,
+                                                      right: 16.0,
+                                                      bottom: 24.0),
+                                                  child: ConstrainedBox(
+                                                    constraints:
+                                                        const BoxConstraints(
+                                                            minWidth: double
+                                                                .infinity),
+                                                    child: IgnorePointer(
+                                                      ignoring: false,
+                                                      child: RaisedButton(
+                                                        color: Theme.of(context)
+                                                            .primaryColorLight,
+                                                        padding:
+                                                            EdgeInsets.only(
+                                                                top: 14.0,
+                                                                bottom: 14.0),
+                                                        child: Text(
+                                                          "Charge ${currentCurrency.format(totalAmount)} ${currentCurrency.shortName}"
+                                                              .toUpperCase(),
+                                                          maxLines: 1,
+                                                          textAlign:
+                                                              TextAlign.center,
+                                                          style: theme
+                                                              .invoiceChargeAmountStyle,
+                                                        ),
+                                                        onPressed: () {
+                                                          onInvoiceSubmitted(
+                                                              currentSale,
+                                                              invoiceBloc,
+                                                              userProfile,
+                                                              accountModel);
+                                                        },
+                                                      ),
                                                     ),
-                                                    onPressed: () {
-                                                      onInvoiceSubmitted(
-                                                          currentSale,
-                                                          invoiceBloc,
-                                                          userProfile,
-                                                          accountModel);
-                                                    },
                                                   ),
                                                 ),
-                                              ),
-                                            ),
-                                            Padding(
-                                              padding: const EdgeInsets.only(
-                                                  bottom: 24),
-                                              child: _buildViewSwitch(context),
-                                            ),
-                                            Padding(
-                                              padding: EdgeInsets.only(
-                                                  left: 0.0, right: 16.0),
-                                              child: Row(children: <Widget>[
-                                                Expanded(
-                                                    child: Align(
-                                                        alignment: Alignment
-                                                            .centerLeft,
-                                                        child: GestureDetector(
-                                                            behavior:
-                                                                HitTestBehavior
-                                                                    .translucent,
-                                                            onTap: () {
-                                                              var currentSaleRoute =
-                                                                  CupertinoPageRoute(
-                                                                      fullscreenDialog:
-                                                                          true,
-                                                                      builder:
-                                                                          (_) =>
-                                                                              SaleView(
+                                                Padding(
+                                                  padding:
+                                                      const EdgeInsets.only(
+                                                          bottom: 24),
+                                                  child:
+                                                      _buildViewSwitch(context),
+                                                ),
+                                                Padding(
+                                                  padding: EdgeInsets.only(
+                                                      left: 0.0, right: 16.0),
+                                                  child: Row(children: <Widget>[
+                                                    Expanded(
+                                                        child: Align(
+                                                            alignment: Alignment
+                                                                .centerLeft,
+                                                            child:
+                                                                GestureDetector(
+                                                                    behavior:
+                                                                        HitTestBehavior
+                                                                            .translucent,
+                                                                    onTap: () {
+                                                                      var currentSaleRoute = CupertinoPageRoute(
+                                                                          fullscreenDialog: true,
+                                                                          builder: (_) => SaleView(
                                                                                 onCharge: (accModel, sale) {
                                                                                   onInvoiceSubmitted(sale, invoiceBloc, userProfile, accModel);
                                                                                 },
                                                                                 onDeleteSale: () => approveClear(currentSale),
                                                                               ));
-                                                              Navigator.of(
-                                                                      context)
-                                                                  .push(
-                                                                      currentSaleRoute);
-                                                            },
-                                                            child: Container(
-                                                              alignment: Alignment
-                                                                  .centerLeft,
-                                                              width: 80.0,
-                                                              child: Badge(
-                                                                key: badgeKey,
-                                                                position: BadgePosition
-                                                                    .topRight(
-                                                                        top: 5,
-                                                                        right:
-                                                                            -10),
-                                                                animationType:
-                                                                    BadgeAnimationType
-                                                                        .scale,
-                                                                badgeColor: Theme.of(
-                                                                        context)
-                                                                    .floatingActionButtonTheme
-                                                                    .backgroundColor,
-                                                                badgeContent:
-                                                                    Text(
-                                                                  currentSale
-                                                                      .totalNumOfItems
-                                                                      .toString(),
-                                                                  style: TextStyle(
-                                                                      color: Colors
-                                                                          .white),
-                                                                ),
-                                                                child: Padding(
-                                                                  padding: const EdgeInsets
-                                                                          .only(
-                                                                      left:
-                                                                          20.0,
-                                                                      bottom:
-                                                                          8.0,
-                                                                      right:
-                                                                          4.0,
-                                                                      top:
-                                                                          20.0),
-                                                                  child: Image
-                                                                      .asset(
-                                                                    "src/icon/cart.png",
-                                                                    width: 24.0,
-                                                                    color: Theme.of(
-                                                                            context)
-                                                                        .primaryTextTheme
-                                                                        .button
-                                                                        .color,
-                                                                  ),
+                                                                      Navigator.of(
+                                                                              context)
+                                                                          .push(
+                                                                              currentSaleRoute);
+                                                                    },
+                                                                    child:
+                                                                        Container(
+                                                                      alignment:
+                                                                          Alignment
+                                                                              .centerLeft,
+                                                                      width:
+                                                                          80.0,
+                                                                      child:
+                                                                          Badge(
+                                                                        key:
+                                                                            badgeKey,
+                                                                        position: BadgePosition.topRight(
+                                                                            top:
+                                                                                5,
+                                                                            right:
+                                                                                -10),
+                                                                        animationType:
+                                                                            BadgeAnimationType.scale,
+                                                                        badgeColor: Theme.of(context)
+                                                                            .floatingActionButtonTheme
+                                                                            .backgroundColor,
+                                                                        badgeContent:
+                                                                            Text(
+                                                                          currentSale
+                                                                              .totalNumOfItems
+                                                                              .toString(),
+                                                                          style:
+                                                                              TextStyle(color: Colors.white),
+                                                                        ),
+                                                                        child:
+                                                                            Padding(
+                                                                          padding: const EdgeInsets.only(
+                                                                              left: 20.0,
+                                                                              bottom: 8.0,
+                                                                              right: 4.0,
+                                                                              top: 20.0),
+                                                                          child:
+                                                                              Image.asset(
+                                                                            "src/icon/cart.png",
+                                                                            width:
+                                                                                24.0,
+                                                                            color:
+                                                                                Theme.of(context).primaryTextTheme.button.color,
+                                                                          ),
+                                                                        ),
+                                                                      ),
+                                                                    )))),
+                                                    Expanded(
+                                                        child: Align(
+                                                            alignment: Alignment
+                                                                .centerRight,
+                                                            child:
+                                                                SingleChildScrollView(
+                                                              scrollDirection:
+                                                                  Axis.horizontal,
+                                                              child: Padding(
+                                                                padding: EdgeInsets
+                                                                    .only(
+                                                                        left:
+                                                                            8.0),
+                                                                child: Text(
+                                                                  _isKeypadView
+                                                                      ? currentCurrency
+                                                                          .format(
+                                                                              currentAmount)
+                                                                      : "",
+                                                                  maxLines: 1,
+                                                                  style: theme
+                                                                      .invoiceAmountStyle
+                                                                      .copyWith(
+                                                                          color: Theme.of(context)
+                                                                              .textTheme
+                                                                              .headline
+                                                                              .color),
+                                                                  textAlign:
+                                                                      TextAlign
+                                                                          .right,
                                                                 ),
                                                               ),
-                                                            )))),
-                                                Expanded(
-                                                    child: Align(
-                                                        alignment: Alignment
-                                                            .centerRight,
-                                                        child:
-                                                            SingleChildScrollView(
-                                                          scrollDirection:
-                                                              Axis.horizontal,
-                                                          child: Padding(
-                                                            padding:
-                                                                EdgeInsets.only(
-                                                                    left: 8.0),
-                                                            child: Text(
-                                                              _isKeypadView
-                                                                  ? currentCurrency
-                                                                      .format(
-                                                                          currentAmount)
-                                                                  : "",
-                                                              maxLines: 1,
-                                                              style: theme
-                                                                  .invoiceAmountStyle
-                                                                  .copyWith(
-                                                                      color: Theme.of(
-                                                                              context)
-                                                                          .textTheme
-                                                                          .headline
-                                                                          .color),
-                                                              textAlign:
-                                                                  TextAlign
-                                                                      .right,
-                                                            ),
-                                                          ),
-                                                        ))),
-                                                Theme(
-                                                    data: Theme.of(context)
-                                                        .copyWith(
+                                                            ))),
+                                                    Theme(
+                                                        data: Theme.of(context).copyWith(
                                                             canvasColor: Theme
                                                                     .of(context)
                                                                 .backgroundColor),
-                                                    child: new StreamBuilder<
-                                                            AccountSettings>(
-                                                        stream: accountBloc
-                                                            .accountSettingsStream,
-                                                        builder: (settingCtx,
-                                                            settingSnapshot) {
-                                                          return StreamBuilder<
-                                                                  AccountModel>(
-                                                              stream: accountBloc
-                                                                  .accountStream,
-                                                              builder: (context,
-                                                                  snapshot) {
-                                                                List<CurrencyWrapper>
-                                                                    currencies =
-                                                                    Currency
-                                                                        .currencies
-                                                                        .map((c) =>
-                                                                            CurrencyWrapper.fromBTC(c))
-                                                                        .toList();
-                                                                currencies
-                                                                  ..addAll(accountModel
-                                                                      .fiatConversionList
-                                                                      .map((f) =>
-                                                                          CurrencyWrapper.fromFiat(
-                                                                              f)));
+                                                        child: new StreamBuilder<
+                                                                AccountSettings>(
+                                                            stream: accountBloc
+                                                                .accountSettingsStream,
+                                                            builder: (settingCtx,
+                                                                settingSnapshot) {
+                                                              return StreamBuilder<
+                                                                      AccountModel>(
+                                                                  stream: accountBloc
+                                                                      .accountStream,
+                                                                  builder: (context,
+                                                                      snapshot) {
+                                                                    List<CurrencyWrapper>
+                                                                        currencies =
+                                                                        Currency
+                                                                            .currencies
+                                                                            .map((c) =>
+                                                                                CurrencyWrapper.fromBTC(c))
+                                                                            .toList();
+                                                                    currencies
+                                                                      ..addAll(accountModel
+                                                                          .fiatConversionList
+                                                                          .map((f) =>
+                                                                              CurrencyWrapper.fromFiat(f)));
 
-                                                                return DropdownButtonHideUnderline(
-                                                                  child:
-                                                                      ButtonTheme(
-                                                                    alignedDropdown:
-                                                                        true,
-                                                                    child: BreezDropdownButton(
-                                                                        onChanged: (value) => changeCurrency(currentSale, value, userProfileBloc, accountModel),
-                                                                        iconEnabledColor: Theme.of(context).textTheme.headline.color,
-                                                                        value: currentCurrency.shortName,
-                                                                        style: theme.invoiceAmountStyle.copyWith(color: Theme.of(context).textTheme.headline.color),
-                                                                        items: Currency.currencies.map((Currency value) {
-                                                                          return DropdownMenuItem<
-                                                                              String>(
-                                                                            value:
-                                                                                value.tickerSymbol,
-                                                                            child:
-                                                                                Material(
-                                                                              child: Text(
-                                                                                value.tickerSymbol.toUpperCase(),
-                                                                                textAlign: TextAlign.right,
-                                                                                style: theme.invoiceAmountStyle.copyWith(color: Theme.of(context).textTheme.headline.color),
-                                                                              ),
-                                                                            ),
-                                                                          );
-                                                                        }).toList()
-                                                                          ..addAll(
-                                                                            accountModel.fiatConversionList.map((FiatConversion
-                                                                                fiat) {
-                                                                              return new DropdownMenuItem<String>(
-                                                                                value: fiat.currencyData.shortName,
+                                                                    return DropdownButtonHideUnderline(
+                                                                      child:
+                                                                          ButtonTheme(
+                                                                        alignedDropdown:
+                                                                            true,
+                                                                        child: BreezDropdownButton(
+                                                                            onChanged: (value) => changeCurrency(currentSale, value, userProfileBloc, accountModel),
+                                                                            iconEnabledColor: Theme.of(context).textTheme.headline.color,
+                                                                            value: currentCurrency.shortName,
+                                                                            style: theme.invoiceAmountStyle.copyWith(color: Theme.of(context).textTheme.headline.color),
+                                                                            items: Currency.currencies.map((Currency value) {
+                                                                              return DropdownMenuItem<String>(
+                                                                                value: value.tickerSymbol,
                                                                                 child: Material(
-                                                                                  child: new Text(
-                                                                                    fiat.currencyData.shortName,
+                                                                                  child: Text(
+                                                                                    value.tickerSymbol.toUpperCase(),
                                                                                     textAlign: TextAlign.right,
                                                                                     style: theme.invoiceAmountStyle.copyWith(color: Theme.of(context).textTheme.headline.color),
                                                                                   ),
                                                                                 ),
                                                                               );
-                                                                            }).toList(),
-                                                                          )),
-                                                                  ),
-                                                                );
-                                                              });
-                                                        })),
-                                              ]),
+                                                                            }).toList()
+                                                                              ..addAll(
+                                                                                accountModel.fiatConversionList.map((FiatConversion fiat) {
+                                                                                  return new DropdownMenuItem<String>(
+                                                                                    value: fiat.currencyData.shortName,
+                                                                                    child: Material(
+                                                                                      child: new Text(
+                                                                                        fiat.currencyData.shortName,
+                                                                                        textAlign: TextAlign.right,
+                                                                                        style: theme.invoiceAmountStyle.copyWith(color: Theme.of(context).textTheme.headline.color),
+                                                                                      ),
+                                                                                    ),
+                                                                                  );
+                                                                                }).toList(),
+                                                                              )),
+                                                                      ),
+                                                                    );
+                                                                  });
+                                                            })),
+                                                  ]),
+                                                ),
+                                              ],
                                             ),
-                                          ],
-                                        ),
-                                        decoration: BoxDecoration(
-                                          color:
-                                              Theme.of(context).backgroundColor,
-                                        ),
-                                        height:
-                                            MediaQuery.of(context).size.height *
+                                            decoration: BoxDecoration(
+                                              color: Theme.of(context)
+                                                  .backgroundColor,
+                                            ),
+                                            height: MediaQuery.of(context)
+                                                    .size
+                                                    .height *
                                                 0.29),
-                                    Expanded(
-                                        child: _isKeypadView
-                                            ? _numPad(
-                                                posCatalogBloc, currentSale)
-                                            : _itemsView(currentSale,
-                                                accountModel, posCatalogBloc))
+                                        Expanded(
+                                            child: _isKeypadView
+                                                ? _numPad(
+                                                    posCatalogBloc, currentSale)
+                                                : _itemsView(
+                                                    currentSale,
+                                                    accountModel,
+                                                    posCatalogBloc))
+                                      ],
+                                    ),
+                                    _itemInTransition != null
+                                        ? Positioned(
+                                            child: ScaleTransition(
+                                              scale: _scaleTransition,
+                                              child: Opacity(
+                                                opacity:
+                                                    _opacityTransition.value,
+                                                child: ItemAvatar(
+                                                    _itemInTransition.imageURL),
+                                              ),
+                                            ),
+                                            left:
+                                                _transitionAnimation.value.left,
+                                            top: _transitionAnimation.value.top)
+                                        : SizedBox()
                                   ],
-                                ),
-                                _itemInTransition != null
-                                    ? Positioned(
-                                        child: ScaleTransition(
-                                          scale: _scaleTransition,
-                                          child: Opacity(
-                                            opacity: _opacityTransition.value,
-                                            child: ItemAvatar(
-                                                _itemInTransition.imageURL),
-                                          ),
-                                        ),
-                                        left: _transitionAnimation.value.left,
-                                        top: _transitionAnimation.value.top)
-                                    : SizedBox()
-                              ],
+                                );
+                              },
                             );
                           });
                     });

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -74,7 +74,7 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
       AccountBloc accountBloc = AppBlocsProvider.of<AccountBloc>(context);
       accountSubscription = accountBloc.accountStream.listen((acc) {
         currentCurrency =
-            CurrencyWrapper.fromShortName(acc.posCurrencyShortName, acc);
+            CurrencyWrapper.fromShortName(acc.posCurrencyShortName, acc) ?? CurrencyWrapper.fromBTC(Currency.BTC);
       });
       FetchRates fetchRatesAction = FetchRates();
       accountBloc.userActionsSink.add(fetchRatesAction);
@@ -83,7 +83,6 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
           UserProfileBloc userProfileBloc =
               AppBlocsProvider.of<UserProfileBloc>(context);
           setState(() {
-            currentCurrency = CurrencyWrapper.fromBTC(Currency.BTC);
             bypassExchangeRateLock = false;
             showFlushbar(context,
                 message: "Failed to retrieve fiat exchange rates.");

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -134,15 +134,20 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
                     builder: (context, snapshot) {
                       var userProfile = snapshot.data;
                       if (userProfile == null) {
-                        return Loader();
+                        return Center(child: Loader());
                       }
                       return StreamBuilder<AccountModel>(
                           stream: accountBloc.accountStream,
                           builder: (context, snapshot) {
                             var accountModel = snapshot.data;
                             if (accountModel == null) {
-                              return Loader();
+                              return Container();
                             }
+
+                            if (accountModel.fiatConversionList.isEmpty) {
+                              return Center(child: Loader());
+                            }
+
                             double totalAmount = currentSale.totalChargeSat /
                                 currentCurrency.satConversionRate;
                             return Stack(
@@ -850,10 +855,10 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
 
       if (currency != null) {
         userProfileBloc.currencySink.add(currency);
-        accountBloc.posCurrencySink.add(currency.tickerSymbol);
+        userProfileBloc.posCurrencySink.add(currency.tickerSymbol);
       } else {
         userProfileBloc.fiatConversionSink.add(value);
-        accountBloc.posCurrencySink.add(value);
+        userProfileBloc.posCurrencySink.add(value);
       }
     });
   }

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -72,9 +72,7 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
     if (accountSubscription == null) {
       AccountBloc accountBloc = AppBlocsProvider.of<AccountBloc>(context);
       accountSubscription = accountBloc.accountStream.listen((acc) {
-        currentCurrency = _useFiat
-            ? CurrencyWrapper.fromFiat(acc.fiatCurrency)
-            : CurrencyWrapper.fromBTC(acc.currency);
+        currentCurrency = acc.posCurrency;
       });
 
       _itemFilterController.addListener(
@@ -371,7 +369,7 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
                                                                     alignedDropdown:
                                                                         true,
                                                                     child: BreezDropdownButton(
-                                                                        onChanged: (value) => changeCurrency(currentSale, value, userProfileBloc),
+                                                                        onChanged: (value) => changeCurrency(currentSale, value, userProfileBloc, accountBloc),
                                                                         iconEnabledColor: Theme.of(context).textTheme.headline.color,
                                                                         value: currentCurrency.shortName,
                                                                         style: theme.invoiceAmountStyle.copyWith(color: Theme.of(context).textTheme.headline.color),
@@ -839,8 +837,8 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
     });
   }
 
-  changeCurrency(
-      Sale currentSale, String value, UserProfileBloc userProfileBloc) {
+  changeCurrency(Sale currentSale, String value,
+      UserProfileBloc userProfileBloc, AccountBloc accountBloc) {
     setState(() {
       Currency currency = Currency.fromTickerSymbol(value);
 
@@ -852,8 +850,10 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
 
       if (currency != null) {
         userProfileBloc.currencySink.add(currency);
+        accountBloc.posCurrencySink.add(currency.tickerSymbol);
       } else {
         userProfileBloc.fiatConversionSink.add(value);
+        accountBloc.posCurrencySink.add(value);
       }
     });
   }

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -16,6 +16,7 @@ import 'package:breez/bloc/pos_catalog/bloc.dart';
 import 'package:breez/bloc/pos_catalog/model.dart';
 import 'package:breez/bloc/user_profile/breez_user_model.dart';
 import 'package:breez/bloc/user_profile/currency.dart';
+import 'package:breez/bloc/user_profile/user_actions.dart';
 import 'package:breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:breez/routes/charge/currency_wrapper.dart';
 import 'package:breez/routes/charge/sale_view.dart';
@@ -873,11 +874,11 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
 
       if (currency != null) {
         userProfileBloc.currencySink.add(currency);
-        userProfileBloc.posCurrencySink.add(currency.tickerSymbol);
       } else {
         userProfileBloc.fiatConversionSink.add(value);
-        userProfileBloc.posCurrencySink.add(value);
       }
+      SetPOSCurrency setPOSCurrency = SetPOSCurrency(value);
+      userProfileBloc.userActionsSink.add(setPOSCurrency);
     });
   }
 

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -60,6 +60,7 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
   Animation<double> _scaleTransition;
   Animation<double> _opacityTransition;
   Item _itemInTransition;
+  bool bypassExchangeRateLock = true;
 
   double get currentAmount => currentPendingItem?.total ?? 0;
 
@@ -82,6 +83,7 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
               AppBlocsProvider.of<UserProfileBloc>(context);
           setState(() {
             userProfileBloc.posCurrencySink.add("BTC");
+            bypassExchangeRateLock = false;
             showFlushbar(context,
                 message: "Failed to retrieve fiat exchange rates.");
           });
@@ -156,7 +158,7 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
                               return Container();
                             }
 
-                            if (accountModel.fiatConversionList.isEmpty) {
+                            if (bypassExchangeRateLock && accountModel.fiatConversionList.isEmpty) {
                               return Center(child: Loader());
                             }
 

--- a/lib/routes/charge/sale_view.dart
+++ b/lib/routes/charge/sale_view.dart
@@ -16,7 +16,6 @@ import 'package:flutter/material.dart';
 import 'items/item_avatar.dart';
 
 class SaleView extends StatefulWidget {
-  final bool useFiat;
   final Function() onDeleteSale;
   final Function(AccountModel, Sale) onCharge;
   final PaymentInfo salePayment;
@@ -24,7 +23,6 @@ class SaleView extends StatefulWidget {
 
   const SaleView(
       {Key key,
-      this.useFiat,
       this.onDeleteSale,
       this.onCharge,
       this.salePayment,
@@ -47,6 +45,7 @@ class SaleViewState extends State<SaleView> {
   Sale saleInProgress;
 
   Sale get currentSale => widget.readOnlySale ?? saleInProgress;
+
   @override
   void didChangeDependencies() {
     if (_currentSaleSubscrription == null && !widget.readOnly) {
@@ -103,17 +102,19 @@ class SaleViewState extends State<SaleView> {
               backgroundColor: Theme.of(context).canvasColor,
               leading: backBtn.BackButton(),
               title: Text(widget.salePayment?.title ?? "Current Sale"),
-              actions: widget.readOnly ? [] : <Widget>[
-                IconButton(
-                  icon: Icon(
-                    Icons.delete_forever,
-                    color: Theme.of(context).iconTheme.color,
-                  ),
-                  onPressed: () {
-                    widget.onDeleteSale();
-                  },
-                )
-              ],
+              actions: widget.readOnly
+                  ? []
+                  : <Widget>[
+                      IconButton(
+                        icon: Icon(
+                          Icons.delete_forever,
+                          color: Theme.of(context).iconTheme.color,
+                        ),
+                        onPressed: () {
+                          widget.onDeleteSale();
+                        },
+                      )
+                    ],
               elevation: 0.0,
             ),
             extendBody: false,
@@ -206,7 +207,6 @@ class SaleViewState extends State<SaleView> {
                   onCharge: widget.onCharge,
                   accountModel: accModel,
                   currentSale: currentSale,
-                  useFiat: widget.useFiat,
                 )),
               ),
             ),
@@ -218,7 +218,6 @@ class SaleViewState extends State<SaleView> {
 class _TotalSaleCharge extends StatelessWidget {
   final AccountModel accountModel;
   final Sale currentSale;
-  final bool useFiat;
   final Function(AccountModel accModel, Sale sale) onCharge;
   final PaymentInfo salePayment;
 
@@ -226,7 +225,6 @@ class _TotalSaleCharge extends StatelessWidget {
       {Key key,
       this.accountModel,
       this.currentSale,
-      this.useFiat,
       this.onCharge,
       this.salePayment})
       : super(key: key);
@@ -235,12 +233,8 @@ class _TotalSaleCharge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    CurrencyWrapper currentCurrency;
-    if (useFiat) {
-      currentCurrency = CurrencyWrapper.fromFiat(accountModel.fiatCurrency);
-    } else {
-      currentCurrency = CurrencyWrapper.fromBTC(accountModel.currency);
-    }
+    CurrencyWrapper currentCurrency = CurrencyWrapper.fromShortName(
+        accountModel.posCurrencyShortName, accountModel);
     var totalAmount =
         currentSale.totalChargeSat / currentCurrency.satConversionRate;
 

--- a/lib/routes/transactions/pos_payment_item.dart
+++ b/lib/routes/transactions/pos_payment_item.dart
@@ -65,10 +65,8 @@ class PosPaymentItem extends StatelessWidget {
     action.future.then((sale) {
       if (sale != null) {
         Navigator.of(context).push(FadeInRoute(
-          builder: (context) => SaleView(
-              useFiat: false,
-              readOnlySale: sale as Sale,
-              salePayment: _paymentInfo),
+          builder: (context) =>
+              SaleView(readOnlySale: sale as Sale, salePayment: _paymentInfo),
         ));
       } else {
         showPaymentDetailsDialog(context, _paymentInfo);


### PR DESCRIPTION
This PR addresses [POS-45](https://breeztech.atlassian.net/browse/POS-45).

Selected currency now persist :
- between user and pos mode,
- and after restarts*

*: Unless the app fails to retrieve exchange rates, which in that case the UI renders with BTC. 

If the user does not change to another currency at this point, the stored value for selected currency does not change. Meaning, restarting the app again and getting exchange rates without an error would display the selected currency.