### PR TITLE
Display total charge amount on pos payment dialog

### DIFF
--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -736,7 +736,7 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
           var addSaleAction = SubmitCurrentSale(payReq.paymentHash);
           posCatalogBloc.actionsSink.add(addSaleAction);
           return addSaleAction.future.then((value) {
-            return showPaymentDialog(invoiceBloc, user, payReq.rawPayReq);
+            return showPaymentDialog(invoiceBloc, user, payReq.rawPayReq, satAmount);
           });
         }).then((cleared) {
           if (!cleared) {
@@ -753,13 +753,13 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
   }
 
   Future showPaymentDialog(
-      InvoiceBloc invoiceBloc, BreezUserModel user, String payReq) {
+      InvoiceBloc invoiceBloc, BreezUserModel user, String payReq, double satAmount) {
     return showDialog<bool>(
         useRootNavigator: false,
         context: context,
         barrierDismissible: false,
         builder: (BuildContext context) {
-          return PosPaymentDialog(invoiceBloc, user, payReq);
+          return PosPaymentDialog(invoiceBloc, user, payReq, satAmount);
         }).then((clear) {
       if (clear == true) {
         clearSale();

--- a/lib/routes/charge/pos_payment_dialog.dart
+++ b/lib/routes/charge/pos_payment_dialog.dart
@@ -8,7 +8,9 @@ import 'package:breez/bloc/user_profile/breez_user_model.dart';
 import 'package:breez/routes/charge/currency_wrapper.dart';
 import 'package:breez/routes/sync_progress_dialog.dart';
 import 'package:breez/services/countdown.dart';
+import 'package:breez/services/injector.dart';
 import 'package:breez/widgets/compact_qr_image.dart';
+import 'package:breez/widgets/flushbar.dart';
 import 'package:breez/widgets/loader.dart';
 import 'package:flutter/material.dart';
 import 'package:share_extend/share_extend.dart';
@@ -40,8 +42,6 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
   StreamSubscription<Duration> _timerSubscription;
   StreamSubscription<String> _paidInvoiceSubscription;
   String _countdownString = "3:00";
-
-  bool _syncedToChain = false;
 
   @override
   void initState() {
@@ -82,59 +82,7 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog(
-        titlePadding: EdgeInsets.fromLTRB(20.0, 22.0, 0.0, 8.0),
-        title: _syncedToChain
-            ? Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text(
-                    "Scan to Pay",
-                    style: Theme.of(context).dialogTheme.titleTextStyle,
-                  ),
-                  Row(
-                    children: <Widget>[
-                      IconButton(
-                        splashColor: Colors.transparent,
-                        highlightColor: Colors.transparent,
-                        padding: EdgeInsets.only(
-                            top: 8.0, bottom: 8.0, right: 2.0, left: 14.0),
-                        icon: Icon(IconData(0xe917, fontFamily: 'icomoon')),
-                        color: Theme.of(context).primaryTextTheme.button.color,
-                        onPressed: () {
-                          ShareExtend.share(
-                              "lightning:" + widget.paymentRequest, "text");
-                        },
-                      ),
-                      IconButton(
-                        splashColor: Colors.transparent,
-                        highlightColor: Colors.transparent,
-                        padding: EdgeInsets.only(
-                            top: 8.0, bottom: 8.0, right: 14.0, left: 2.0),
-                        icon: Icon(IconData(0xe90b, fontFamily: 'icomoon')),
-                        color: Theme.of(context).primaryTextTheme.button.color,
-                        onPressed: () {
-                          ServiceInjector()
-                              .device
-                              .setClipboardText(widget.paymentRequest);
-                          showFlushbar(context,
-                              message:
-                                  "Invoice address was copied to your clipboard.",
-                              duration: Duration(seconds: 3));
-                        },
-                      )
-                    ],
-                  )
-                ],
-              )
-            : Container(),
-        contentPadding: EdgeInsets.only(left: 20.0, right: 20.0, bottom: 20.0),
-        content: SingleChildScrollView(child: buildWaitingPayment(context)));
-  }
-
-  Widget buildWaitingPayment(BuildContext context) {
     AccountBloc accountBloc = AppBlocsProvider.of<AccountBloc>(context);
-
     return StreamBuilder<AccountModel>(
         stream: accountBloc.accountStream,
         builder: (context, snapshot) {
@@ -142,64 +90,119 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
           if (account == null) {
             return Loader();
           }
-          _syncedToChain = account.syncedToChain;
-          if (_syncedToChain == false) {
-            return Padding(
-              padding: const EdgeInsets.only(bottom: 40.0),
-              child: SyncProgressDialog(closeOnSync: false),
-            );
-          }
 
-          var saleCurrency = CurrencyWrapper.fromShortName(
-              widget._user.posCurrencyShortName, account);
-          var userCurrency = CurrencyWrapper.fromBTC(widget._user.currency);
-          var priceInSaleCurrency = "";
-          if (saleCurrency.symbol != userCurrency.symbol) {
-            String salePrice = saleCurrency.format(
-                widget.satAmount / saleCurrency.satConversionRate,
-                removeTrailingZeros: true);
-            priceInSaleCurrency = " (${saleCurrency.symbol}$salePrice)";
-          }
-          return ListBody(
-            children: <Widget>[
+          return AlertDialog(
+              titlePadding: EdgeInsets.fromLTRB(20.0, 22.0, 0.0, 8.0),
+              title: _buildDialogTitle(account, context),
+              contentPadding:
+                  EdgeInsets.only(left: 20.0, right: 20.0, bottom: 20.0),
+              content: _buildWaitingPayment(account, context));
+        });
+  }
+
+  Widget _buildDialogTitle(AccountModel account, BuildContext context) {
+    return account.syncedToChain
+        ? Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
               Text(
-                userCurrency.format(
-                        widget.satAmount / userCurrency.satConversionRate,
-                        includeCurrencySuffix: true) +
-                    priceInSaleCurrency,
-                textAlign: TextAlign.center,
-                style: Theme.of(context)
-                    .textTheme
-                    .subtitle1
-                    .copyWith(fontSize: 14.3),
+                "Scan to Pay",
+                style: Theme.of(context).dialogTheme.titleTextStyle,
               ),
-              Padding(
-                padding: const EdgeInsets.symmetric(vertical: 8.0),
-                child: AspectRatio(
-                  aspectRatio: 1.0,
-                  child: Container(
-                    height: 230.0,
-                    width: 230.0,
-                    child: CompactQRImage(
-                      data: widget.paymentRequest,
-                    ),
+              Row(
+                children: <Widget>[
+                  IconButton(
+                    splashColor: Colors.transparent,
+                    highlightColor: Colors.transparent,
+                    padding: EdgeInsets.only(
+                        top: 8.0, bottom: 8.0, right: 2.0, left: 14.0),
+                    icon: Icon(IconData(0xe917, fontFamily: 'icomoon')),
+                    color: Theme.of(context).primaryTextTheme.button.color,
+                    onPressed: () {
+                      ShareExtend.share(
+                          "lightning:" + widget.paymentRequest, "text");
+                    },
                   ),
+                  IconButton(
+                    splashColor: Colors.transparent,
+                    highlightColor: Colors.transparent,
+                    padding: EdgeInsets.only(
+                        top: 8.0, bottom: 8.0, right: 14.0, left: 2.0),
+                    icon: Icon(IconData(0xe90b, fontFamily: 'icomoon')),
+                    color: Theme.of(context).primaryTextTheme.button.color,
+                    onPressed: () {
+                      ServiceInjector()
+                          .device
+                          .setClipboardText(widget.paymentRequest);
+                      showFlushbar(context,
+                          message:
+                              "Invoice address was copied to your clipboard.",
+                          duration: Duration(seconds: 3));
+                    },
+                  )
+                ],
+              )
+            ],
+          )
+        : Container();
+  }
+
+  Widget _buildWaitingPayment(AccountModel account, BuildContext context) {
+    if (account.syncedToChain == false) {
+      return Padding(
+        padding: const EdgeInsets.only(bottom: 40.0),
+        child: SyncProgressDialog(closeOnSync: false),
+      );
+    }
+
+    var saleCurrency = CurrencyWrapper.fromShortName(
+        widget._user.posCurrencyShortName, account);
+    var userCurrency = CurrencyWrapper.fromBTC(widget._user.currency);
+    var priceInSaleCurrency = "";
+    if (saleCurrency != null && saleCurrency.symbol != userCurrency.symbol) {
+      String salePrice = saleCurrency.format(
+          widget.satAmount / saleCurrency.satConversionRate,
+          removeTrailingZeros: true);
+      priceInSaleCurrency = " (${saleCurrency.symbol}$salePrice)";
+    }
+    return SingleChildScrollView(
+      child: ListBody(
+        children: <Widget>[
+          Text(
+            userCurrency.format(
+                    widget.satAmount / userCurrency.satConversionRate,
+                    includeCurrencySuffix: true) +
+                priceInSaleCurrency,
+            textAlign: TextAlign.center,
+            style:
+                Theme.of(context).textTheme.subtitle1.copyWith(fontSize: 14.3),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8.0),
+            child: AspectRatio(
+              aspectRatio: 1.0,
+              child: Container(
+                height: 230.0,
+                width: 230.0,
+                child: CompactQRImage(
+                  data: widget.paymentRequest,
                 ),
               ),
-              Text(_countdownString,
-                  textAlign: TextAlign.center,
-                  style: Theme.of(context)
-                      .primaryTextTheme
-                      .display1
-                      .copyWith(fontSize: 16)),
-              Padding(
-                padding:
-                    const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-                child: _actionsWidget(),
-              ),
-            ],
-          );
-        });
+            ),
+          ),
+          Text(_countdownString,
+              textAlign: TextAlign.center,
+              style: Theme.of(context)
+                  .primaryTextTheme
+                  .display1
+                  .copyWith(fontSize: 16)),
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+            child: _actionsWidget(),
+          ),
+        ],
+      ),
+    );
   }
 
   Widget _actionsWidget() {
@@ -218,7 +221,7 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
         style: Theme.of(context).primaryTextTheme.button,
       ),
       onPressed: () {
-        Navigator.of(context).pop(true);
+        Navigator.of(context).pop(PosPaymentResult(clearSale: true));
       },
     );
   }
@@ -232,7 +235,7 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
         style: Theme.of(context).primaryTextTheme.button,
       ),
       onPressed: () {
-        Navigator.of(context).pop(false);
+        Navigator.of(context).pop(PosPaymentResult());
       },
     );
   }

--- a/lib/routes/create_invoice/qr_code_dialog.dart
+++ b/lib/routes/create_invoice/qr_code_dialog.dart
@@ -87,6 +87,8 @@ class QrCodeDialogState extends State<QrCodeDialog>
                       return Row(
                         children: <Widget>[
                           IconButton(
+                            splashColor: Colors.transparent,
+                            highlightColor: Colors.transparent,
                             padding: EdgeInsets.only(
                                 top: 8.0, bottom: 8.0, right: 2.0, left: 14.0),
                             icon: Icon(IconData(0xe917, fontFamily: 'icomoon')),
@@ -98,6 +100,8 @@ class QrCodeDialogState extends State<QrCodeDialog>
                             },
                           ),
                           IconButton(
+                            splashColor: Colors.transparent,
+                            highlightColor: Colors.transparent,
                             padding: EdgeInsets.only(
                                 top: 8.0, bottom: 8.0, right: 14.0, left: 2.0),
                             icon: Icon(IconData(0xe90b, fontFamily: 'icomoon')),

--- a/lib/routes/create_invoice/qr_code_dialog.dart
+++ b/lib/routes/create_invoice/qr_code_dialog.dart
@@ -120,7 +120,7 @@ class QrCodeDialogState extends State<QrCodeDialog>
                 }),
           ],
         ),
-        titlePadding: EdgeInsets.fromLTRB(24.0, 22.0, 0.0, 8.0),
+        titlePadding: EdgeInsets.fromLTRB(20.0, 22.0, 0.0, 8.0),
         contentPadding: EdgeInsets.only(left: 20.0, right: 20.0, bottom: 20.0),
         children: <Widget>[
           StreamBuilder<AccountModel>(

--- a/lib/routes/create_invoice/qr_code_dialog.dart
+++ b/lib/routes/create_invoice/qr_code_dialog.dart
@@ -163,11 +163,14 @@ class QrCodeDialogState extends State<QrCodeDialog>
                     }
                     return Column(
                       children: [
-                        Container(
-                          width: 230.0,
-                          height: 230.0,
-                          child: CompactQRImage(
-                            data: snapshot.data,
+                        AspectRatio(
+                          aspectRatio: 1,
+                          child: Container(
+                            width: 230.0,
+                            height: 230.0,
+                            child: CompactQRImage(
+                              data: snapshot.data,
+                            ),
                           ),
                         ),
                         Padding(padding: EdgeInsets.only(top: 8.0)),

--- a/lib/widgets/pos_payment_dialog.dart
+++ b/lib/widgets/pos_payment_dialog.dart
@@ -104,7 +104,7 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      titlePadding: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
+      titlePadding: EdgeInsets.fromLTRB(20.0, 22.0, 0.0, 8.0),
       title: _syncedToChain
           ? Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
               Expanded(
@@ -152,7 +152,7 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
               )
             ])
           : Container(),
-      contentPadding: EdgeInsets.symmetric(horizontal: 16),
+      contentPadding: EdgeInsets.only(left: 20.0, right: 20.0, bottom: 20.0),
       content: SingleChildScrollView(
           child: _state == _PosPaymentState.WAITING_FOR_PAYMENT
               ? buildWaitingPayment(context)
@@ -237,7 +237,7 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
                     .copyWith(fontSize: 14.3),
               ),
               Padding(
-                padding:  const EdgeInsets.symmetric(vertical: 12),
+                padding: const EdgeInsets.symmetric(vertical:8.0),
                 child: AspectRatio(
                   aspectRatio: 1.0,
                   child: Container(

--- a/lib/widgets/pos_payment_dialog.dart
+++ b/lib/widgets/pos_payment_dialog.dart
@@ -231,7 +231,10 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
                         includeCurrencySuffix: true) +
                     priceInSaleCurrency,
                 textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.subtitle1,
+                style: Theme.of(context)
+                    .textTheme
+                    .subtitle1
+                    .copyWith(fontSize: 14.3),
               ),
               Padding(
                 padding:  const EdgeInsets.symmetric(vertical: 12),

--- a/lib/widgets/pos_payment_dialog.dart
+++ b/lib/widgets/pos_payment_dialog.dart
@@ -46,6 +46,8 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
   StreamSubscription<String> _sentInvoicesSubscription;
   StreamSubscription<bool> _paidInvoicesSubscription;
 
+  bool _syncedToChain = false;
+
   @override
   void initState() {
     super.initState();
@@ -103,47 +105,53 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
   Widget build(BuildContext context) {
     return AlertDialog(
       titlePadding: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
-      title: Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
-        Expanded(
-          flex: 2,
-          child: AutoSizeText(
-            "Scan to Process Payment",
-            style: Theme.of(context).dialogTheme.titleTextStyle,
-            maxLines: 1,
-            minFontSize: MinFontSize(context).minFontSize,
-            stepGranularity: 0.1,
-          ),
-        ),
-        // TODO: Hide share & copy icons during sync
-        Expanded(
-          flex: 1,
-          child: Row(children: [
-            IconButton(
-              padding: EdgeInsets.only(
-                  top: 8.0, bottom: 8.0, right: 2.0, left: 14.0),
-              icon: Icon(IconData(0xe917, fontFamily: 'icomoon')),
-              color: Theme.of(context).primaryTextTheme.button.color,
-              onPressed: () {
-                ShareExtend.share("lightning:" + widget.paymentRequest, "text");
-              },
-            ),
-            IconButton(
-              padding: EdgeInsets.only(
-                  top: 8.0, bottom: 8.0, right: 14.0, left: 2.0),
-              icon: Icon(IconData(0xe90b, fontFamily: 'icomoon')),
-              color: Theme.of(context).primaryTextTheme.button.color,
-              onPressed: () {
-                ServiceInjector()
-                    .device
-                    .setClipboardText(widget.paymentRequest);
-                showFlushbar(context,
-                    message: "Invoice address was copied to your clipboard.",
-                    duration: Duration(seconds: 3));
-              },
-            )
-          ]),
-        )
-      ]),
+      title: _syncedToChain
+          ? Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
+              Expanded(
+                flex: 2,
+                child: Padding(
+                  padding: const EdgeInsets.only(left: 8.0),
+                  child: AutoSizeText(
+                    "Scan to Process Payment",
+                    style: Theme.of(context).dialogTheme.titleTextStyle,
+                    maxLines: 1,
+                    minFontSize: MinFontSize(context).minFontSize,
+                    stepGranularity: 0.1,
+                  ),
+                ),
+              ),
+              Expanded(
+                flex: 1,
+                child: Row(children: [
+                  IconButton(
+                    iconSize: 16,
+                    icon: Icon(IconData(0xe917, fontFamily: 'icomoon')),
+                    color: Theme.of(context).primaryTextTheme.button.color,
+                    onPressed: () {
+                      ShareExtend.share(
+                          "lightning:" + widget.paymentRequest, "text");
+                    },
+                  ),
+                  Expanded(
+                    child: IconButton(
+                      iconSize: 16,
+                      icon: Icon(IconData(0xe90b, fontFamily: 'icomoon')),
+                      color: Theme.of(context).primaryTextTheme.button.color,
+                      onPressed: () {
+                        ServiceInjector()
+                            .device
+                            .setClipboardText(widget.paymentRequest);
+                        showFlushbar(context,
+                            message:
+                                "Invoice address was copied to your clipboard.",
+                            duration: Duration(seconds: 3));
+                      },
+                    ),
+                  )
+                ]),
+              )
+            ])
+          : Container(),
       contentPadding: EdgeInsets.symmetric(horizontal: 16),
       content: SingleChildScrollView(
           child: _state == _PosPaymentState.WAITING_FOR_PAYMENT
@@ -197,8 +205,8 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
           if (account == null) {
             return Loader();
           }
-
-          if (account.syncedToChain == false) {
+          _syncedToChain = account.syncedToChain;
+          if (_syncedToChain == false) {
             return Padding(
               padding: const EdgeInsets.only(bottom: 40.0),
               child: SyncProgressDialog(closeOnSync: false),
@@ -226,7 +234,7 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
                 style: Theme.of(context).textTheme.subtitle1,
               ),
               Padding(
-                padding: EdgeInsets.only(top: 16.0),
+                padding:  const EdgeInsets.symmetric(vertical: 12),
                 child: AspectRatio(
                   aspectRatio: 1.0,
                   child: Container(
@@ -238,17 +246,15 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
                   ),
                 ),
               ),
-              Padding(
-                  padding: EdgeInsets.only(top: 16.0),
-                  child: Text(_countdownString,
-                      textAlign: TextAlign.center,
-                      style: Theme.of(context)
-                          .primaryTextTheme
-                          .display1
-                          .copyWith(fontSize: 16))),
+              Text(_countdownString,
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context)
+                      .primaryTextTheme
+                      .display1
+                      .copyWith(fontSize: 16)),
               Padding(
                 padding:
-                    const EdgeInsets.symmetric(vertical: 8, horizontal: 17),
+                    const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
                 child: _actionsWidget(),
               ),
             ],

--- a/lib/widgets/pos_payment_dialog.dart
+++ b/lib/widgets/pos_payment_dialog.dart
@@ -106,35 +106,31 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
     return AlertDialog(
       titlePadding: EdgeInsets.fromLTRB(20.0, 22.0, 0.0, 8.0),
       title: _syncedToChain
-          ? Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
-              Expanded(
-                flex: 2,
-                child: Padding(
-                  padding: const EdgeInsets.only(left: 8.0),
-                  child: AutoSizeText(
-                    "Scan to Process Payment",
-                    style: Theme.of(context).dialogTheme.titleTextStyle,
-                    maxLines: 1,
-                    minFontSize: MinFontSize(context).minFontSize,
-                    stepGranularity: 0.1,
-                  ),
+          ? Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  "Scan to Pay",
+                  style: Theme.of(context).dialogTheme.titleTextStyle,
                 ),
-              ),
-              Expanded(
-                flex: 1,
-                child: Row(children: [
-                  IconButton(
-                    iconSize: 16,
-                    icon: Icon(IconData(0xe917, fontFamily: 'icomoon')),
-                    color: Theme.of(context).primaryTextTheme.button.color,
-                    onPressed: () {
-                      ShareExtend.share(
-                          "lightning:" + widget.paymentRequest, "text");
-                    },
-                  ),
-                  Expanded(
-                    child: IconButton(
-                      iconSize: 16,
+                Row(
+                  children: <Widget>[
+                    IconButton(
+                      splashColor: Colors.transparent,
+                      highlightColor: Colors.transparent,
+                      padding: EdgeInsets.only(
+                          top: 8.0, bottom: 8.0, right: 2.0, left: 14.0),
+                      icon: Icon(IconData(0xe917, fontFamily: 'icomoon')),
+                      color: Theme.of(context).primaryTextTheme.button.color,
+                      onPressed: () {
+                        ShareExtend.share("lightning:" + widget.paymentRequest, "text");
+                      },
+                    ),
+                    IconButton(
+                      splashColor: Colors.transparent,
+                      highlightColor: Colors.transparent,
+                      padding: EdgeInsets.only(
+                          top: 8.0, bottom: 8.0, right: 14.0, left: 2.0),
                       icon: Icon(IconData(0xe90b, fontFamily: 'icomoon')),
                       color: Theme.of(context).primaryTextTheme.button.color,
                       onPressed: () {
@@ -146,11 +142,11 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
                                 "Invoice address was copied to your clipboard.",
                             duration: Duration(seconds: 3));
                       },
-                    ),
-                  )
-                ]),
-              )
-            ])
+                    )
+                  ],
+                )
+              ],
+            )
           : Container(),
       contentPadding: EdgeInsets.only(left: 20.0, right: 20.0, bottom: 20.0),
       content: SingleChildScrollView(

--- a/lib/widgets/pos_payment_dialog.dart
+++ b/lib/widgets/pos_payment_dialog.dart
@@ -157,14 +157,14 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
             String salePrice = saleCurrency.format(
                 widget.satAmount / saleCurrency.satConversionRate,
                 removeTrailingZeros: true);
-            priceInSaleCurrency = "(${saleCurrency.symbol}$salePrice)";
+            priceInSaleCurrency = " (${saleCurrency.symbol}$salePrice)";
           }
           return ListBody(
             children: <Widget>[
               Text(
                 userCurrency.format(
                     widget.satAmount / userCurrency.satConversionRate,
-                    includeCurrencySuffix: true) + " " + priceInSaleCurrency,
+                    includeCurrencySuffix: true) + priceInSaleCurrency,
                 textAlign: TextAlign.center,
                 style: Theme.of(context).textTheme.subtitle1,
               ),

--- a/lib/widgets/pos_payment_dialog.dart
+++ b/lib/widgets/pos_payment_dialog.dart
@@ -9,10 +9,13 @@ import 'package:breez/bloc/user_profile/breez_user_model.dart';
 import 'package:breez/routes/charge/currency_wrapper.dart';
 import 'package:breez/routes/sync_progress_dialog.dart';
 import 'package:breez/services/countdown.dart';
+import 'package:breez/services/injector.dart';
 import 'package:breez/theme_data.dart' as theme;
+import 'package:breez/utils/min_font_size.dart';
 import 'package:breez/widgets/compact_qr_image.dart';
 import 'package:breez/widgets/flushbar.dart';
 import 'package:flutter/material.dart';
+import 'package:share_extend/share_extend.dart';
 
 import 'loader.dart';
 
@@ -200,12 +203,47 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: AutoSizeText(
-        "Scan to Process Payment",
-        style: Theme.of(context).dialogTheme.titleTextStyle,
-        maxLines: 1,
-      ),
-      contentPadding: EdgeInsets.fromLTRB(40.0, 28.0, 40.0, 0.0),
+      title: Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
+        Expanded(
+          flex: 2,
+          child: AutoSizeText(
+            "Scan to Process Payment",
+            style: Theme.of(context).dialogTheme.titleTextStyle,
+            maxLines: 1,
+            minFontSize: MinFontSize(context).minFontSize,
+            stepGranularity: 0.1,
+          ),
+        ),
+        Expanded(
+          flex: 1,
+          child: Row(children: [
+            IconButton(
+              padding: EdgeInsets.only(
+                  top: 8.0, bottom: 8.0, right: 2.0, left: 14.0),
+              icon: Icon(IconData(0xe917, fontFamily: 'icomoon')),
+              color: Theme.of(context).primaryTextTheme.button.color,
+              onPressed: () {
+                ShareExtend.share("lightning:" + widget.paymentRequest, "text");
+              },
+            ),
+            IconButton(
+              padding: EdgeInsets.only(
+                  top: 8.0, bottom: 8.0, right: 14.0, left: 2.0),
+              icon: Icon(IconData(0xe90b, fontFamily: 'icomoon')),
+              color: Theme.of(context).primaryTextTheme.button.color,
+              onPressed: () {
+                ServiceInjector()
+                    .device
+                    .setClipboardText(widget.paymentRequest);
+                showFlushbar(context,
+                    message: "Invoice address was copied to your clipboard.",
+                    duration: Duration(seconds: 3));
+              },
+            )
+          ]),
+        )
+      ]),
+      contentPadding: EdgeInsets.fromLTRB(20.0, 28.0, 20.0, 0.0),
       content: SingleChildScrollView(
           child: _state == _PosPaymentState.WAITING_FOR_PAYMENT
               ? buildWaitingPayment(context)


### PR DESCRIPTION
This PR addresses [POS-67](https://breeztech.atlassian.net/browse/POS-67)

"Scan the QR code to process this payment." text is replaced with "Scan to Process Payment" and moved to dialog's title.

Total charge amount is displayed in last selected currency(BTC/SAT) above QR image. If a fiat currency is selected, it's displayed right next to it in parenthesis.