### PR TITLE
Wait for sync when server is not ready

### DIFF
--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -547,6 +547,7 @@ class AccountBloc {
         Observable(_breezLib.notificationStream).listen((event) async {
       if (event.type ==
           NotificationEvent_NotificationType.LIGHTNING_SERVICE_DOWN) {
+            _accountController.add(_accountController.value.copyWith(serverReady: false));
         _pollSyncStatus();
         if (!_retryingLightningService) {
           _retryingLightningService = true;
@@ -560,6 +561,7 @@ class AccountBloc {
         _refreshAccountAndPayments();
       }
       if (event.type == NotificationEvent_NotificationType.READY) {
+        _accountController.add(_accountController.value.copyWith(serverReady: true));
         _refreshAccountAndPayments();
       }
       if (event.type ==

--- a/lib/bloc/account/account_model.dart
+++ b/lib/bloc/account/account_model.dart
@@ -148,6 +148,7 @@ class AccountModel {
   final bool enableInProgress;
   final double syncProgress;
   final bool syncedToChain;
+  final bool serverReady;
   final SyncUIState syncUIState;
 
   AccountModel(this._accountResponse, this._currency, this._fiatShortName,
@@ -158,6 +159,7 @@ class AccountModel {
       this.enableInProgress = false,
       this.syncProgress = 0,
       this.syncedToChain = false,
+      this.serverReady = false,
       this.syncUIState = SyncUIState.NONE});
 
   AccountModel.initial()
@@ -188,6 +190,7 @@ class AccountModel {
       bool enableInProgress,
       double syncProgress,
       bool syncedToChain,
+      bool serverReady,
       bool initial,
       SyncUIState syncUIState}) {
     return AccountModel(
@@ -202,6 +205,7 @@ class AccountModel {
         enableInProgress: enableInProgress ?? this.enableInProgress,
         syncProgress: syncProgress ?? this.syncProgress,
         syncedToChain: syncedToChain ?? this.syncedToChain,
+        serverReady: serverReady ?? this.serverReady,
         syncUIState: syncUIState ?? this.syncUIState,
         initial: initial ?? this.initial);
   }

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -34,6 +34,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import '../status_indicator.dart';
+import '../sync_progress_dialog.dart';
 import 'items/item_avatar.dart';
 import 'items/items_list.dart';
 import 'pos_payment_dialog.dart';
@@ -727,37 +728,62 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
           AppBlocsProvider.of<PosCatalogBloc>(context);
       var lockSale = SetCurrentSale(currentSale.copyWith(priceLocked: true));
       posCatalogBloc.actionsSink.add(lockSale);
-      lockSale.future.then((value) {
-        var newInvoiceAction = NewInvoice(InvoiceRequestModel(
-            user.name,
-            _invoiceDescriptionController.text,
-            user.avatarURL,
-            Int64(satAmount.toInt()),
-            expiry: Int64(user.cancellationTimeoutValue.toInt())));
-        invoiceBloc.actionsSink.add(newInvoiceAction);
-        newInvoiceAction.future.then((value) {
-          var payReq = value as PaymentRequestModel;
-          var addSaleAction = SubmitCurrentSale(payReq.paymentHash);
-          posCatalogBloc.actionsSink.add(addSaleAction);
-          return addSaleAction.future.then((submittedSale) {
-            return showPaymentDialog(invoiceBloc, user, payReq.rawPayReq, satAmount).then((cleared) {
-              if (!cleared) {
-                var unLockSale =
-                SetCurrentSale(submittedSale.copyWith(priceLocked: false));
-                posCatalogBloc.actionsSink.add(unLockSale);
-              }
+      waitForSync().then((value) {
+        if (!value) {
+          return;
+        }
+        lockSale.future.then((value) {
+          var newInvoiceAction = NewInvoice(InvoiceRequestModel(
+              user.name,
+              _invoiceDescriptionController.text,
+              user.avatarURL,
+              Int64(satAmount.toInt()),
+              expiry: Int64(user.cancellationTimeoutValue.toInt())));
+          invoiceBloc.actionsSink.add(newInvoiceAction);
+          newInvoiceAction.future.then((value) {
+            var payReq = value as PaymentRequestModel;
+            var addSaleAction = SubmitCurrentSale(payReq.paymentHash);
+            posCatalogBloc.actionsSink.add(addSaleAction);
+            return addSaleAction.future.then((submittedSale) {
+              return showPaymentDialog(
+                      invoiceBloc, user, payReq.rawPayReq, satAmount)
+                  .then((cleared) {
+                if (!cleared) {
+                  var unLockSale = SetCurrentSale(
+                      submittedSale.copyWith(priceLocked: false));
+                  posCatalogBloc.actionsSink.add(unLockSale);
+                }
+              });
             });
+          }).catchError((error) {
+            showFlushbar(context,
+                message: error.toString(), duration: Duration(seconds: 10));
           });
-        }).catchError((error) {
-          showFlushbar(context,
-              message: error.toString(), duration: Duration(seconds: 10));
         });
       });
     }
   }
 
-  Future showPaymentDialog(
-      InvoiceBloc invoiceBloc, BreezUserModel user, String payReq, double satAmount) {
+  Future<bool> waitForSync() {
+    return showDialog(
+        useRootNavigator: false,
+        context: context,
+        builder: (context) => AlertDialog(
+              content: SyncProgressDialog(closeOnSync: true),
+              actions: <Widget>[
+                FlatButton(
+                  onPressed: (() {
+                    Navigator.pop(context, false);
+                  }),
+                  child: Text("CLOSE",
+                      style: Theme.of(context).primaryTextTheme.button),
+                )
+              ],
+            ));
+  }
+
+  Future showPaymentDialog(InvoiceBloc invoiceBloc, BreezUserModel user,
+      String payReq, double satAmount) {
     return showDialog<PosPaymentResult>(
         useRootNavigator: false,
         context: context,

--- a/lib/routes/charge/pos_payment_dialog.dart
+++ b/lib/routes/charge/pos_payment_dialog.dart
@@ -6,7 +6,6 @@ import 'package:breez/bloc/blocs_provider.dart';
 import 'package:breez/bloc/invoice/invoice_bloc.dart';
 import 'package:breez/bloc/user_profile/breez_user_model.dart';
 import 'package:breez/routes/charge/currency_wrapper.dart';
-import 'package:breez/routes/sync_progress_dialog.dart';
 import 'package:breez/services/countdown.dart';
 import 'package:breez/services/injector.dart';
 import 'package:breez/widgets/compact_qr_image.dart';
@@ -101,60 +100,49 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
   }
 
   Widget _buildDialogTitle(AccountModel account, BuildContext context) {
-    return account.syncedToChain
-        ? Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                "Scan to Pay",
-                style: Theme.of(context).dialogTheme.titleTextStyle,
-              ),
-              Row(
-                children: <Widget>[
-                  IconButton(
-                    splashColor: Colors.transparent,
-                    highlightColor: Colors.transparent,
-                    padding: EdgeInsets.only(
-                        top: 8.0, bottom: 8.0, right: 2.0, left: 14.0),
-                    icon: Icon(IconData(0xe917, fontFamily: 'icomoon')),
-                    color: Theme.of(context).primaryTextTheme.button.color,
-                    onPressed: () {
-                      ShareExtend.share(
-                          "lightning:" + widget.paymentRequest, "text");
-                    },
-                  ),
-                  IconButton(
-                    splashColor: Colors.transparent,
-                    highlightColor: Colors.transparent,
-                    padding: EdgeInsets.only(
-                        top: 8.0, bottom: 8.0, right: 14.0, left: 2.0),
-                    icon: Icon(IconData(0xe90b, fontFamily: 'icomoon')),
-                    color: Theme.of(context).primaryTextTheme.button.color,
-                    onPressed: () {
-                      ServiceInjector()
-                          .device
-                          .setClipboardText(widget.paymentRequest);
-                      showFlushbar(context,
-                          message:
-                              "Invoice address was copied to your clipboard.",
-                          duration: Duration(seconds: 3));
-                    },
-                  )
-                ],
-              )
-            ],
-          )
-        : Container();
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          "Scan to Pay",
+          style: Theme.of(context).dialogTheme.titleTextStyle,
+        ),
+        Row(
+          children: <Widget>[
+            IconButton(
+              splashColor: Colors.transparent,
+              highlightColor: Colors.transparent,
+              padding: EdgeInsets.only(
+                  top: 8.0, bottom: 8.0, right: 2.0, left: 14.0),
+              icon: Icon(IconData(0xe917, fontFamily: 'icomoon')),
+              color: Theme.of(context).primaryTextTheme.button.color,
+              onPressed: () {
+                ShareExtend.share("lightning:" + widget.paymentRequest, "text");
+              },
+            ),
+            IconButton(
+              splashColor: Colors.transparent,
+              highlightColor: Colors.transparent,
+              padding: EdgeInsets.only(
+                  top: 8.0, bottom: 8.0, right: 14.0, left: 2.0),
+              icon: Icon(IconData(0xe90b, fontFamily: 'icomoon')),
+              color: Theme.of(context).primaryTextTheme.button.color,
+              onPressed: () {
+                ServiceInjector()
+                    .device
+                    .setClipboardText(widget.paymentRequest);
+                showFlushbar(context,
+                    message: "Invoice address was copied to your clipboard.",
+                    duration: Duration(seconds: 3));
+              },
+            )
+          ],
+        )
+      ],
+    );
   }
 
   Widget _buildWaitingPayment(AccountModel account, BuildContext context) {
-    if (account.syncedToChain == false) {
-      return Padding(
-        padding: const EdgeInsets.only(bottom: 40.0),
-        child: SyncProgressDialog(closeOnSync: false),
-      );
-    }
-
     var saleCurrency = CurrencyWrapper.fromShortName(
         widget._user.posCurrencyShortName, account);
     var userCurrency = CurrencyWrapper.fromBTC(widget._user.currency);
@@ -174,8 +162,7 @@ class _PosPaymentDialogState extends State<PosPaymentDialog> {
                     includeCurrencySuffix: true) +
                 priceInSaleCurrency,
             textAlign: TextAlign.center,
-            style:
-                Theme.of(context).primaryTextTheme.display1,
+            style: Theme.of(context).primaryTextTheme.display1,
           ),
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 8.0),

--- a/lib/routes/sync_progress_dialog.dart
+++ b/lib/routes/sync_progress_dialog.dart
@@ -25,7 +25,8 @@ class SyncProgressDialogState extends State<SyncProgressDialog> {
     if (_accountBloc == null && this.widget.closeOnSync) {
       _accountBloc = AppBlocsProvider.of<AccountBloc>(context);
       _accountBloc.accountStream
-          .firstWhere((a) => a?.syncedToChain == true, orElse: () => null)
+          .firstWhere((a) => a?.syncedToChain == true && a.serverReady,
+              orElse: () => null)
           .then((a) {
         if (this.mounted) {
           Navigator.of(context).pop(true);
@@ -44,14 +45,17 @@ class SyncProgressDialogState extends State<SyncProgressDialog> {
         if (acc == null) {
           return SizedBox();
         }
+
         return Container(
           width: MediaQuery.of(context).size.width,
           height: 150.0,
           child: CircularProgress(
               color: Theme.of(context).textTheme.button.color,
               size: 100.0,
-              value: acc.syncProgress,
-              title: "Synchronizing to the network"),
+              value: acc.serverReady ? acc.syncProgress : null,
+              title: acc.serverReady
+                  ? "Synchronizing to the network"
+                  : "Waiting for network"),
         );
       },
     );

--- a/lib/widgets/circular_progress.dart
+++ b/lib/widgets/circular_progress.dart
@@ -34,7 +34,7 @@ class CircularProgress extends StatelessWidget {
                 ),
               ),
             ),
-            Center(
+            value == null ? SizedBox() : Center(
                 child: Container(
               width: size * 0.6,
               child: AutoSizeText("${(value * 100).round().toString()}%",


### PR DESCRIPTION
This PR fixes the sync progress dialog to refer to the daemon status as well.
If the daemon is not ready the sync progress shows a progress indicator with "Waiting for network" text.
The serverStatus flag is now populated in AccountModel.
In addition the waiting for sync handling in the POS flow is now moved outside (and before) the payment dialog.