### PR TITLE
Support spontaneous payment

### DIFF
--- a/lib/bloc/account/account_actions.dart
+++ b/lib/bloc/account/account_actions.dart
@@ -1,5 +1,5 @@
 import 'package:breez/bloc/async_action.dart';
-
+import 'package:fixnum/fixnum.dart';
 import 'account_model.dart';
 
 class SendPaymentFailureReport extends AsyncAction {
@@ -23,6 +23,14 @@ class SendPayment extends AsyncAction {
   final bool ignoreGlobalFeedback;
 
   SendPayment(this.paymentRequest, {this.ignoreGlobalFeedback = false});
+}
+
+class SendSpontaneousPayment extends AsyncAction {
+  final String nodeID;
+  final Int64 amount;
+  final String description;
+
+  SendSpontaneousPayment(this.nodeID, this.amount, this.description);
 }
 
 class CancelPaymentRequest extends AsyncAction {

--- a/lib/bloc/account/account_model.dart
+++ b/lib/bloc/account/account_model.dart
@@ -537,15 +537,17 @@ class PayRequest {
 
 class CompletedPayment {
   final PayRequest paymentRequest;
+  final String paymentHash;
   final bool cancelled;
   final bool ignoreGlobalFeedback;
 
-  CompletedPayment(this.paymentRequest,
+  CompletedPayment(this.paymentRequest, this.paymentHash,
       {this.cancelled = false, this.ignoreGlobalFeedback = false});
 }
 
 class PaymentError implements Exception {
   final PayRequest request;
+  final String paymentHash;
   final Object error;
   final String traceReport;
   final bool ignoreGlobalFeedback;
@@ -554,7 +556,7 @@ class PaymentError implements Exception {
       traceReport == null ||
       traceReport.isEmpty;
 
-  PaymentError(this.request, this.error, this.traceReport,
+  PaymentError(this.request, this.paymentHash, this.error, this.traceReport,
       {this.ignoreGlobalFeedback = false});
 
   String errMsg() => error?.toString();

--- a/lib/bloc/invoice/invoice_bloc.dart
+++ b/lib/bloc/invoice/invoice_bloc.dart
@@ -13,6 +13,7 @@ import 'package:breez/services/nfc.dart';
 import 'package:breez/services/notifications.dart';
 import 'package:breez/utils/bip21.dart';
 import 'package:fixnum/fixnum.dart';
+import 'package:hex/hex.dart';
 import 'package:rxdart/rxdart.dart';
 
 import '../async_actions_handler.dart';
@@ -78,7 +79,10 @@ class InvoiceBloc with AsyncActionsHandler {
           return s;
         }
         return null;
-      });
+      }).where((event) => event != null);
+
+  Stream<String> get clipboardNodeIdStream =>
+      device.rawClipboardStream.where((s) => s != null &&s.length == 66);
 
   void _listenInvoiceRequests(BreezBridge breezLib, NFCService nfc) {
     _newInvoiceRequestController.stream.listen((invoiceRequest) {
@@ -182,8 +186,7 @@ class InvoiceBloc with AsyncActionsHandler {
           try {
             await breezLib.getRelatedInvoice(paymentRequest);
             log.info("filtering our invoice from clipboard");
-             _receivedInvoicesController
-              .add(null);
+            _receivedInvoicesController.add(null);
             _receivedInvoicesController
                 .addError(PaymentRequestModel(null, paymentRequest, null));
             return null;

--- a/lib/routes/home/account_page.dart
+++ b/lib/routes/home/account_page.dart
@@ -6,6 +6,7 @@ import 'package:breez/bloc/lsp/lsp_bloc.dart';
 import 'package:breez/bloc/lsp/lsp_model.dart';
 import 'package:breez/bloc/user_profile/currency.dart';
 import 'package:breez/bloc/user_profile/user_profile_bloc.dart';
+import 'package:breez/home_page.dart';
 import 'package:breez/utils/date.dart';
 import 'package:breez/widgets/fixed_sliver_delegate.dart';
 import 'package:breez/widgets/scroll_watcher.dart';
@@ -186,7 +187,7 @@ class AccountPageState extends State<AccountPage>
                 (offset / (DASHBOARD_MAX_HEIGHT - DASHBOARD_MIN_HEIGHT))
                     .clamp(0.0, 1.0);
             return account != null && !account.initial
-                ? FloatingActionsBar(account, height, heightFactor)
+                ? FloatingActionsBar(account, height, heightFactor, firstPaymentItemKey)
                 : Positioned(top: 0.0, child: SizedBox());
           },
         ),

--- a/lib/routes/spontaneous_payment/spontaneous_payment_page.dart
+++ b/lib/routes/spontaneous_payment/spontaneous_payment_page.dart
@@ -1,0 +1,239 @@
+import 'dart:async';
+
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:breez/bloc/account/account_actions.dart';
+import 'package:breez/bloc/account/account_bloc.dart';
+import 'package:breez/bloc/account/account_model.dart';
+import 'package:breez/bloc/blocs_provider.dart';
+import 'package:breez/theme_data.dart' as theme;
+import 'package:breez/utils/min_font_size.dart';
+import 'package:breez/widgets/amount_form_field.dart';
+import 'package:breez/widgets/back_button.dart' as backBtn;
+import 'package:breez/widgets/collapsible_list_item.dart';
+import 'package:breez/widgets/error_dialog.dart';
+import 'package:breez/widgets/keyboard_done_action.dart';
+import 'package:breez/widgets/processsing_payment_dialog.dart';
+import 'package:breez/widgets/single_button_bottom_bar.dart';
+import 'package:breez/widgets/static_loader.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class SpontaneousPaymentPage extends StatefulWidget {
+  final String nodeID;
+  final GlobalKey firstPaymentItemKey;
+
+  const SpontaneousPaymentPage(this.nodeID, this.firstPaymentItemKey);
+
+  @override
+  State<StatefulWidget> createState() {
+    return SpontaneousPaymentPageState();
+  }
+}
+
+class SpontaneousPaymentPageState extends State<SpontaneousPaymentPage> {
+  final _formKey = GlobalKey<FormState>();
+
+  final TextEditingController _descriptionController = TextEditingController();
+  final TextEditingController _amountController = TextEditingController();
+
+  final FocusNode _amountFocusNode = FocusNode();
+  KeyboardDoneAction _doneAction;
+  ModalRoute _currentRoute;
+
+  @override
+  void initState() {
+    _doneAction = KeyboardDoneAction(<FocusNode>[_amountFocusNode]);
+    super.initState();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_currentRoute == null) {
+      _currentRoute = ModalRoute.of(context);
+    }
+  }
+
+  @override
+  void dispose() {
+    _doneAction.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final String _title = "Send Payment";
+    AccountBloc accountBloc = AppBlocsProvider.of<AccountBloc>(context);
+
+    return Scaffold(
+      bottomNavigationBar: StreamBuilder<AccountModel>(
+          stream: accountBloc.accountStream,
+          builder: (context, snapshot) {
+            if (!snapshot.hasData) {
+              return StaticLoader();
+            }
+            var account = snapshot.data;
+            return Padding(
+              padding: const EdgeInsets.only(top: 24.0),
+              child: SingleButtonBottomBar(
+                stickToBottom: true,
+                text: "PAY",
+                onPressed: () {
+                  if (_formKey.currentState.validate()) {
+                    _sendPayment(accountBloc, account);
+                  }
+                },
+              ),
+            );
+          }),
+      appBar: AppBar(
+        iconTheme: Theme.of(context).appBarTheme.iconTheme,
+        textTheme: Theme.of(context).appBarTheme.textTheme,
+        backgroundColor: Theme.of(context).canvasColor,
+        leading: backBtn.BackButton(),
+        title: Text(_title,
+            style: Theme.of(context).appBarTheme.textTheme.headline6),
+        elevation: 0.0,
+      ),
+      body: StreamBuilder<AccountModel>(
+        stream: accountBloc.accountStream,
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return StaticLoader();
+          }
+          AccountModel acc = snapshot.data;
+          return Form(
+            key: _formKey,
+            child: Padding(
+              padding: EdgeInsets.only(
+                  left: 16.0, right: 16.0, bottom: 40.0, top: 24.0),
+              child: Column(
+                mainAxisSize: MainAxisSize.max,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  _buildNodeIdDescription(),
+                  TextFormField(
+                    controller: _descriptionController,
+                    keyboardType: TextInputType.multiline,
+                    textInputAction: TextInputAction.done,
+                    maxLines: null,
+                    maxLength: 90,
+                    maxLengthEnforced: true,
+                    decoration: InputDecoration(
+                      labelText: "Tip Message (optional)",
+                    ),
+                    style: theme.FieldTextStyle.textStyle,
+                  ),
+                  AmountFormField(
+                      context: context,
+                      accountModel: acc,
+                      focusNode: _amountFocusNode,
+                      controller: _amountController,
+                      validatorFn: acc.validateOutgoingPayment,
+                      style: theme.FieldTextStyle.textStyle),
+                  Container(
+                    width: MediaQuery.of(context).size.width,
+                    height: 48,
+                    padding: EdgeInsets.only(top: 16.0),
+                    child: _buildPayableBTC(acc),
+                  ),
+                  StreamBuilder(
+                      stream: accountBloc.accountStream,
+                      builder: (BuildContext context,
+                          AsyncSnapshot<AccountModel> accSnapshot) {
+                        if (!accSnapshot.hasData) {
+                          return Container();
+                        }
+                        AccountModel acc = accSnapshot.data;
+
+                        String message;
+                        if (accSnapshot.hasError) {
+                          message = accSnapshot.error.toString();
+                        } else if (acc.processingConnection) {
+                          message =
+                              'You will be able to receive payments after Breez is finished opening a secure channel with our server. This usually takes ~10 minutes to be completed. Please try again in a couple of minutes.';
+                        }
+
+                        if (message != null) {
+                          return Container(
+                              padding: EdgeInsets.only(
+                                  top: 50.0, left: 30.0, right: 30.0),
+                              child: Column(children: <Widget>[
+                                Text(
+                                  message,
+                                  textAlign: TextAlign.center,
+                                  style: theme.warningStyle.copyWith(
+                                      color: Theme.of(context).errorColor),
+                                ),
+                              ]));
+                        } else {
+                          return SizedBox();
+                        }
+                      })
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildPayableBTC(AccountModel acc) {
+    return GestureDetector(
+      child: AutoSizeText(
+        "Pay up to: ${acc.currency.format(acc.maxAllowedToPay)}",
+        style: theme.textStyle,
+        maxLines: 1,
+        minFontSize: MinFontSize(context).minFontSize,
+      ),
+      onTap: () => _amountController.text = acc.currency.format(
+          acc.maxAllowedToPay,
+          includeDisplayName: false,
+          userInput: true),
+    );
+  }
+
+  Widget _buildNodeIdDescription() {
+    return CollapsibleListItem(
+        title: "Node ID", sharedValue: widget.nodeID, color: Colors.white);
+  }
+
+  Future _sendPayment(AccountBloc accBloc, AccountModel account) async {
+    String tipMessage = _descriptionController.text;
+    var amount = account.currency.parse(_amountController.text);
+    var ok = await promptAreYouSure(context, "Send Payment",
+        Text("Are you sure you want to ${account.currency.format(amount)} to this node?\n\n${this.widget.nodeID}"),
+        okText: "Pay", cancelText: "Cancel");
+    if (ok) {
+      var sendAction =
+          SendSpontaneousPayment(widget.nodeID, amount, tipMessage);
+      accBloc.userActionsSink.add(sendAction);
+      try {
+        String paymentHash = await sendAction.future;
+        showDialog(
+            useRootNavigator: false,
+            context: context,
+            barrierDismissible: false,
+            builder: (_) => ProcessingPaymentDialog(
+                  context,
+                  paymentHash,
+                  accBloc,
+                  widget.firstPaymentItemKey,
+                  300,
+                  (_) {},
+                  popOnCompletion: true,
+                ));
+        Navigator.of(context).removeRoute(_currentRoute);
+      } catch (err) {
+        promptError(
+            context,
+            "Payment Error",
+            Text(
+              err.toString(),
+              style: Theme.of(context).dialogTheme.contentTextStyle,
+            ));
+      }
+    }
+  }
+}

--- a/lib/services/breezlib/breez_bridge.dart
+++ b/lib/services/breezlib/breez_bridge.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-
 import 'package:breez/logger.dart' as logger;
 import 'package:breez/services/breezlib/data/rpc.pb.dart';
 import 'package:fixnum/fixnum.dart';
@@ -227,6 +226,15 @@ class BreezBridge {
   Future<ReverseSwapPaymentStatuses> reverseSwapPayments() {
     return _invokeMethodWhenReady("reverseSwapPayments")
         .then((p) => ReverseSwapPaymentStatuses()..mergeFromBuffer(p ?? []));
+  }
+
+  Future<String> sendSpontaneousPayment(String destNode, Int64 amount, String description) {
+    var request = SpontaneousPaymentRequest()
+      ..description = description
+      ..destNode = destNode
+      ..amount = amount;
+      return _invokeMethodWhenReady(
+        "sendSpontaneousPayment", {"argument": request.writeToBuffer()}).then((res) => res as String);
   }
 
   Future sendPaymentForRequest(String blankInvoicePaymentRequest,

--- a/lib/services/breezlib/data/rpc.pb.dart
+++ b/lib/services/breezlib/data/rpc.pb.dart
@@ -15,41 +15,31 @@ import 'rpc.pbenum.dart';
 export 'rpc.pbenum.dart';
 
 class ChainStatus extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ChainStatus',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
-    ..a<$core.int>(1, 'blockHeight', $pb.PbFieldType.OU3,
-        protoName: 'blockHeight')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ChainStatus', package: const $pb.PackageName('data'), createEmptyInstance: create)
+    ..a<$core.int>(1, 'blockHeight', $pb.PbFieldType.OU3, protoName: 'blockHeight')
     ..aOB(2, 'syncedToChain', protoName: 'syncedToChain')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   ChainStatus._() : super();
   factory ChainStatus() => create();
-  factory ChainStatus.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ChainStatus.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ChainStatus.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ChainStatus.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   ChainStatus clone() => ChainStatus()..mergeFromMessage(this);
-  ChainStatus copyWith(void Function(ChainStatus) updates) =>
-      super.copyWith((message) => updates(message as ChainStatus));
+  ChainStatus copyWith(void Function(ChainStatus) updates) => super.copyWith((message) => updates(message as ChainStatus));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ChainStatus create() => ChainStatus._();
   ChainStatus createEmptyInstance() => create();
   static $pb.PbList<ChainStatus> createRepeated() => $pb.PbList<ChainStatus>();
   @$core.pragma('dart2js:noInline')
-  static ChainStatus getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ChainStatus>(create);
+  static ChainStatus getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChainStatus>(create);
   static ChainStatus _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get blockHeight => $_getIZ(0);
   @$pb.TagNumber(1)
-  set blockHeight($core.int v) {
-    $_setUnsignedInt32(0, v);
-  }
-
+  set blockHeight($core.int v) { $_setUnsignedInt32(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasBlockHeight() => $_has(0);
   @$pb.TagNumber(1)
@@ -58,10 +48,7 @@ class ChainStatus extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get syncedToChain => $_getBF(1);
   @$pb.TagNumber(2)
-  set syncedToChain($core.bool v) {
-    $_setBool(1, v);
-  }
-
+  set syncedToChain($core.bool v) { $_setBool(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasSyncedToChain() => $_has(1);
   @$pb.TagNumber(2)
@@ -69,15 +56,11 @@ class ChainStatus extends $pb.GeneratedMessage {
 }
 
 class Account extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Account',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Account', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'id')
     ..aInt64(2, 'balance')
     ..aInt64(3, 'walletBalance', protoName: 'walletBalance')
-    ..e<Account_AccountStatus>(4, 'status', $pb.PbFieldType.OE,
-        defaultOrMaker: Account_AccountStatus.DISCONNECTED,
-        valueOf: Account_AccountStatus.valueOf,
-        enumValues: Account_AccountStatus.values)
+    ..e<Account_AccountStatus>(4, 'status', $pb.PbFieldType.OE, defaultOrMaker: Account_AccountStatus.DISCONNECTED, valueOf: Account_AccountStatus.valueOf, enumValues: Account_AccountStatus.values)
     ..aInt64(5, 'maxAllowedToReceive', protoName: 'maxAllowedToReceive')
     ..aInt64(6, 'maxAllowedToPay', protoName: 'maxAllowedToPay')
     ..aInt64(7, 'maxPaymentAmount', protoName: 'maxPaymentAmount')
@@ -87,36 +70,28 @@ class Account extends $pb.GeneratedMessage {
     ..aOS(11, 'channelPoint', protoName: 'channelPoint')
     ..aOB(12, 'readyForPayments', protoName: 'readyForPayments')
     ..aInt64(13, 'tipHeight', protoName: 'tipHeight')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   Account._() : super();
   factory Account() => create();
-  factory Account.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Account.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory Account.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Account.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   Account clone() => Account()..mergeFromMessage(this);
-  Account copyWith(void Function(Account) updates) =>
-      super.copyWith((message) => updates(message as Account));
+  Account copyWith(void Function(Account) updates) => super.copyWith((message) => updates(message as Account));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Account create() => Account._();
   Account createEmptyInstance() => create();
   static $pb.PbList<Account> createRepeated() => $pb.PbList<Account>();
   @$core.pragma('dart2js:noInline')
-  static Account getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Account>(create);
+  static Account getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Account>(create);
   static Account _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) {
-    $_setString(0, v);
-  }
-
+  set id($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
@@ -125,10 +100,7 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get balance => $_getI64(1);
   @$pb.TagNumber(2)
-  set balance($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set balance($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasBalance() => $_has(1);
   @$pb.TagNumber(2)
@@ -137,10 +109,7 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get walletBalance => $_getI64(2);
   @$pb.TagNumber(3)
-  set walletBalance($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set walletBalance($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasWalletBalance() => $_has(2);
   @$pb.TagNumber(3)
@@ -149,10 +118,7 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   Account_AccountStatus get status => $_getN(3);
   @$pb.TagNumber(4)
-  set status(Account_AccountStatus v) {
-    setField(4, v);
-  }
-
+  set status(Account_AccountStatus v) { setField(4, v); }
   @$pb.TagNumber(4)
   $core.bool hasStatus() => $_has(3);
   @$pb.TagNumber(4)
@@ -161,10 +127,7 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $fixnum.Int64 get maxAllowedToReceive => $_getI64(4);
   @$pb.TagNumber(5)
-  set maxAllowedToReceive($fixnum.Int64 v) {
-    $_setInt64(4, v);
-  }
-
+  set maxAllowedToReceive($fixnum.Int64 v) { $_setInt64(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasMaxAllowedToReceive() => $_has(4);
   @$pb.TagNumber(5)
@@ -173,10 +136,7 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get maxAllowedToPay => $_getI64(5);
   @$pb.TagNumber(6)
-  set maxAllowedToPay($fixnum.Int64 v) {
-    $_setInt64(5, v);
-  }
-
+  set maxAllowedToPay($fixnum.Int64 v) { $_setInt64(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasMaxAllowedToPay() => $_has(5);
   @$pb.TagNumber(6)
@@ -185,10 +145,7 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $fixnum.Int64 get maxPaymentAmount => $_getI64(6);
   @$pb.TagNumber(7)
-  set maxPaymentAmount($fixnum.Int64 v) {
-    $_setInt64(6, v);
-  }
-
+  set maxPaymentAmount($fixnum.Int64 v) { $_setInt64(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasMaxPaymentAmount() => $_has(6);
   @$pb.TagNumber(7)
@@ -197,10 +154,7 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $fixnum.Int64 get routingNodeFee => $_getI64(7);
   @$pb.TagNumber(8)
-  set routingNodeFee($fixnum.Int64 v) {
-    $_setInt64(7, v);
-  }
-
+  set routingNodeFee($fixnum.Int64 v) { $_setInt64(7, v); }
   @$pb.TagNumber(8)
   $core.bool hasRoutingNodeFee() => $_has(7);
   @$pb.TagNumber(8)
@@ -209,10 +163,7 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.bool get enabled => $_getBF(8);
   @$pb.TagNumber(9)
-  set enabled($core.bool v) {
-    $_setBool(8, v);
-  }
-
+  set enabled($core.bool v) { $_setBool(8, v); }
   @$pb.TagNumber(9)
   $core.bool hasEnabled() => $_has(8);
   @$pb.TagNumber(9)
@@ -221,10 +172,7 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $fixnum.Int64 get maxChanReserve => $_getI64(9);
   @$pb.TagNumber(10)
-  set maxChanReserve($fixnum.Int64 v) {
-    $_setInt64(9, v);
-  }
-
+  set maxChanReserve($fixnum.Int64 v) { $_setInt64(9, v); }
   @$pb.TagNumber(10)
   $core.bool hasMaxChanReserve() => $_has(9);
   @$pb.TagNumber(10)
@@ -233,10 +181,7 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $core.String get channelPoint => $_getSZ(10);
   @$pb.TagNumber(11)
-  set channelPoint($core.String v) {
-    $_setString(10, v);
-  }
-
+  set channelPoint($core.String v) { $_setString(10, v); }
   @$pb.TagNumber(11)
   $core.bool hasChannelPoint() => $_has(10);
   @$pb.TagNumber(11)
@@ -245,10 +190,7 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(12)
   $core.bool get readyForPayments => $_getBF(11);
   @$pb.TagNumber(12)
-  set readyForPayments($core.bool v) {
-    $_setBool(11, v);
-  }
-
+  set readyForPayments($core.bool v) { $_setBool(11, v); }
   @$pb.TagNumber(12)
   $core.bool hasReadyForPayments() => $_has(11);
   @$pb.TagNumber(12)
@@ -257,10 +199,7 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(13)
   $fixnum.Int64 get tipHeight => $_getI64(12);
   @$pb.TagNumber(13)
-  set tipHeight($fixnum.Int64 v) {
-    $_setInt64(12, v);
-  }
-
+  set tipHeight($fixnum.Int64 v) { $_setInt64(12, v); }
   @$pb.TagNumber(13)
   $core.bool hasTipHeight() => $_has(12);
   @$pb.TagNumber(13)
@@ -268,59 +207,44 @@ class Account extends $pb.GeneratedMessage {
 }
 
 class Payment extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Payment',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
-    ..e<Payment_PaymentType>(1, 'type', $pb.PbFieldType.OE,
-        defaultOrMaker: Payment_PaymentType.DEPOSIT,
-        valueOf: Payment_PaymentType.valueOf,
-        enumValues: Payment_PaymentType.values)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Payment', package: const $pb.PackageName('data'), createEmptyInstance: create)
+    ..e<Payment_PaymentType>(1, 'type', $pb.PbFieldType.OE, defaultOrMaker: Payment_PaymentType.DEPOSIT, valueOf: Payment_PaymentType.valueOf, enumValues: Payment_PaymentType.values)
     ..aInt64(3, 'amount')
     ..aInt64(4, 'creationTimestamp', protoName: 'creationTimestamp')
-    ..aOM<InvoiceMemo>(6, 'invoiceMemo',
-        protoName: 'invoiceMemo', subBuilder: InvoiceMemo.create)
+    ..aOM<InvoiceMemo>(6, 'invoiceMemo', protoName: 'invoiceMemo', subBuilder: InvoiceMemo.create)
     ..aOS(7, 'redeemTxID', protoName: 'redeemTxID')
     ..aOS(8, 'paymentHash', protoName: 'paymentHash')
     ..aOS(9, 'destination')
-    ..a<$core.int>(10, 'PendingExpirationHeight', $pb.PbFieldType.OU3,
-        protoName: 'PendingExpirationHeight')
-    ..aInt64(11, 'PendingExpirationTimestamp',
-        protoName: 'PendingExpirationTimestamp')
+    ..a<$core.int>(10, 'PendingExpirationHeight', $pb.PbFieldType.OU3, protoName: 'PendingExpirationHeight')
+    ..aInt64(11, 'PendingExpirationTimestamp', protoName: 'PendingExpirationTimestamp')
     ..aInt64(12, 'fee')
     ..aOS(13, 'preimage')
     ..aOS(14, 'closedChannelPoint', protoName: 'closedChannelPoint')
     ..aOB(15, 'isChannelPending', protoName: 'isChannelPending')
     ..aOB(16, 'isChannelCloseConfimed', protoName: 'isChannelCloseConfimed')
     ..aOS(17, 'closedChannelTxID', protoName: 'closedChannelTxID')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   Payment._() : super();
   factory Payment() => create();
-  factory Payment.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Payment.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory Payment.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Payment.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   Payment clone() => Payment()..mergeFromMessage(this);
-  Payment copyWith(void Function(Payment) updates) =>
-      super.copyWith((message) => updates(message as Payment));
+  Payment copyWith(void Function(Payment) updates) => super.copyWith((message) => updates(message as Payment));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Payment create() => Payment._();
   Payment createEmptyInstance() => create();
   static $pb.PbList<Payment> createRepeated() => $pb.PbList<Payment>();
   @$core.pragma('dart2js:noInline')
-  static Payment getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Payment>(create);
+  static Payment getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Payment>(create);
   static Payment _defaultInstance;
 
   @$pb.TagNumber(1)
   Payment_PaymentType get type => $_getN(0);
   @$pb.TagNumber(1)
-  set type(Payment_PaymentType v) {
-    setField(1, v);
-  }
-
+  set type(Payment_PaymentType v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasType() => $_has(0);
   @$pb.TagNumber(1)
@@ -329,10 +253,7 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get amount => $_getI64(1);
   @$pb.TagNumber(3)
-  set amount($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amount($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(3)
   $core.bool hasAmount() => $_has(1);
   @$pb.TagNumber(3)
@@ -341,10 +262,7 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get creationTimestamp => $_getI64(2);
   @$pb.TagNumber(4)
-  set creationTimestamp($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set creationTimestamp($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(4)
   $core.bool hasCreationTimestamp() => $_has(2);
   @$pb.TagNumber(4)
@@ -353,10 +271,7 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   InvoiceMemo get invoiceMemo => $_getN(3);
   @$pb.TagNumber(6)
-  set invoiceMemo(InvoiceMemo v) {
-    setField(6, v);
-  }
-
+  set invoiceMemo(InvoiceMemo v) { setField(6, v); }
   @$pb.TagNumber(6)
   $core.bool hasInvoiceMemo() => $_has(3);
   @$pb.TagNumber(6)
@@ -367,10 +282,7 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.String get redeemTxID => $_getSZ(4);
   @$pb.TagNumber(7)
-  set redeemTxID($core.String v) {
-    $_setString(4, v);
-  }
-
+  set redeemTxID($core.String v) { $_setString(4, v); }
   @$pb.TagNumber(7)
   $core.bool hasRedeemTxID() => $_has(4);
   @$pb.TagNumber(7)
@@ -379,10 +291,7 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.String get paymentHash => $_getSZ(5);
   @$pb.TagNumber(8)
-  set paymentHash($core.String v) {
-    $_setString(5, v);
-  }
-
+  set paymentHash($core.String v) { $_setString(5, v); }
   @$pb.TagNumber(8)
   $core.bool hasPaymentHash() => $_has(5);
   @$pb.TagNumber(8)
@@ -391,10 +300,7 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.String get destination => $_getSZ(6);
   @$pb.TagNumber(9)
-  set destination($core.String v) {
-    $_setString(6, v);
-  }
-
+  set destination($core.String v) { $_setString(6, v); }
   @$pb.TagNumber(9)
   $core.bool hasDestination() => $_has(6);
   @$pb.TagNumber(9)
@@ -403,10 +309,7 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $core.int get pendingExpirationHeight => $_getIZ(7);
   @$pb.TagNumber(10)
-  set pendingExpirationHeight($core.int v) {
-    $_setUnsignedInt32(7, v);
-  }
-
+  set pendingExpirationHeight($core.int v) { $_setUnsignedInt32(7, v); }
   @$pb.TagNumber(10)
   $core.bool hasPendingExpirationHeight() => $_has(7);
   @$pb.TagNumber(10)
@@ -415,10 +318,7 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $fixnum.Int64 get pendingExpirationTimestamp => $_getI64(8);
   @$pb.TagNumber(11)
-  set pendingExpirationTimestamp($fixnum.Int64 v) {
-    $_setInt64(8, v);
-  }
-
+  set pendingExpirationTimestamp($fixnum.Int64 v) { $_setInt64(8, v); }
   @$pb.TagNumber(11)
   $core.bool hasPendingExpirationTimestamp() => $_has(8);
   @$pb.TagNumber(11)
@@ -427,10 +327,7 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(12)
   $fixnum.Int64 get fee => $_getI64(9);
   @$pb.TagNumber(12)
-  set fee($fixnum.Int64 v) {
-    $_setInt64(9, v);
-  }
-
+  set fee($fixnum.Int64 v) { $_setInt64(9, v); }
   @$pb.TagNumber(12)
   $core.bool hasFee() => $_has(9);
   @$pb.TagNumber(12)
@@ -439,10 +336,7 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(13)
   $core.String get preimage => $_getSZ(10);
   @$pb.TagNumber(13)
-  set preimage($core.String v) {
-    $_setString(10, v);
-  }
-
+  set preimage($core.String v) { $_setString(10, v); }
   @$pb.TagNumber(13)
   $core.bool hasPreimage() => $_has(10);
   @$pb.TagNumber(13)
@@ -451,10 +345,7 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(14)
   $core.String get closedChannelPoint => $_getSZ(11);
   @$pb.TagNumber(14)
-  set closedChannelPoint($core.String v) {
-    $_setString(11, v);
-  }
-
+  set closedChannelPoint($core.String v) { $_setString(11, v); }
   @$pb.TagNumber(14)
   $core.bool hasClosedChannelPoint() => $_has(11);
   @$pb.TagNumber(14)
@@ -463,10 +354,7 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(15)
   $core.bool get isChannelPending => $_getBF(12);
   @$pb.TagNumber(15)
-  set isChannelPending($core.bool v) {
-    $_setBool(12, v);
-  }
-
+  set isChannelPending($core.bool v) { $_setBool(12, v); }
   @$pb.TagNumber(15)
   $core.bool hasIsChannelPending() => $_has(12);
   @$pb.TagNumber(15)
@@ -475,10 +363,7 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(16)
   $core.bool get isChannelCloseConfimed => $_getBF(13);
   @$pb.TagNumber(16)
-  set isChannelCloseConfimed($core.bool v) {
-    $_setBool(13, v);
-  }
-
+  set isChannelCloseConfimed($core.bool v) { $_setBool(13, v); }
   @$pb.TagNumber(16)
   $core.bool hasIsChannelCloseConfimed() => $_has(13);
   @$pb.TagNumber(16)
@@ -487,10 +372,7 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(17)
   $core.String get closedChannelTxID => $_getSZ(14);
   @$pb.TagNumber(17)
-  set closedChannelTxID($core.String v) {
-    $_setString(14, v);
-  }
-
+  set closedChannelTxID($core.String v) { $_setString(14, v); }
   @$pb.TagNumber(17)
   $core.bool hasClosedChannelTxID() => $_has(14);
   @$pb.TagNumber(17)
@@ -498,32 +380,24 @@ class Payment extends $pb.GeneratedMessage {
 }
 
 class PaymentsList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PaymentsList',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
-    ..pc<Payment>(1, 'paymentsList', $pb.PbFieldType.PM,
-        protoName: 'paymentsList', subBuilder: Payment.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PaymentsList', package: const $pb.PackageName('data'), createEmptyInstance: create)
+    ..pc<Payment>(1, 'paymentsList', $pb.PbFieldType.PM, protoName: 'paymentsList', subBuilder: Payment.create)
+    ..hasRequiredFields = false
+  ;
 
   PaymentsList._() : super();
   factory PaymentsList() => create();
-  factory PaymentsList.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PaymentsList.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory PaymentsList.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PaymentsList.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   PaymentsList clone() => PaymentsList()..mergeFromMessage(this);
-  PaymentsList copyWith(void Function(PaymentsList) updates) =>
-      super.copyWith((message) => updates(message as PaymentsList));
+  PaymentsList copyWith(void Function(PaymentsList) updates) => super.copyWith((message) => updates(message as PaymentsList));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PaymentsList create() => PaymentsList._();
   PaymentsList createEmptyInstance() => create();
-  static $pb.PbList<PaymentsList> createRepeated() =>
-      $pb.PbList<PaymentsList>();
+  static $pb.PbList<PaymentsList> createRepeated() => $pb.PbList<PaymentsList>();
   @$core.pragma('dart2js:noInline')
-  static PaymentsList getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<PaymentsList>(create);
+  static PaymentsList getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PaymentsList>(create);
   static PaymentsList _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -531,41 +405,31 @@ class PaymentsList extends $pb.GeneratedMessage {
 }
 
 class PaymentResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PaymentResponse',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PaymentResponse', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'paymentError', protoName: 'paymentError')
     ..aOS(2, 'traceReport', protoName: 'traceReport')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   PaymentResponse._() : super();
   factory PaymentResponse() => create();
-  factory PaymentResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PaymentResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory PaymentResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PaymentResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   PaymentResponse clone() => PaymentResponse()..mergeFromMessage(this);
-  PaymentResponse copyWith(void Function(PaymentResponse) updates) =>
-      super.copyWith((message) => updates(message as PaymentResponse));
+  PaymentResponse copyWith(void Function(PaymentResponse) updates) => super.copyWith((message) => updates(message as PaymentResponse));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PaymentResponse create() => PaymentResponse._();
   PaymentResponse createEmptyInstance() => create();
-  static $pb.PbList<PaymentResponse> createRepeated() =>
-      $pb.PbList<PaymentResponse>();
+  static $pb.PbList<PaymentResponse> createRepeated() => $pb.PbList<PaymentResponse>();
   @$core.pragma('dart2js:noInline')
-  static PaymentResponse getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<PaymentResponse>(create);
+  static PaymentResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PaymentResponse>(create);
   static PaymentResponse _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get paymentError => $_getSZ(0);
   @$pb.TagNumber(1)
-  set paymentError($core.String v) {
-    $_setString(0, v);
-  }
-
+  set paymentError($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPaymentError() => $_has(0);
   @$pb.TagNumber(1)
@@ -574,10 +438,7 @@ class PaymentResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get traceReport => $_getSZ(1);
   @$pb.TagNumber(2)
-  set traceReport($core.String v) {
-    $_setString(1, v);
-  }
-
+  set traceReport($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasTraceReport() => $_has(1);
   @$pb.TagNumber(2)
@@ -585,43 +446,31 @@ class PaymentResponse extends $pb.GeneratedMessage {
 }
 
 class SendWalletCoinsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('SendWalletCoinsRequest',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('SendWalletCoinsRequest', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'address')
     ..aInt64(2, 'satPerByteFee', protoName: 'satPerByteFee')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   SendWalletCoinsRequest._() : super();
   factory SendWalletCoinsRequest() => create();
-  factory SendWalletCoinsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SendWalletCoinsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  SendWalletCoinsRequest clone() =>
-      SendWalletCoinsRequest()..mergeFromMessage(this);
-  SendWalletCoinsRequest copyWith(
-          void Function(SendWalletCoinsRequest) updates) =>
-      super.copyWith((message) => updates(message as SendWalletCoinsRequest));
+  factory SendWalletCoinsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SendWalletCoinsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  SendWalletCoinsRequest clone() => SendWalletCoinsRequest()..mergeFromMessage(this);
+  SendWalletCoinsRequest copyWith(void Function(SendWalletCoinsRequest) updates) => super.copyWith((message) => updates(message as SendWalletCoinsRequest));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SendWalletCoinsRequest create() => SendWalletCoinsRequest._();
   SendWalletCoinsRequest createEmptyInstance() => create();
-  static $pb.PbList<SendWalletCoinsRequest> createRepeated() =>
-      $pb.PbList<SendWalletCoinsRequest>();
+  static $pb.PbList<SendWalletCoinsRequest> createRepeated() => $pb.PbList<SendWalletCoinsRequest>();
   @$core.pragma('dart2js:noInline')
-  static SendWalletCoinsRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<SendWalletCoinsRequest>(create);
+  static SendWalletCoinsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SendWalletCoinsRequest>(create);
   static SendWalletCoinsRequest _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -630,10 +479,7 @@ class SendWalletCoinsRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get satPerByteFee => $_getI64(1);
   @$pb.TagNumber(2)
-  set satPerByteFee($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set satPerByteFee($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasSatPerByteFee() => $_has(1);
   @$pb.TagNumber(2)
@@ -641,41 +487,31 @@ class SendWalletCoinsRequest extends $pb.GeneratedMessage {
 }
 
 class PayInvoiceRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PayInvoiceRequest',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PayInvoiceRequest', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aInt64(1, 'amount')
     ..aOS(2, 'paymentRequest', protoName: 'paymentRequest')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   PayInvoiceRequest._() : super();
   factory PayInvoiceRequest() => create();
-  factory PayInvoiceRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PayInvoiceRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory PayInvoiceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PayInvoiceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   PayInvoiceRequest clone() => PayInvoiceRequest()..mergeFromMessage(this);
-  PayInvoiceRequest copyWith(void Function(PayInvoiceRequest) updates) =>
-      super.copyWith((message) => updates(message as PayInvoiceRequest));
+  PayInvoiceRequest copyWith(void Function(PayInvoiceRequest) updates) => super.copyWith((message) => updates(message as PayInvoiceRequest));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PayInvoiceRequest create() => PayInvoiceRequest._();
   PayInvoiceRequest createEmptyInstance() => create();
-  static $pb.PbList<PayInvoiceRequest> createRepeated() =>
-      $pb.PbList<PayInvoiceRequest>();
+  static $pb.PbList<PayInvoiceRequest> createRepeated() => $pb.PbList<PayInvoiceRequest>();
   @$core.pragma('dart2js:noInline')
-  static PayInvoiceRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<PayInvoiceRequest>(create);
+  static PayInvoiceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PayInvoiceRequest>(create);
   static PayInvoiceRequest _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get amount => $_getI64(0);
   @$pb.TagNumber(1)
-  set amount($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set amount($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAmount() => $_has(0);
   @$pb.TagNumber(1)
@@ -684,19 +520,66 @@ class PayInvoiceRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get paymentRequest => $_getSZ(1);
   @$pb.TagNumber(2)
-  set paymentRequest($core.String v) {
-    $_setString(1, v);
-  }
-
+  set paymentRequest($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasPaymentRequest() => $_has(1);
   @$pb.TagNumber(2)
   void clearPaymentRequest() => clearField(2);
 }
 
+class SpontaneousPaymentRequest extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('SpontaneousPaymentRequest', package: const $pb.PackageName('data'), createEmptyInstance: create)
+    ..aInt64(1, 'amount')
+    ..aOS(2, 'destNode', protoName: 'destNode')
+    ..aOS(3, 'description')
+    ..hasRequiredFields = false
+  ;
+
+  SpontaneousPaymentRequest._() : super();
+  factory SpontaneousPaymentRequest() => create();
+  factory SpontaneousPaymentRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SpontaneousPaymentRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  SpontaneousPaymentRequest clone() => SpontaneousPaymentRequest()..mergeFromMessage(this);
+  SpontaneousPaymentRequest copyWith(void Function(SpontaneousPaymentRequest) updates) => super.copyWith((message) => updates(message as SpontaneousPaymentRequest));
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static SpontaneousPaymentRequest create() => SpontaneousPaymentRequest._();
+  SpontaneousPaymentRequest createEmptyInstance() => create();
+  static $pb.PbList<SpontaneousPaymentRequest> createRepeated() => $pb.PbList<SpontaneousPaymentRequest>();
+  @$core.pragma('dart2js:noInline')
+  static SpontaneousPaymentRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SpontaneousPaymentRequest>(create);
+  static SpontaneousPaymentRequest _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get amount => $_getI64(0);
+  @$pb.TagNumber(1)
+  set amount($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAmount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAmount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get destNode => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set destNode($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasDestNode() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearDestNode() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get description => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set description($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasDescription() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearDescription() => clearField(3);
+}
+
 class InvoiceMemo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('InvoiceMemo',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('InvoiceMemo', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'description')
     ..aInt64(2, 'amount')
     ..aOS(3, 'payeeName', protoName: 'payeeName')
@@ -705,36 +588,28 @@ class InvoiceMemo extends $pb.GeneratedMessage {
     ..aOS(6, 'payerImageURL', protoName: 'payerImageURL')
     ..aOB(7, 'transferRequest', protoName: 'transferRequest')
     ..aInt64(8, 'expiry')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   InvoiceMemo._() : super();
   factory InvoiceMemo() => create();
-  factory InvoiceMemo.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory InvoiceMemo.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory InvoiceMemo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory InvoiceMemo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   InvoiceMemo clone() => InvoiceMemo()..mergeFromMessage(this);
-  InvoiceMemo copyWith(void Function(InvoiceMemo) updates) =>
-      super.copyWith((message) => updates(message as InvoiceMemo));
+  InvoiceMemo copyWith(void Function(InvoiceMemo) updates) => super.copyWith((message) => updates(message as InvoiceMemo));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static InvoiceMemo create() => InvoiceMemo._();
   InvoiceMemo createEmptyInstance() => create();
   static $pb.PbList<InvoiceMemo> createRepeated() => $pb.PbList<InvoiceMemo>();
   @$core.pragma('dart2js:noInline')
-  static InvoiceMemo getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<InvoiceMemo>(create);
+  static InvoiceMemo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<InvoiceMemo>(create);
   static InvoiceMemo _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get description => $_getSZ(0);
   @$pb.TagNumber(1)
-  set description($core.String v) {
-    $_setString(0, v);
-  }
-
+  set description($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDescription() => $_has(0);
   @$pb.TagNumber(1)
@@ -743,10 +618,7 @@ class InvoiceMemo extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amount => $_getI64(1);
   @$pb.TagNumber(2)
-  set amount($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amount($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmount() => $_has(1);
   @$pb.TagNumber(2)
@@ -755,10 +627,7 @@ class InvoiceMemo extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get payeeName => $_getSZ(2);
   @$pb.TagNumber(3)
-  set payeeName($core.String v) {
-    $_setString(2, v);
-  }
-
+  set payeeName($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasPayeeName() => $_has(2);
   @$pb.TagNumber(3)
@@ -767,10 +636,7 @@ class InvoiceMemo extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get payeeImageURL => $_getSZ(3);
   @$pb.TagNumber(4)
-  set payeeImageURL($core.String v) {
-    $_setString(3, v);
-  }
-
+  set payeeImageURL($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasPayeeImageURL() => $_has(3);
   @$pb.TagNumber(4)
@@ -779,10 +645,7 @@ class InvoiceMemo extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get payerName => $_getSZ(4);
   @$pb.TagNumber(5)
-  set payerName($core.String v) {
-    $_setString(4, v);
-  }
-
+  set payerName($core.String v) { $_setString(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasPayerName() => $_has(4);
   @$pb.TagNumber(5)
@@ -791,10 +654,7 @@ class InvoiceMemo extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.String get payerImageURL => $_getSZ(5);
   @$pb.TagNumber(6)
-  set payerImageURL($core.String v) {
-    $_setString(5, v);
-  }
-
+  set payerImageURL($core.String v) { $_setString(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasPayerImageURL() => $_has(5);
   @$pb.TagNumber(6)
@@ -803,10 +663,7 @@ class InvoiceMemo extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.bool get transferRequest => $_getBF(6);
   @$pb.TagNumber(7)
-  set transferRequest($core.bool v) {
-    $_setBool(6, v);
-  }
-
+  set transferRequest($core.bool v) { $_setBool(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasTransferRequest() => $_has(6);
   @$pb.TagNumber(7)
@@ -815,10 +672,7 @@ class InvoiceMemo extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $fixnum.Int64 get expiry => $_getI64(7);
   @$pb.TagNumber(8)
-  set expiry($fixnum.Int64 v) {
-    $_setInt64(7, v);
-  }
-
+  set expiry($fixnum.Int64 v) { $_setInt64(7, v); }
   @$pb.TagNumber(8)
   $core.bool hasExpiry() => $_has(7);
   @$pb.TagNumber(8)
@@ -826,41 +680,32 @@ class InvoiceMemo extends $pb.GeneratedMessage {
 }
 
 class Invoice extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Invoice',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Invoice', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOM<InvoiceMemo>(1, 'memo', subBuilder: InvoiceMemo.create)
     ..aOB(2, 'settled')
     ..aInt64(3, 'amtPaid', protoName: 'amtPaid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   Invoice._() : super();
   factory Invoice() => create();
-  factory Invoice.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Invoice.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory Invoice.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Invoice.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   Invoice clone() => Invoice()..mergeFromMessage(this);
-  Invoice copyWith(void Function(Invoice) updates) =>
-      super.copyWith((message) => updates(message as Invoice));
+  Invoice copyWith(void Function(Invoice) updates) => super.copyWith((message) => updates(message as Invoice));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Invoice create() => Invoice._();
   Invoice createEmptyInstance() => create();
   static $pb.PbList<Invoice> createRepeated() => $pb.PbList<Invoice>();
   @$core.pragma('dart2js:noInline')
-  static Invoice getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Invoice>(create);
+  static Invoice getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Invoice>(create);
   static Invoice _defaultInstance;
 
   @$pb.TagNumber(1)
   InvoiceMemo get memo => $_getN(0);
   @$pb.TagNumber(1)
-  set memo(InvoiceMemo v) {
-    setField(1, v);
-  }
-
+  set memo(InvoiceMemo v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasMemo() => $_has(0);
   @$pb.TagNumber(1)
@@ -871,10 +716,7 @@ class Invoice extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get settled => $_getBF(1);
   @$pb.TagNumber(2)
-  set settled($core.bool v) {
-    $_setBool(1, v);
-  }
-
+  set settled($core.bool v) { $_setBool(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasSettled() => $_has(1);
   @$pb.TagNumber(2)
@@ -883,10 +725,7 @@ class Invoice extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get amtPaid => $_getI64(2);
   @$pb.TagNumber(3)
-  set amtPaid($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set amtPaid($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasAmtPaid() => $_has(2);
   @$pb.TagNumber(3)
@@ -894,44 +733,31 @@ class Invoice extends $pb.GeneratedMessage {
 }
 
 class NotificationEvent extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('NotificationEvent',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
-    ..e<NotificationEvent_NotificationType>(1, 'type', $pb.PbFieldType.OE,
-        defaultOrMaker: NotificationEvent_NotificationType.READY,
-        valueOf: NotificationEvent_NotificationType.valueOf,
-        enumValues: NotificationEvent_NotificationType.values)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('NotificationEvent', package: const $pb.PackageName('data'), createEmptyInstance: create)
+    ..e<NotificationEvent_NotificationType>(1, 'type', $pb.PbFieldType.OE, defaultOrMaker: NotificationEvent_NotificationType.READY, valueOf: NotificationEvent_NotificationType.valueOf, enumValues: NotificationEvent_NotificationType.values)
     ..pPS(2, 'data')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   NotificationEvent._() : super();
   factory NotificationEvent() => create();
-  factory NotificationEvent.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory NotificationEvent.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory NotificationEvent.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NotificationEvent.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   NotificationEvent clone() => NotificationEvent()..mergeFromMessage(this);
-  NotificationEvent copyWith(void Function(NotificationEvent) updates) =>
-      super.copyWith((message) => updates(message as NotificationEvent));
+  NotificationEvent copyWith(void Function(NotificationEvent) updates) => super.copyWith((message) => updates(message as NotificationEvent));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static NotificationEvent create() => NotificationEvent._();
   NotificationEvent createEmptyInstance() => create();
-  static $pb.PbList<NotificationEvent> createRepeated() =>
-      $pb.PbList<NotificationEvent>();
+  static $pb.PbList<NotificationEvent> createRepeated() => $pb.PbList<NotificationEvent>();
   @$core.pragma('dart2js:noInline')
-  static NotificationEvent getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<NotificationEvent>(create);
+  static NotificationEvent getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NotificationEvent>(create);
   static NotificationEvent _defaultInstance;
 
   @$pb.TagNumber(1)
   NotificationEvent_NotificationType get type => $_getN(0);
   @$pb.TagNumber(1)
-  set type(NotificationEvent_NotificationType v) {
-    setField(1, v);
-  }
-
+  set type(NotificationEvent_NotificationType v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasType() => $_has(0);
   @$pb.TagNumber(1)
@@ -942,44 +768,34 @@ class NotificationEvent extends $pb.GeneratedMessage {
 }
 
 class AddFundInitReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('AddFundInitReply',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('AddFundInitReply', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'address')
     ..aInt64(2, 'maxAllowedDeposit', protoName: 'maxAllowedDeposit')
     ..aOS(3, 'errorMessage', protoName: 'errorMessage')
     ..aOS(4, 'backupJson', protoName: 'backupJson')
     ..aInt64(5, 'requiredReserve', protoName: 'requiredReserve')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   AddFundInitReply._() : super();
   factory AddFundInitReply() => create();
-  factory AddFundInitReply.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AddFundInitReply.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory AddFundInitReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory AddFundInitReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   AddFundInitReply clone() => AddFundInitReply()..mergeFromMessage(this);
-  AddFundInitReply copyWith(void Function(AddFundInitReply) updates) =>
-      super.copyWith((message) => updates(message as AddFundInitReply));
+  AddFundInitReply copyWith(void Function(AddFundInitReply) updates) => super.copyWith((message) => updates(message as AddFundInitReply));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AddFundInitReply create() => AddFundInitReply._();
   AddFundInitReply createEmptyInstance() => create();
-  static $pb.PbList<AddFundInitReply> createRepeated() =>
-      $pb.PbList<AddFundInitReply>();
+  static $pb.PbList<AddFundInitReply> createRepeated() => $pb.PbList<AddFundInitReply>();
   @$core.pragma('dart2js:noInline')
-  static AddFundInitReply getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<AddFundInitReply>(create);
+  static AddFundInitReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundInitReply>(create);
   static AddFundInitReply _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -988,10 +804,7 @@ class AddFundInitReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get maxAllowedDeposit => $_getI64(1);
   @$pb.TagNumber(2)
-  set maxAllowedDeposit($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set maxAllowedDeposit($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasMaxAllowedDeposit() => $_has(1);
   @$pb.TagNumber(2)
@@ -1000,10 +813,7 @@ class AddFundInitReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get errorMessage => $_getSZ(2);
   @$pb.TagNumber(3)
-  set errorMessage($core.String v) {
-    $_setString(2, v);
-  }
-
+  set errorMessage($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasErrorMessage() => $_has(2);
   @$pb.TagNumber(3)
@@ -1012,10 +822,7 @@ class AddFundInitReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get backupJson => $_getSZ(3);
   @$pb.TagNumber(4)
-  set backupJson($core.String v) {
-    $_setString(3, v);
-  }
-
+  set backupJson($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasBackupJson() => $_has(3);
   @$pb.TagNumber(4)
@@ -1024,10 +831,7 @@ class AddFundInitReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $fixnum.Int64 get requiredReserve => $_getI64(4);
   @$pb.TagNumber(5)
-  set requiredReserve($fixnum.Int64 v) {
-    $_setInt64(4, v);
-  }
-
+  set requiredReserve($fixnum.Int64 v) { $_setInt64(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasRequiredReserve() => $_has(4);
   @$pb.TagNumber(5)
@@ -1035,40 +839,30 @@ class AddFundInitReply extends $pb.GeneratedMessage {
 }
 
 class AddFundReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('AddFundReply',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('AddFundReply', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'errorMessage', protoName: 'errorMessage')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   AddFundReply._() : super();
   factory AddFundReply() => create();
-  factory AddFundReply.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AddFundReply.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory AddFundReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory AddFundReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   AddFundReply clone() => AddFundReply()..mergeFromMessage(this);
-  AddFundReply copyWith(void Function(AddFundReply) updates) =>
-      super.copyWith((message) => updates(message as AddFundReply));
+  AddFundReply copyWith(void Function(AddFundReply) updates) => super.copyWith((message) => updates(message as AddFundReply));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AddFundReply create() => AddFundReply._();
   AddFundReply createEmptyInstance() => create();
-  static $pb.PbList<AddFundReply> createRepeated() =>
-      $pb.PbList<AddFundReply>();
+  static $pb.PbList<AddFundReply> createRepeated() => $pb.PbList<AddFundReply>();
   @$core.pragma('dart2js:noInline')
-  static AddFundReply getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<AddFundReply>(create);
+  static AddFundReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundReply>(create);
   static AddFundReply _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get errorMessage => $_getSZ(0);
   @$pb.TagNumber(1)
-  set errorMessage($core.String v) {
-    $_setString(0, v);
-  }
-
+  set errorMessage($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasErrorMessage() => $_has(0);
   @$pb.TagNumber(1)
@@ -1076,43 +870,33 @@ class AddFundReply extends $pb.GeneratedMessage {
 }
 
 class RefundRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('RefundRequest',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('RefundRequest', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'address')
     ..aOS(2, 'refundAddress', protoName: 'refundAddress')
     ..a<$core.int>(3, 'targetConf', $pb.PbFieldType.O3)
     ..aInt64(4, 'satPerByte')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   RefundRequest._() : super();
   factory RefundRequest() => create();
-  factory RefundRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RefundRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RefundRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RefundRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   RefundRequest clone() => RefundRequest()..mergeFromMessage(this);
-  RefundRequest copyWith(void Function(RefundRequest) updates) =>
-      super.copyWith((message) => updates(message as RefundRequest));
+  RefundRequest copyWith(void Function(RefundRequest) updates) => super.copyWith((message) => updates(message as RefundRequest));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RefundRequest create() => RefundRequest._();
   RefundRequest createEmptyInstance() => create();
-  static $pb.PbList<RefundRequest> createRepeated() =>
-      $pb.PbList<RefundRequest>();
+  static $pb.PbList<RefundRequest> createRepeated() => $pb.PbList<RefundRequest>();
   @$core.pragma('dart2js:noInline')
-  static RefundRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<RefundRequest>(create);
+  static RefundRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RefundRequest>(create);
   static RefundRequest _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -1121,10 +905,7 @@ class RefundRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get refundAddress => $_getSZ(1);
   @$pb.TagNumber(2)
-  set refundAddress($core.String v) {
-    $_setString(1, v);
-  }
-
+  set refundAddress($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasRefundAddress() => $_has(1);
   @$pb.TagNumber(2)
@@ -1133,10 +914,7 @@ class RefundRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.int get targetConf => $_getIZ(2);
   @$pb.TagNumber(3)
-  set targetConf($core.int v) {
-    $_setSignedInt32(2, v);
-  }
-
+  set targetConf($core.int v) { $_setSignedInt32(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasTargetConf() => $_has(2);
   @$pb.TagNumber(3)
@@ -1145,10 +923,7 @@ class RefundRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get satPerByte => $_getI64(3);
   @$pb.TagNumber(4)
-  set satPerByte($fixnum.Int64 v) {
-    $_setInt64(3, v);
-  }
-
+  set satPerByte($fixnum.Int64 v) { $_setInt64(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasSatPerByte() => $_has(3);
   @$pb.TagNumber(4)
@@ -1156,43 +931,31 @@ class RefundRequest extends $pb.GeneratedMessage {
 }
 
 class AddFundError extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('AddFundError',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
-    ..aOM<SwapAddressInfo>(1, 'swapAddressInfo',
-        protoName: 'swapAddressInfo', subBuilder: SwapAddressInfo.create)
-    ..a<$core.double>(2, 'hoursToUnlock', $pb.PbFieldType.OF,
-        protoName: 'hoursToUnlock')
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('AddFundError', package: const $pb.PackageName('data'), createEmptyInstance: create)
+    ..aOM<SwapAddressInfo>(1, 'swapAddressInfo', protoName: 'swapAddressInfo', subBuilder: SwapAddressInfo.create)
+    ..a<$core.double>(2, 'hoursToUnlock', $pb.PbFieldType.OF, protoName: 'hoursToUnlock')
+    ..hasRequiredFields = false
+  ;
 
   AddFundError._() : super();
   factory AddFundError() => create();
-  factory AddFundError.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AddFundError.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory AddFundError.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory AddFundError.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   AddFundError clone() => AddFundError()..mergeFromMessage(this);
-  AddFundError copyWith(void Function(AddFundError) updates) =>
-      super.copyWith((message) => updates(message as AddFundError));
+  AddFundError copyWith(void Function(AddFundError) updates) => super.copyWith((message) => updates(message as AddFundError));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AddFundError create() => AddFundError._();
   AddFundError createEmptyInstance() => create();
-  static $pb.PbList<AddFundError> createRepeated() =>
-      $pb.PbList<AddFundError>();
+  static $pb.PbList<AddFundError> createRepeated() => $pb.PbList<AddFundError>();
   @$core.pragma('dart2js:noInline')
-  static AddFundError getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<AddFundError>(create);
+  static AddFundError getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundError>(create);
   static AddFundError _defaultInstance;
 
   @$pb.TagNumber(1)
   SwapAddressInfo get swapAddressInfo => $_getN(0);
   @$pb.TagNumber(1)
-  set swapAddressInfo(SwapAddressInfo v) {
-    setField(1, v);
-  }
-
+  set swapAddressInfo(SwapAddressInfo v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasSwapAddressInfo() => $_has(0);
   @$pb.TagNumber(1)
@@ -1203,10 +966,7 @@ class AddFundError extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.double get hoursToUnlock => $_getN(1);
   @$pb.TagNumber(2)
-  set hoursToUnlock($core.double v) {
-    $_setFloat(1, v);
-  }
-
+  set hoursToUnlock($core.double v) { $_setFloat(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasHoursToUnlock() => $_has(1);
   @$pb.TagNumber(2)
@@ -1214,36 +974,26 @@ class AddFundError extends $pb.GeneratedMessage {
 }
 
 class FundStatusReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('FundStatusReply',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
-    ..pc<SwapAddressInfo>(1, 'unConfirmedAddresses', $pb.PbFieldType.PM,
-        protoName: 'unConfirmedAddresses', subBuilder: SwapAddressInfo.create)
-    ..pc<SwapAddressInfo>(2, 'confirmedAddresses', $pb.PbFieldType.PM,
-        protoName: 'confirmedAddresses', subBuilder: SwapAddressInfo.create)
-    ..pc<SwapAddressInfo>(3, 'refundableAddresses', $pb.PbFieldType.PM,
-        protoName: 'refundableAddresses', subBuilder: SwapAddressInfo.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('FundStatusReply', package: const $pb.PackageName('data'), createEmptyInstance: create)
+    ..pc<SwapAddressInfo>(1, 'unConfirmedAddresses', $pb.PbFieldType.PM, protoName: 'unConfirmedAddresses', subBuilder: SwapAddressInfo.create)
+    ..pc<SwapAddressInfo>(2, 'confirmedAddresses', $pb.PbFieldType.PM, protoName: 'confirmedAddresses', subBuilder: SwapAddressInfo.create)
+    ..pc<SwapAddressInfo>(3, 'refundableAddresses', $pb.PbFieldType.PM, protoName: 'refundableAddresses', subBuilder: SwapAddressInfo.create)
+    ..hasRequiredFields = false
+  ;
 
   FundStatusReply._() : super();
   factory FundStatusReply() => create();
-  factory FundStatusReply.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory FundStatusReply.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory FundStatusReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory FundStatusReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   FundStatusReply clone() => FundStatusReply()..mergeFromMessage(this);
-  FundStatusReply copyWith(void Function(FundStatusReply) updates) =>
-      super.copyWith((message) => updates(message as FundStatusReply));
+  FundStatusReply copyWith(void Function(FundStatusReply) updates) => super.copyWith((message) => updates(message as FundStatusReply));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static FundStatusReply create() => FundStatusReply._();
   FundStatusReply createEmptyInstance() => create();
-  static $pb.PbList<FundStatusReply> createRepeated() =>
-      $pb.PbList<FundStatusReply>();
+  static $pb.PbList<FundStatusReply> createRepeated() => $pb.PbList<FundStatusReply>();
   @$core.pragma('dart2js:noInline')
-  static FundStatusReply getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<FundStatusReply>(create);
+  static FundStatusReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<FundStatusReply>(create);
   static FundStatusReply _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -1257,41 +1007,31 @@ class FundStatusReply extends $pb.GeneratedMessage {
 }
 
 class RemoveFundRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('RemoveFundRequest',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('RemoveFundRequest', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'address')
     ..aInt64(2, 'amount')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   RemoveFundRequest._() : super();
   factory RemoveFundRequest() => create();
-  factory RemoveFundRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RemoveFundRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RemoveFundRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RemoveFundRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   RemoveFundRequest clone() => RemoveFundRequest()..mergeFromMessage(this);
-  RemoveFundRequest copyWith(void Function(RemoveFundRequest) updates) =>
-      super.copyWith((message) => updates(message as RemoveFundRequest));
+  RemoveFundRequest copyWith(void Function(RemoveFundRequest) updates) => super.copyWith((message) => updates(message as RemoveFundRequest));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RemoveFundRequest create() => RemoveFundRequest._();
   RemoveFundRequest createEmptyInstance() => create();
-  static $pb.PbList<RemoveFundRequest> createRepeated() =>
-      $pb.PbList<RemoveFundRequest>();
+  static $pb.PbList<RemoveFundRequest> createRepeated() => $pb.PbList<RemoveFundRequest>();
   @$core.pragma('dart2js:noInline')
-  static RemoveFundRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<RemoveFundRequest>(create);
+  static RemoveFundRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFundRequest>(create);
   static RemoveFundRequest _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -1300,10 +1040,7 @@ class RemoveFundRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amount => $_getI64(1);
   @$pb.TagNumber(2)
-  set amount($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amount($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmount() => $_has(1);
   @$pb.TagNumber(2)
@@ -1311,41 +1048,31 @@ class RemoveFundRequest extends $pb.GeneratedMessage {
 }
 
 class RemoveFundReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('RemoveFundReply',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('RemoveFundReply', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'txid')
     ..aOS(2, 'errorMessage', protoName: 'errorMessage')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   RemoveFundReply._() : super();
   factory RemoveFundReply() => create();
-  factory RemoveFundReply.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RemoveFundReply.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory RemoveFundReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RemoveFundReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   RemoveFundReply clone() => RemoveFundReply()..mergeFromMessage(this);
-  RemoveFundReply copyWith(void Function(RemoveFundReply) updates) =>
-      super.copyWith((message) => updates(message as RemoveFundReply));
+  RemoveFundReply copyWith(void Function(RemoveFundReply) updates) => super.copyWith((message) => updates(message as RemoveFundReply));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RemoveFundReply create() => RemoveFundReply._();
   RemoveFundReply createEmptyInstance() => create();
-  static $pb.PbList<RemoveFundReply> createRepeated() =>
-      $pb.PbList<RemoveFundReply>();
+  static $pb.PbList<RemoveFundReply> createRepeated() => $pb.PbList<RemoveFundReply>();
   @$core.pragma('dart2js:noInline')
-  static RemoveFundReply getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<RemoveFundReply>(create);
+  static RemoveFundReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFundReply>(create);
   static RemoveFundReply _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set txid($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -1354,10 +1081,7 @@ class RemoveFundReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get errorMessage => $_getSZ(1);
   @$pb.TagNumber(2)
-  set errorMessage($core.String v) {
-    $_setString(1, v);
-  }
-
+  set errorMessage($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasErrorMessage() => $_has(1);
   @$pb.TagNumber(2)
@@ -1365,56 +1089,40 @@ class RemoveFundReply extends $pb.GeneratedMessage {
 }
 
 class SwapAddressInfo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('SwapAddressInfo',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('SwapAddressInfo', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'address')
     ..aOS(2, 'PaymentHash', protoName: 'PaymentHash')
     ..aInt64(3, 'ConfirmedAmount', protoName: 'ConfirmedAmount')
     ..pPS(4, 'ConfirmedTransactionIds', protoName: 'ConfirmedTransactionIds')
     ..aInt64(5, 'PaidAmount', protoName: 'PaidAmount')
-    ..a<$core.int>(6, 'lockHeight', $pb.PbFieldType.OU3,
-        protoName: 'lockHeight')
+    ..a<$core.int>(6, 'lockHeight', $pb.PbFieldType.OU3, protoName: 'lockHeight')
     ..aOS(7, 'errorMessage', protoName: 'errorMessage')
     ..aOS(8, 'lastRefundTxID', protoName: 'lastRefundTxID')
-    ..e<SwapError>(9, 'swapError', $pb.PbFieldType.OE,
-        protoName: 'swapError',
-        defaultOrMaker: SwapError.NO_ERROR,
-        valueOf: SwapError.valueOf,
-        enumValues: SwapError.values)
+    ..e<SwapError>(9, 'swapError', $pb.PbFieldType.OE, protoName: 'swapError', defaultOrMaker: SwapError.NO_ERROR, valueOf: SwapError.valueOf, enumValues: SwapError.values)
     ..aOS(10, 'FundingTxID', protoName: 'FundingTxID')
-    ..a<$core.double>(11, 'hoursToUnlock', $pb.PbFieldType.OF,
-        protoName: 'hoursToUnlock')
-    ..hasRequiredFields = false;
+    ..a<$core.double>(11, 'hoursToUnlock', $pb.PbFieldType.OF, protoName: 'hoursToUnlock')
+    ..hasRequiredFields = false
+  ;
 
   SwapAddressInfo._() : super();
   factory SwapAddressInfo() => create();
-  factory SwapAddressInfo.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SwapAddressInfo.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SwapAddressInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SwapAddressInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   SwapAddressInfo clone() => SwapAddressInfo()..mergeFromMessage(this);
-  SwapAddressInfo copyWith(void Function(SwapAddressInfo) updates) =>
-      super.copyWith((message) => updates(message as SwapAddressInfo));
+  SwapAddressInfo copyWith(void Function(SwapAddressInfo) updates) => super.copyWith((message) => updates(message as SwapAddressInfo));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SwapAddressInfo create() => SwapAddressInfo._();
   SwapAddressInfo createEmptyInstance() => create();
-  static $pb.PbList<SwapAddressInfo> createRepeated() =>
-      $pb.PbList<SwapAddressInfo>();
+  static $pb.PbList<SwapAddressInfo> createRepeated() => $pb.PbList<SwapAddressInfo>();
   @$core.pragma('dart2js:noInline')
-  static SwapAddressInfo getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<SwapAddressInfo>(create);
+  static SwapAddressInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SwapAddressInfo>(create);
   static SwapAddressInfo _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -1423,10 +1131,7 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get paymentHash => $_getSZ(1);
   @$pb.TagNumber(2)
-  set paymentHash($core.String v) {
-    $_setString(1, v);
-  }
-
+  set paymentHash($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasPaymentHash() => $_has(1);
   @$pb.TagNumber(2)
@@ -1435,10 +1140,7 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get confirmedAmount => $_getI64(2);
   @$pb.TagNumber(3)
-  set confirmedAmount($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set confirmedAmount($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasConfirmedAmount() => $_has(2);
   @$pb.TagNumber(3)
@@ -1450,10 +1152,7 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $fixnum.Int64 get paidAmount => $_getI64(4);
   @$pb.TagNumber(5)
-  set paidAmount($fixnum.Int64 v) {
-    $_setInt64(4, v);
-  }
-
+  set paidAmount($fixnum.Int64 v) { $_setInt64(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasPaidAmount() => $_has(4);
   @$pb.TagNumber(5)
@@ -1462,10 +1161,7 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.int get lockHeight => $_getIZ(5);
   @$pb.TagNumber(6)
-  set lockHeight($core.int v) {
-    $_setUnsignedInt32(5, v);
-  }
-
+  set lockHeight($core.int v) { $_setUnsignedInt32(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasLockHeight() => $_has(5);
   @$pb.TagNumber(6)
@@ -1474,10 +1170,7 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.String get errorMessage => $_getSZ(6);
   @$pb.TagNumber(7)
-  set errorMessage($core.String v) {
-    $_setString(6, v);
-  }
-
+  set errorMessage($core.String v) { $_setString(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasErrorMessage() => $_has(6);
   @$pb.TagNumber(7)
@@ -1486,10 +1179,7 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.String get lastRefundTxID => $_getSZ(7);
   @$pb.TagNumber(8)
-  set lastRefundTxID($core.String v) {
-    $_setString(7, v);
-  }
-
+  set lastRefundTxID($core.String v) { $_setString(7, v); }
   @$pb.TagNumber(8)
   $core.bool hasLastRefundTxID() => $_has(7);
   @$pb.TagNumber(8)
@@ -1498,10 +1188,7 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   SwapError get swapError => $_getN(8);
   @$pb.TagNumber(9)
-  set swapError(SwapError v) {
-    setField(9, v);
-  }
-
+  set swapError(SwapError v) { setField(9, v); }
   @$pb.TagNumber(9)
   $core.bool hasSwapError() => $_has(8);
   @$pb.TagNumber(9)
@@ -1510,10 +1197,7 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $core.String get fundingTxID => $_getSZ(9);
   @$pb.TagNumber(10)
-  set fundingTxID($core.String v) {
-    $_setString(9, v);
-  }
-
+  set fundingTxID($core.String v) { $_setString(9, v); }
   @$pb.TagNumber(10)
   $core.bool hasFundingTxID() => $_has(9);
   @$pb.TagNumber(10)
@@ -1522,10 +1206,7 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $core.double get hoursToUnlock => $_getN(10);
   @$pb.TagNumber(11)
-  set hoursToUnlock($core.double v) {
-    $_setFloat(10, v);
-  }
-
+  set hoursToUnlock($core.double v) { $_setFloat(10, v); }
   @$pb.TagNumber(11)
   $core.bool hasHoursToUnlock() => $_has(10);
   @$pb.TagNumber(11)
@@ -1533,32 +1214,24 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
 }
 
 class SwapAddressList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('SwapAddressList',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
-    ..pc<SwapAddressInfo>(1, 'addresses', $pb.PbFieldType.PM,
-        subBuilder: SwapAddressInfo.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('SwapAddressList', package: const $pb.PackageName('data'), createEmptyInstance: create)
+    ..pc<SwapAddressInfo>(1, 'addresses', $pb.PbFieldType.PM, subBuilder: SwapAddressInfo.create)
+    ..hasRequiredFields = false
+  ;
 
   SwapAddressList._() : super();
   factory SwapAddressList() => create();
-  factory SwapAddressList.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SwapAddressList.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SwapAddressList.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SwapAddressList.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   SwapAddressList clone() => SwapAddressList()..mergeFromMessage(this);
-  SwapAddressList copyWith(void Function(SwapAddressList) updates) =>
-      super.copyWith((message) => updates(message as SwapAddressList));
+  SwapAddressList copyWith(void Function(SwapAddressList) updates) => super.copyWith((message) => updates(message as SwapAddressList));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SwapAddressList create() => SwapAddressList._();
   SwapAddressList createEmptyInstance() => create();
-  static $pb.PbList<SwapAddressList> createRepeated() =>
-      $pb.PbList<SwapAddressList>();
+  static $pb.PbList<SwapAddressList> createRepeated() => $pb.PbList<SwapAddressList>();
   @$core.pragma('dart2js:noInline')
-  static SwapAddressList getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<SwapAddressList>(create);
+  static SwapAddressList getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SwapAddressList>(create);
   static SwapAddressList _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -1566,50 +1239,33 @@ class SwapAddressList extends $pb.GeneratedMessage {
 }
 
 class CreateRatchetSessionRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      'CreateRatchetSessionRequest',
-      package: const $pb.PackageName('data'),
-      createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('CreateRatchetSessionRequest', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'secret')
     ..aOS(2, 'remotePubKey', protoName: 'remotePubKey')
     ..aOS(3, 'sessionID', protoName: 'sessionID')
-    ..a<$fixnum.Int64>(4, 'expiry', $pb.PbFieldType.OU6,
-        defaultOrMaker: $fixnum.Int64.ZERO)
-    ..hasRequiredFields = false;
+    ..a<$fixnum.Int64>(4, 'expiry', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..hasRequiredFields = false
+  ;
 
   CreateRatchetSessionRequest._() : super();
   factory CreateRatchetSessionRequest() => create();
-  factory CreateRatchetSessionRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateRatchetSessionRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  CreateRatchetSessionRequest clone() =>
-      CreateRatchetSessionRequest()..mergeFromMessage(this);
-  CreateRatchetSessionRequest copyWith(
-          void Function(CreateRatchetSessionRequest) updates) =>
-      super.copyWith(
-          (message) => updates(message as CreateRatchetSessionRequest));
+  factory CreateRatchetSessionRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateRatchetSessionRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  CreateRatchetSessionRequest clone() => CreateRatchetSessionRequest()..mergeFromMessage(this);
+  CreateRatchetSessionRequest copyWith(void Function(CreateRatchetSessionRequest) updates) => super.copyWith((message) => updates(message as CreateRatchetSessionRequest));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
-  static CreateRatchetSessionRequest create() =>
-      CreateRatchetSessionRequest._();
+  static CreateRatchetSessionRequest create() => CreateRatchetSessionRequest._();
   CreateRatchetSessionRequest createEmptyInstance() => create();
-  static $pb.PbList<CreateRatchetSessionRequest> createRepeated() =>
-      $pb.PbList<CreateRatchetSessionRequest>();
+  static $pb.PbList<CreateRatchetSessionRequest> createRepeated() => $pb.PbList<CreateRatchetSessionRequest>();
   @$core.pragma('dart2js:noInline')
-  static CreateRatchetSessionRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<CreateRatchetSessionRequest>(create);
+  static CreateRatchetSessionRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateRatchetSessionRequest>(create);
   static CreateRatchetSessionRequest _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get secret => $_getSZ(0);
   @$pb.TagNumber(1)
-  set secret($core.String v) {
-    $_setString(0, v);
-  }
-
+  set secret($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSecret() => $_has(0);
   @$pb.TagNumber(1)
@@ -1618,10 +1274,7 @@ class CreateRatchetSessionRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get remotePubKey => $_getSZ(1);
   @$pb.TagNumber(2)
-  set remotePubKey($core.String v) {
-    $_setString(1, v);
-  }
-
+  set remotePubKey($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasRemotePubKey() => $_has(1);
   @$pb.TagNumber(2)
@@ -1630,10 +1283,7 @@ class CreateRatchetSessionRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get sessionID => $_getSZ(2);
   @$pb.TagNumber(3)
-  set sessionID($core.String v) {
-    $_setString(2, v);
-  }
-
+  set sessionID($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasSessionID() => $_has(2);
   @$pb.TagNumber(3)
@@ -1642,10 +1292,7 @@ class CreateRatchetSessionRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get expiry => $_getI64(3);
   @$pb.TagNumber(4)
-  set expiry($fixnum.Int64 v) {
-    $_setInt64(3, v);
-  }
-
+  set expiry($fixnum.Int64 v) { $_setInt64(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasExpiry() => $_has(3);
   @$pb.TagNumber(4)
@@ -1653,45 +1300,32 @@ class CreateRatchetSessionRequest extends $pb.GeneratedMessage {
 }
 
 class CreateRatchetSessionReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('CreateRatchetSessionReply',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('CreateRatchetSessionReply', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'sessionID', protoName: 'sessionID')
     ..aOS(2, 'secret')
     ..aOS(3, 'pubKey', protoName: 'pubKey')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   CreateRatchetSessionReply._() : super();
   factory CreateRatchetSessionReply() => create();
-  factory CreateRatchetSessionReply.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateRatchetSessionReply.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  CreateRatchetSessionReply clone() =>
-      CreateRatchetSessionReply()..mergeFromMessage(this);
-  CreateRatchetSessionReply copyWith(
-          void Function(CreateRatchetSessionReply) updates) =>
-      super
-          .copyWith((message) => updates(message as CreateRatchetSessionReply));
+  factory CreateRatchetSessionReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateRatchetSessionReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  CreateRatchetSessionReply clone() => CreateRatchetSessionReply()..mergeFromMessage(this);
+  CreateRatchetSessionReply copyWith(void Function(CreateRatchetSessionReply) updates) => super.copyWith((message) => updates(message as CreateRatchetSessionReply));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CreateRatchetSessionReply create() => CreateRatchetSessionReply._();
   CreateRatchetSessionReply createEmptyInstance() => create();
-  static $pb.PbList<CreateRatchetSessionReply> createRepeated() =>
-      $pb.PbList<CreateRatchetSessionReply>();
+  static $pb.PbList<CreateRatchetSessionReply> createRepeated() => $pb.PbList<CreateRatchetSessionReply>();
   @$core.pragma('dart2js:noInline')
-  static CreateRatchetSessionReply getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<CreateRatchetSessionReply>(create);
+  static CreateRatchetSessionReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateRatchetSessionReply>(create);
   static CreateRatchetSessionReply _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sessionID => $_getSZ(0);
   @$pb.TagNumber(1)
-  set sessionID($core.String v) {
-    $_setString(0, v);
-  }
-
+  set sessionID($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSessionID() => $_has(0);
   @$pb.TagNumber(1)
@@ -1700,10 +1334,7 @@ class CreateRatchetSessionReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get secret => $_getSZ(1);
   @$pb.TagNumber(2)
-  set secret($core.String v) {
-    $_setString(1, v);
-  }
-
+  set secret($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasSecret() => $_has(1);
   @$pb.TagNumber(2)
@@ -1712,10 +1343,7 @@ class CreateRatchetSessionReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get pubKey => $_getSZ(2);
   @$pb.TagNumber(3)
-  set pubKey($core.String v) {
-    $_setString(2, v);
-  }
-
+  set pubKey($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasPubKey() => $_has(2);
   @$pb.TagNumber(3)
@@ -1723,44 +1351,32 @@ class CreateRatchetSessionReply extends $pb.GeneratedMessage {
 }
 
 class RatchetSessionInfoReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('RatchetSessionInfoReply',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('RatchetSessionInfoReply', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'sessionID', protoName: 'sessionID')
     ..aOB(2, 'initiated')
     ..aOS(3, 'userInfo', protoName: 'userInfo')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   RatchetSessionInfoReply._() : super();
   factory RatchetSessionInfoReply() => create();
-  factory RatchetSessionInfoReply.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RatchetSessionInfoReply.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  RatchetSessionInfoReply clone() =>
-      RatchetSessionInfoReply()..mergeFromMessage(this);
-  RatchetSessionInfoReply copyWith(
-          void Function(RatchetSessionInfoReply) updates) =>
-      super.copyWith((message) => updates(message as RatchetSessionInfoReply));
+  factory RatchetSessionInfoReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RatchetSessionInfoReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  RatchetSessionInfoReply clone() => RatchetSessionInfoReply()..mergeFromMessage(this);
+  RatchetSessionInfoReply copyWith(void Function(RatchetSessionInfoReply) updates) => super.copyWith((message) => updates(message as RatchetSessionInfoReply));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RatchetSessionInfoReply create() => RatchetSessionInfoReply._();
   RatchetSessionInfoReply createEmptyInstance() => create();
-  static $pb.PbList<RatchetSessionInfoReply> createRepeated() =>
-      $pb.PbList<RatchetSessionInfoReply>();
+  static $pb.PbList<RatchetSessionInfoReply> createRepeated() => $pb.PbList<RatchetSessionInfoReply>();
   @$core.pragma('dart2js:noInline')
-  static RatchetSessionInfoReply getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<RatchetSessionInfoReply>(create);
+  static RatchetSessionInfoReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatchetSessionInfoReply>(create);
   static RatchetSessionInfoReply _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sessionID => $_getSZ(0);
   @$pb.TagNumber(1)
-  set sessionID($core.String v) {
-    $_setString(0, v);
-  }
-
+  set sessionID($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSessionID() => $_has(0);
   @$pb.TagNumber(1)
@@ -1769,10 +1385,7 @@ class RatchetSessionInfoReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get initiated => $_getBF(1);
   @$pb.TagNumber(2)
-  set initiated($core.bool v) {
-    $_setBool(1, v);
-  }
-
+  set initiated($core.bool v) { $_setBool(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasInitiated() => $_has(1);
   @$pb.TagNumber(2)
@@ -1781,10 +1394,7 @@ class RatchetSessionInfoReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get userInfo => $_getSZ(2);
   @$pb.TagNumber(3)
-  set userInfo($core.String v) {
-    $_setString(2, v);
-  }
-
+  set userInfo($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasUserInfo() => $_has(2);
   @$pb.TagNumber(3)
@@ -1792,47 +1402,31 @@ class RatchetSessionInfoReply extends $pb.GeneratedMessage {
 }
 
 class RatchetSessionSetInfoRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      'RatchetSessionSetInfoRequest',
-      package: const $pb.PackageName('data'),
-      createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('RatchetSessionSetInfoRequest', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'sessionID', protoName: 'sessionID')
     ..aOS(2, 'userInfo', protoName: 'userInfo')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   RatchetSessionSetInfoRequest._() : super();
   factory RatchetSessionSetInfoRequest() => create();
-  factory RatchetSessionSetInfoRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RatchetSessionSetInfoRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  RatchetSessionSetInfoRequest clone() =>
-      RatchetSessionSetInfoRequest()..mergeFromMessage(this);
-  RatchetSessionSetInfoRequest copyWith(
-          void Function(RatchetSessionSetInfoRequest) updates) =>
-      super.copyWith(
-          (message) => updates(message as RatchetSessionSetInfoRequest));
+  factory RatchetSessionSetInfoRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RatchetSessionSetInfoRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  RatchetSessionSetInfoRequest clone() => RatchetSessionSetInfoRequest()..mergeFromMessage(this);
+  RatchetSessionSetInfoRequest copyWith(void Function(RatchetSessionSetInfoRequest) updates) => super.copyWith((message) => updates(message as RatchetSessionSetInfoRequest));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
-  static RatchetSessionSetInfoRequest create() =>
-      RatchetSessionSetInfoRequest._();
+  static RatchetSessionSetInfoRequest create() => RatchetSessionSetInfoRequest._();
   RatchetSessionSetInfoRequest createEmptyInstance() => create();
-  static $pb.PbList<RatchetSessionSetInfoRequest> createRepeated() =>
-      $pb.PbList<RatchetSessionSetInfoRequest>();
+  static $pb.PbList<RatchetSessionSetInfoRequest> createRepeated() => $pb.PbList<RatchetSessionSetInfoRequest>();
   @$core.pragma('dart2js:noInline')
-  static RatchetSessionSetInfoRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<RatchetSessionSetInfoRequest>(create);
+  static RatchetSessionSetInfoRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatchetSessionSetInfoRequest>(create);
   static RatchetSessionSetInfoRequest _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sessionID => $_getSZ(0);
   @$pb.TagNumber(1)
-  set sessionID($core.String v) {
-    $_setString(0, v);
-  }
-
+  set sessionID($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSessionID() => $_has(0);
   @$pb.TagNumber(1)
@@ -1841,10 +1435,7 @@ class RatchetSessionSetInfoRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get userInfo => $_getSZ(1);
   @$pb.TagNumber(2)
-  set userInfo($core.String v) {
-    $_setString(1, v);
-  }
-
+  set userInfo($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasUserInfo() => $_has(1);
   @$pb.TagNumber(2)
@@ -1852,43 +1443,31 @@ class RatchetSessionSetInfoRequest extends $pb.GeneratedMessage {
 }
 
 class RatchetEncryptRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('RatchetEncryptRequest',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('RatchetEncryptRequest', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'sessionID', protoName: 'sessionID')
     ..aOS(2, 'message')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   RatchetEncryptRequest._() : super();
   factory RatchetEncryptRequest() => create();
-  factory RatchetEncryptRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RatchetEncryptRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  RatchetEncryptRequest clone() =>
-      RatchetEncryptRequest()..mergeFromMessage(this);
-  RatchetEncryptRequest copyWith(
-          void Function(RatchetEncryptRequest) updates) =>
-      super.copyWith((message) => updates(message as RatchetEncryptRequest));
+  factory RatchetEncryptRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RatchetEncryptRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  RatchetEncryptRequest clone() => RatchetEncryptRequest()..mergeFromMessage(this);
+  RatchetEncryptRequest copyWith(void Function(RatchetEncryptRequest) updates) => super.copyWith((message) => updates(message as RatchetEncryptRequest));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RatchetEncryptRequest create() => RatchetEncryptRequest._();
   RatchetEncryptRequest createEmptyInstance() => create();
-  static $pb.PbList<RatchetEncryptRequest> createRepeated() =>
-      $pb.PbList<RatchetEncryptRequest>();
+  static $pb.PbList<RatchetEncryptRequest> createRepeated() => $pb.PbList<RatchetEncryptRequest>();
   @$core.pragma('dart2js:noInline')
-  static RatchetEncryptRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<RatchetEncryptRequest>(create);
+  static RatchetEncryptRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatchetEncryptRequest>(create);
   static RatchetEncryptRequest _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sessionID => $_getSZ(0);
   @$pb.TagNumber(1)
-  set sessionID($core.String v) {
-    $_setString(0, v);
-  }
-
+  set sessionID($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSessionID() => $_has(0);
   @$pb.TagNumber(1)
@@ -1897,10 +1476,7 @@ class RatchetEncryptRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get message => $_getSZ(1);
   @$pb.TagNumber(2)
-  set message($core.String v) {
-    $_setString(1, v);
-  }
-
+  set message($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasMessage() => $_has(1);
   @$pb.TagNumber(2)
@@ -1908,43 +1484,31 @@ class RatchetEncryptRequest extends $pb.GeneratedMessage {
 }
 
 class RatchetDecryptRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('RatchetDecryptRequest',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('RatchetDecryptRequest', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'sessionID', protoName: 'sessionID')
     ..aOS(2, 'encryptedMessage', protoName: 'encryptedMessage')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   RatchetDecryptRequest._() : super();
   factory RatchetDecryptRequest() => create();
-  factory RatchetDecryptRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory RatchetDecryptRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  RatchetDecryptRequest clone() =>
-      RatchetDecryptRequest()..mergeFromMessage(this);
-  RatchetDecryptRequest copyWith(
-          void Function(RatchetDecryptRequest) updates) =>
-      super.copyWith((message) => updates(message as RatchetDecryptRequest));
+  factory RatchetDecryptRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RatchetDecryptRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  RatchetDecryptRequest clone() => RatchetDecryptRequest()..mergeFromMessage(this);
+  RatchetDecryptRequest copyWith(void Function(RatchetDecryptRequest) updates) => super.copyWith((message) => updates(message as RatchetDecryptRequest));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RatchetDecryptRequest create() => RatchetDecryptRequest._();
   RatchetDecryptRequest createEmptyInstance() => create();
-  static $pb.PbList<RatchetDecryptRequest> createRepeated() =>
-      $pb.PbList<RatchetDecryptRequest>();
+  static $pb.PbList<RatchetDecryptRequest> createRepeated() => $pb.PbList<RatchetDecryptRequest>();
   @$core.pragma('dart2js:noInline')
-  static RatchetDecryptRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<RatchetDecryptRequest>(create);
+  static RatchetDecryptRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatchetDecryptRequest>(create);
   static RatchetDecryptRequest _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sessionID => $_getSZ(0);
   @$pb.TagNumber(1)
-  set sessionID($core.String v) {
-    $_setString(0, v);
-  }
-
+  set sessionID($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSessionID() => $_has(0);
   @$pb.TagNumber(1)
@@ -1953,10 +1517,7 @@ class RatchetDecryptRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get encryptedMessage => $_getSZ(1);
   @$pb.TagNumber(2)
-  set encryptedMessage($core.String v) {
-    $_setString(1, v);
-  }
-
+  set encryptedMessage($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasEncryptedMessage() => $_has(1);
   @$pb.TagNumber(2)
@@ -1964,43 +1525,31 @@ class RatchetDecryptRequest extends $pb.GeneratedMessage {
 }
 
 class BootstrapFilesRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('BootstrapFilesRequest',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('BootstrapFilesRequest', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'WorkingDir', protoName: 'WorkingDir')
     ..pPS(2, 'FullPaths', protoName: 'FullPaths')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   BootstrapFilesRequest._() : super();
   factory BootstrapFilesRequest() => create();
-  factory BootstrapFilesRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory BootstrapFilesRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  BootstrapFilesRequest clone() =>
-      BootstrapFilesRequest()..mergeFromMessage(this);
-  BootstrapFilesRequest copyWith(
-          void Function(BootstrapFilesRequest) updates) =>
-      super.copyWith((message) => updates(message as BootstrapFilesRequest));
+  factory BootstrapFilesRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BootstrapFilesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  BootstrapFilesRequest clone() => BootstrapFilesRequest()..mergeFromMessage(this);
+  BootstrapFilesRequest copyWith(void Function(BootstrapFilesRequest) updates) => super.copyWith((message) => updates(message as BootstrapFilesRequest));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static BootstrapFilesRequest create() => BootstrapFilesRequest._();
   BootstrapFilesRequest createEmptyInstance() => create();
-  static $pb.PbList<BootstrapFilesRequest> createRepeated() =>
-      $pb.PbList<BootstrapFilesRequest>();
+  static $pb.PbList<BootstrapFilesRequest> createRepeated() => $pb.PbList<BootstrapFilesRequest>();
   @$core.pragma('dart2js:noInline')
-  static BootstrapFilesRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<BootstrapFilesRequest>(create);
+  static BootstrapFilesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BootstrapFilesRequest>(create);
   static BootstrapFilesRequest _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get workingDir => $_getSZ(0);
   @$pb.TagNumber(1)
-  set workingDir($core.String v) {
-    $_setString(0, v);
-  }
-
+  set workingDir($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasWorkingDir() => $_has(0);
   @$pb.TagNumber(1)
@@ -2011,40 +1560,31 @@ class BootstrapFilesRequest extends $pb.GeneratedMessage {
 }
 
 class Peers extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Peers',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Peers', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOB(1, 'isDefault', protoName: 'isDefault')
     ..pPS(2, 'peer')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   Peers._() : super();
   factory Peers() => create();
-  factory Peers.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Peers.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory Peers.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Peers.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   Peers clone() => Peers()..mergeFromMessage(this);
-  Peers copyWith(void Function(Peers) updates) =>
-      super.copyWith((message) => updates(message as Peers));
+  Peers copyWith(void Function(Peers) updates) => super.copyWith((message) => updates(message as Peers));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Peers create() => Peers._();
   Peers createEmptyInstance() => create();
   static $pb.PbList<Peers> createRepeated() => $pb.PbList<Peers>();
   @$core.pragma('dart2js:noInline')
-  static Peers getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Peers>(create);
+  static Peers getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Peers>(create);
   static Peers _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get isDefault => $_getBF(0);
   @$pb.TagNumber(1)
-  set isDefault($core.bool v) {
-    $_setBool(0, v);
-  }
-
+  set isDefault($core.bool v) { $_setBool(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasIsDefault() => $_has(0);
   @$pb.TagNumber(1)
@@ -2055,41 +1595,32 @@ class Peers extends $pb.GeneratedMessage {
 }
 
 class TxSpentURL extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('TxSpentURL',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('TxSpentURL', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'URL', protoName: 'URL')
     ..aOB(2, 'isDefault', protoName: 'isDefault')
     ..aOB(3, 'disabled')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   TxSpentURL._() : super();
   factory TxSpentURL() => create();
-  factory TxSpentURL.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TxSpentURL.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TxSpentURL.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TxSpentURL.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   TxSpentURL clone() => TxSpentURL()..mergeFromMessage(this);
-  TxSpentURL copyWith(void Function(TxSpentURL) updates) =>
-      super.copyWith((message) => updates(message as TxSpentURL));
+  TxSpentURL copyWith(void Function(TxSpentURL) updates) => super.copyWith((message) => updates(message as TxSpentURL));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static TxSpentURL create() => TxSpentURL._();
   TxSpentURL createEmptyInstance() => create();
   static $pb.PbList<TxSpentURL> createRepeated() => $pb.PbList<TxSpentURL>();
   @$core.pragma('dart2js:noInline')
-  static TxSpentURL getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<TxSpentURL>(create);
+  static TxSpentURL getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxSpentURL>(create);
   static TxSpentURL _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get uRL => $_getSZ(0);
   @$pb.TagNumber(1)
-  set uRL($core.String v) {
-    $_setString(0, v);
-  }
-
+  set uRL($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasURL() => $_has(0);
   @$pb.TagNumber(1)
@@ -2098,10 +1629,7 @@ class TxSpentURL extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get isDefault => $_getBF(1);
   @$pb.TagNumber(2)
-  set isDefault($core.bool v) {
-    $_setBool(1, v);
-  }
-
+  set isDefault($core.bool v) { $_setBool(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasIsDefault() => $_has(1);
   @$pb.TagNumber(2)
@@ -2110,10 +1638,7 @@ class TxSpentURL extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get disabled => $_getBF(2);
   @$pb.TagNumber(3)
-  set disabled($core.bool v) {
-    $_setBool(2, v);
-  }
-
+  set disabled($core.bool v) { $_setBool(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasDisabled() => $_has(2);
   @$pb.TagNumber(3)
@@ -2121,40 +1646,31 @@ class TxSpentURL extends $pb.GeneratedMessage {
 }
 
 class rate extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('rate',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('rate', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'coin')
     ..a<$core.double>(2, 'value', $pb.PbFieldType.OD)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   rate._() : super();
   factory rate() => create();
-  factory rate.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory rate.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory rate.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory rate.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   rate clone() => rate()..mergeFromMessage(this);
-  rate copyWith(void Function(rate) updates) =>
-      super.copyWith((message) => updates(message as rate));
+  rate copyWith(void Function(rate) updates) => super.copyWith((message) => updates(message as rate));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static rate create() => rate._();
   rate createEmptyInstance() => create();
   static $pb.PbList<rate> createRepeated() => $pb.PbList<rate>();
   @$core.pragma('dart2js:noInline')
-  static rate getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<rate>(create);
+  static rate getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<rate>(create);
   static rate _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get coin => $_getSZ(0);
   @$pb.TagNumber(1)
-  set coin($core.String v) {
-    $_setString(0, v);
-  }
-
+  set coin($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCoin() => $_has(0);
   @$pb.TagNumber(1)
@@ -2163,10 +1679,7 @@ class rate extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.double get value => $_getN(1);
   @$pb.TagNumber(2)
-  set value($core.double v) {
-    $_setDouble(1, v);
-  }
-
+  set value($core.double v) { $_setDouble(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasValue() => $_has(1);
   @$pb.TagNumber(2)
@@ -2174,30 +1687,24 @@ class rate extends $pb.GeneratedMessage {
 }
 
 class Rates extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Rates',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Rates', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..pc<rate>(1, 'rates', $pb.PbFieldType.PM, subBuilder: rate.create)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   Rates._() : super();
   factory Rates() => create();
-  factory Rates.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Rates.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory Rates.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Rates.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   Rates clone() => Rates()..mergeFromMessage(this);
-  Rates copyWith(void Function(Rates) updates) =>
-      super.copyWith((message) => updates(message as Rates));
+  Rates copyWith(void Function(Rates) updates) => super.copyWith((message) => updates(message as Rates));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Rates create() => Rates._();
   Rates createEmptyInstance() => create();
   static $pb.PbList<Rates> createRepeated() => $pb.PbList<Rates>();
   @$core.pragma('dart2js:noInline')
-  static Rates getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Rates>(create);
+  static Rates getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Rates>(create);
   static Rates _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -2205,8 +1712,7 @@ class Rates extends $pb.GeneratedMessage {
 }
 
 class LSPInformation extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('LSPInformation',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('LSPInformation', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'name')
     ..aOS(2, 'widgetUrl')
     ..aOS(3, 'pubkey')
@@ -2217,37 +1723,28 @@ class LSPInformation extends $pb.GeneratedMessage {
     ..a<$core.double>(8, 'feeRate', $pb.PbFieldType.OD)
     ..a<$core.int>(9, 'timeLockDelta', $pb.PbFieldType.OU3)
     ..aInt64(10, 'minHtlcMsat')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   LSPInformation._() : super();
   factory LSPInformation() => create();
-  factory LSPInformation.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory LSPInformation.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory LSPInformation.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory LSPInformation.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   LSPInformation clone() => LSPInformation()..mergeFromMessage(this);
-  LSPInformation copyWith(void Function(LSPInformation) updates) =>
-      super.copyWith((message) => updates(message as LSPInformation));
+  LSPInformation copyWith(void Function(LSPInformation) updates) => super.copyWith((message) => updates(message as LSPInformation));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LSPInformation create() => LSPInformation._();
   LSPInformation createEmptyInstance() => create();
-  static $pb.PbList<LSPInformation> createRepeated() =>
-      $pb.PbList<LSPInformation>();
+  static $pb.PbList<LSPInformation> createRepeated() => $pb.PbList<LSPInformation>();
   @$core.pragma('dart2js:noInline')
-  static LSPInformation getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<LSPInformation>(create);
+  static LSPInformation getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LSPInformation>(create);
   static LSPInformation _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -2256,10 +1753,7 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get widgetUrl => $_getSZ(1);
   @$pb.TagNumber(2)
-  set widgetUrl($core.String v) {
-    $_setString(1, v);
-  }
-
+  set widgetUrl($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasWidgetUrl() => $_has(1);
   @$pb.TagNumber(2)
@@ -2268,10 +1762,7 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get pubkey => $_getSZ(2);
   @$pb.TagNumber(3)
-  set pubkey($core.String v) {
-    $_setString(2, v);
-  }
-
+  set pubkey($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasPubkey() => $_has(2);
   @$pb.TagNumber(3)
@@ -2280,10 +1771,7 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get host => $_getSZ(3);
   @$pb.TagNumber(4)
-  set host($core.String v) {
-    $_setString(3, v);
-  }
-
+  set host($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasHost() => $_has(3);
   @$pb.TagNumber(4)
@@ -2292,10 +1780,7 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $fixnum.Int64 get channelCapacity => $_getI64(4);
   @$pb.TagNumber(5)
-  set channelCapacity($fixnum.Int64 v) {
-    $_setInt64(4, v);
-  }
-
+  set channelCapacity($fixnum.Int64 v) { $_setInt64(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasChannelCapacity() => $_has(4);
   @$pb.TagNumber(5)
@@ -2304,10 +1789,7 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.int get targetConf => $_getIZ(5);
   @$pb.TagNumber(6)
-  set targetConf($core.int v) {
-    $_setSignedInt32(5, v);
-  }
-
+  set targetConf($core.int v) { $_setSignedInt32(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasTargetConf() => $_has(5);
   @$pb.TagNumber(6)
@@ -2316,10 +1798,7 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $fixnum.Int64 get baseFeeMsat => $_getI64(6);
   @$pb.TagNumber(7)
-  set baseFeeMsat($fixnum.Int64 v) {
-    $_setInt64(6, v);
-  }
-
+  set baseFeeMsat($fixnum.Int64 v) { $_setInt64(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasBaseFeeMsat() => $_has(6);
   @$pb.TagNumber(7)
@@ -2328,10 +1807,7 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.double get feeRate => $_getN(7);
   @$pb.TagNumber(8)
-  set feeRate($core.double v) {
-    $_setDouble(7, v);
-  }
-
+  set feeRate($core.double v) { $_setDouble(7, v); }
   @$pb.TagNumber(8)
   $core.bool hasFeeRate() => $_has(7);
   @$pb.TagNumber(8)
@@ -2340,10 +1816,7 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.int get timeLockDelta => $_getIZ(8);
   @$pb.TagNumber(9)
-  set timeLockDelta($core.int v) {
-    $_setUnsignedInt32(8, v);
-  }
-
+  set timeLockDelta($core.int v) { $_setUnsignedInt32(8, v); }
   @$pb.TagNumber(9)
   $core.bool hasTimeLockDelta() => $_has(8);
   @$pb.TagNumber(9)
@@ -2352,10 +1825,7 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $fixnum.Int64 get minHtlcMsat => $_getI64(9);
   @$pb.TagNumber(10)
-  set minHtlcMsat($fixnum.Int64 v) {
-    $_setInt64(9, v);
-  }
-
+  set minHtlcMsat($fixnum.Int64 v) { $_setInt64(9, v); }
   @$pb.TagNumber(10)
   $core.bool hasMinHtlcMsat() => $_has(9);
   @$pb.TagNumber(10)
@@ -2363,90 +1833,71 @@ class LSPInformation extends $pb.GeneratedMessage {
 }
 
 class LSPList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('LSPList',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
-    ..m<$core.String, LSPInformation>(1, 'lsps',
-        entryClassName: 'LSPList.LspsEntry',
-        keyFieldType: $pb.PbFieldType.OS,
-        valueFieldType: $pb.PbFieldType.OM,
-        valueCreator: LSPInformation.create,
-        packageName: const $pb.PackageName('data'))
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('LSPList', package: const $pb.PackageName('data'), createEmptyInstance: create)
+    ..m<$core.String, LSPInformation>(1, 'lsps', entryClassName: 'LSPList.LspsEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OM, valueCreator: LSPInformation.create, packageName: const $pb.PackageName('data'))
+    ..hasRequiredFields = false
+  ;
 
   LSPList._() : super();
   factory LSPList() => create();
-  factory LSPList.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory LSPList.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory LSPList.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory LSPList.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   LSPList clone() => LSPList()..mergeFromMessage(this);
-  LSPList copyWith(void Function(LSPList) updates) =>
-      super.copyWith((message) => updates(message as LSPList));
+  LSPList copyWith(void Function(LSPList) updates) => super.copyWith((message) => updates(message as LSPList));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LSPList create() => LSPList._();
   LSPList createEmptyInstance() => create();
   static $pb.PbList<LSPList> createRepeated() => $pb.PbList<LSPList>();
   @$core.pragma('dart2js:noInline')
-  static LSPList getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LSPList>(create);
+  static LSPList getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LSPList>(create);
   static LSPList _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.Map<$core.String, LSPInformation> get lsps => $_getMap(0);
 }
 
-enum LNUrlResponse_Action { withdraw, channel, notSet }
+enum LNUrlResponse_Action {
+  withdraw, 
+  channel, 
+  notSet
+}
 
 class LNUrlResponse extends $pb.GeneratedMessage {
-  static const $core.Map<$core.int, LNUrlResponse_Action>
-      _LNUrlResponse_ActionByTag = {
-    1: LNUrlResponse_Action.withdraw,
-    2: LNUrlResponse_Action.channel,
-    0: LNUrlResponse_Action.notSet
+  static const $core.Map<$core.int, LNUrlResponse_Action> _LNUrlResponse_ActionByTag = {
+    1 : LNUrlResponse_Action.withdraw,
+    2 : LNUrlResponse_Action.channel,
+    0 : LNUrlResponse_Action.notSet
   };
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('LNUrlResponse',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('LNUrlResponse', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..oo(0, [1, 2])
     ..aOM<LNUrlWithdraw>(1, 'withdraw', subBuilder: LNUrlWithdraw.create)
     ..aOM<LNURLChannel>(2, 'channel', subBuilder: LNURLChannel.create)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   LNUrlResponse._() : super();
   factory LNUrlResponse() => create();
-  factory LNUrlResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory LNUrlResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory LNUrlResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory LNUrlResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   LNUrlResponse clone() => LNUrlResponse()..mergeFromMessage(this);
-  LNUrlResponse copyWith(void Function(LNUrlResponse) updates) =>
-      super.copyWith((message) => updates(message as LNUrlResponse));
+  LNUrlResponse copyWith(void Function(LNUrlResponse) updates) => super.copyWith((message) => updates(message as LNUrlResponse));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LNUrlResponse create() => LNUrlResponse._();
   LNUrlResponse createEmptyInstance() => create();
-  static $pb.PbList<LNUrlResponse> createRepeated() =>
-      $pb.PbList<LNUrlResponse>();
+  static $pb.PbList<LNUrlResponse> createRepeated() => $pb.PbList<LNUrlResponse>();
   @$core.pragma('dart2js:noInline')
-  static LNUrlResponse getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<LNUrlResponse>(create);
+  static LNUrlResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNUrlResponse>(create);
   static LNUrlResponse _defaultInstance;
 
-  LNUrlResponse_Action whichAction() =>
-      _LNUrlResponse_ActionByTag[$_whichOneof(0)];
+  LNUrlResponse_Action whichAction() => _LNUrlResponse_ActionByTag[$_whichOneof(0)];
   void clearAction() => clearField($_whichOneof(0));
 
   @$pb.TagNumber(1)
   LNUrlWithdraw get withdraw => $_getN(0);
   @$pb.TagNumber(1)
-  set withdraw(LNUrlWithdraw v) {
-    setField(1, v);
-  }
-
+  set withdraw(LNUrlWithdraw v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasWithdraw() => $_has(0);
   @$pb.TagNumber(1)
@@ -2457,10 +1908,7 @@ class LNUrlResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   LNURLChannel get channel => $_getN(1);
   @$pb.TagNumber(2)
-  set channel(LNURLChannel v) {
-    setField(2, v);
-  }
-
+  set channel(LNURLChannel v) { setField(2, v); }
   @$pb.TagNumber(2)
   $core.bool hasChannel() => $_has(1);
   @$pb.TagNumber(2)
@@ -2470,42 +1918,32 @@ class LNUrlResponse extends $pb.GeneratedMessage {
 }
 
 class LNUrlWithdraw extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('LNUrlWithdraw',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('LNUrlWithdraw', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aInt64(1, 'minAmount')
     ..aInt64(2, 'maxAmount')
     ..aOS(3, 'defaultDescription')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   LNUrlWithdraw._() : super();
   factory LNUrlWithdraw() => create();
-  factory LNUrlWithdraw.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory LNUrlWithdraw.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory LNUrlWithdraw.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory LNUrlWithdraw.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   LNUrlWithdraw clone() => LNUrlWithdraw()..mergeFromMessage(this);
-  LNUrlWithdraw copyWith(void Function(LNUrlWithdraw) updates) =>
-      super.copyWith((message) => updates(message as LNUrlWithdraw));
+  LNUrlWithdraw copyWith(void Function(LNUrlWithdraw) updates) => super.copyWith((message) => updates(message as LNUrlWithdraw));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LNUrlWithdraw create() => LNUrlWithdraw._();
   LNUrlWithdraw createEmptyInstance() => create();
-  static $pb.PbList<LNUrlWithdraw> createRepeated() =>
-      $pb.PbList<LNUrlWithdraw>();
+  static $pb.PbList<LNUrlWithdraw> createRepeated() => $pb.PbList<LNUrlWithdraw>();
   @$core.pragma('dart2js:noInline')
-  static LNUrlWithdraw getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<LNUrlWithdraw>(create);
+  static LNUrlWithdraw getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNUrlWithdraw>(create);
   static LNUrlWithdraw _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get minAmount => $_getI64(0);
   @$pb.TagNumber(1)
-  set minAmount($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set minAmount($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMinAmount() => $_has(0);
   @$pb.TagNumber(1)
@@ -2514,10 +1952,7 @@ class LNUrlWithdraw extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get maxAmount => $_getI64(1);
   @$pb.TagNumber(2)
-  set maxAmount($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set maxAmount($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasMaxAmount() => $_has(1);
   @$pb.TagNumber(2)
@@ -2526,10 +1961,7 @@ class LNUrlWithdraw extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get defaultDescription => $_getSZ(2);
   @$pb.TagNumber(3)
-  set defaultDescription($core.String v) {
-    $_setString(2, v);
-  }
-
+  set defaultDescription($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasDefaultDescription() => $_has(2);
   @$pb.TagNumber(3)
@@ -2537,42 +1969,32 @@ class LNUrlWithdraw extends $pb.GeneratedMessage {
 }
 
 class LNURLChannel extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('LNURLChannel',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('LNURLChannel', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'k1')
     ..aOS(2, 'callback')
     ..aOS(3, 'uri')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   LNURLChannel._() : super();
   factory LNURLChannel() => create();
-  factory LNURLChannel.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory LNURLChannel.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory LNURLChannel.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory LNURLChannel.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   LNURLChannel clone() => LNURLChannel()..mergeFromMessage(this);
-  LNURLChannel copyWith(void Function(LNURLChannel) updates) =>
-      super.copyWith((message) => updates(message as LNURLChannel));
+  LNURLChannel copyWith(void Function(LNURLChannel) updates) => super.copyWith((message) => updates(message as LNURLChannel));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LNURLChannel create() => LNURLChannel._();
   LNURLChannel createEmptyInstance() => create();
-  static $pb.PbList<LNURLChannel> createRepeated() =>
-      $pb.PbList<LNURLChannel>();
+  static $pb.PbList<LNURLChannel> createRepeated() => $pb.PbList<LNURLChannel>();
   @$core.pragma('dart2js:noInline')
-  static LNURLChannel getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<LNURLChannel>(create);
+  static LNURLChannel getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNURLChannel>(create);
   static LNURLChannel _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get k1 => $_getSZ(0);
   @$pb.TagNumber(1)
-  set k1($core.String v) {
-    $_setString(0, v);
-  }
-
+  set k1($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasK1() => $_has(0);
   @$pb.TagNumber(1)
@@ -2581,10 +2003,7 @@ class LNURLChannel extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get callback => $_getSZ(1);
   @$pb.TagNumber(2)
-  set callback($core.String v) {
-    $_setString(1, v);
-  }
-
+  set callback($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasCallback() => $_has(1);
   @$pb.TagNumber(2)
@@ -2593,10 +2012,7 @@ class LNURLChannel extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get uri => $_getSZ(2);
   @$pb.TagNumber(3)
-  set uri($core.String v) {
-    $_setString(2, v);
-  }
-
+  set uri($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasUri() => $_has(2);
   @$pb.TagNumber(3)
@@ -2604,41 +2020,31 @@ class LNURLChannel extends $pb.GeneratedMessage {
 }
 
 class ReverseSwapRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ReverseSwapRequest',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ReverseSwapRequest', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'address')
     ..aInt64(2, 'amount')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   ReverseSwapRequest._() : super();
   factory ReverseSwapRequest() => create();
-  factory ReverseSwapRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ReverseSwapRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ReverseSwapRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ReverseSwapRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   ReverseSwapRequest clone() => ReverseSwapRequest()..mergeFromMessage(this);
-  ReverseSwapRequest copyWith(void Function(ReverseSwapRequest) updates) =>
-      super.copyWith((message) => updates(message as ReverseSwapRequest));
+  ReverseSwapRequest copyWith(void Function(ReverseSwapRequest) updates) => super.copyWith((message) => updates(message as ReverseSwapRequest));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReverseSwapRequest create() => ReverseSwapRequest._();
   ReverseSwapRequest createEmptyInstance() => create();
-  static $pb.PbList<ReverseSwapRequest> createRepeated() =>
-      $pb.PbList<ReverseSwapRequest>();
+  static $pb.PbList<ReverseSwapRequest> createRepeated() => $pb.PbList<ReverseSwapRequest>();
   @$core.pragma('dart2js:noInline')
-  static ReverseSwapRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ReverseSwapRequest>(create);
+  static ReverseSwapRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapRequest>(create);
   static ReverseSwapRequest _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) {
-    $_setString(0, v);
-  }
-
+  set address($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -2647,10 +2053,7 @@ class ReverseSwapRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amount => $_getI64(1);
   @$pb.TagNumber(2)
-  set amount($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set amount($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAmount() => $_has(1);
   @$pb.TagNumber(2)
@@ -2658,8 +2061,7 @@ class ReverseSwapRequest extends $pb.GeneratedMessage {
 }
 
 class ReverseSwap extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ReverseSwap',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ReverseSwap', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'id')
     ..aOS(2, 'invoice')
     ..aOS(3, 'script')
@@ -2673,36 +2075,28 @@ class ReverseSwap extends $pb.GeneratedMessage {
     ..aInt64(11, 'startBlockHeight')
     ..aInt64(12, 'claimFee')
     ..aOS(13, 'claimTxid')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   ReverseSwap._() : super();
   factory ReverseSwap() => create();
-  factory ReverseSwap.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ReverseSwap.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ReverseSwap.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ReverseSwap.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   ReverseSwap clone() => ReverseSwap()..mergeFromMessage(this);
-  ReverseSwap copyWith(void Function(ReverseSwap) updates) =>
-      super.copyWith((message) => updates(message as ReverseSwap));
+  ReverseSwap copyWith(void Function(ReverseSwap) updates) => super.copyWith((message) => updates(message as ReverseSwap));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReverseSwap create() => ReverseSwap._();
   ReverseSwap createEmptyInstance() => create();
   static $pb.PbList<ReverseSwap> createRepeated() => $pb.PbList<ReverseSwap>();
   @$core.pragma('dart2js:noInline')
-  static ReverseSwap getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ReverseSwap>(create);
+  static ReverseSwap getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwap>(create);
   static ReverseSwap _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) {
-    $_setString(0, v);
-  }
-
+  set id($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
@@ -2711,10 +2105,7 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get invoice => $_getSZ(1);
   @$pb.TagNumber(2)
-  set invoice($core.String v) {
-    $_setString(1, v);
-  }
-
+  set invoice($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasInvoice() => $_has(1);
   @$pb.TagNumber(2)
@@ -2723,10 +2114,7 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get script => $_getSZ(2);
   @$pb.TagNumber(3)
-  set script($core.String v) {
-    $_setString(2, v);
-  }
-
+  set script($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasScript() => $_has(2);
   @$pb.TagNumber(3)
@@ -2735,10 +2123,7 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get lockupAddress => $_getSZ(3);
   @$pb.TagNumber(4)
-  set lockupAddress($core.String v) {
-    $_setString(3, v);
-  }
-
+  set lockupAddress($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasLockupAddress() => $_has(3);
   @$pb.TagNumber(4)
@@ -2747,10 +2132,7 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get preimage => $_getSZ(4);
   @$pb.TagNumber(5)
-  set preimage($core.String v) {
-    $_setString(4, v);
-  }
-
+  set preimage($core.String v) { $_setString(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasPreimage() => $_has(4);
   @$pb.TagNumber(5)
@@ -2759,10 +2141,7 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.String get key => $_getSZ(5);
   @$pb.TagNumber(6)
-  set key($core.String v) {
-    $_setString(5, v);
-  }
-
+  set key($core.String v) { $_setString(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasKey() => $_has(5);
   @$pb.TagNumber(6)
@@ -2771,10 +2150,7 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.String get claimAddress => $_getSZ(6);
   @$pb.TagNumber(7)
-  set claimAddress($core.String v) {
-    $_setString(6, v);
-  }
-
+  set claimAddress($core.String v) { $_setString(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasClaimAddress() => $_has(6);
   @$pb.TagNumber(7)
@@ -2783,10 +2159,7 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $fixnum.Int64 get lnAmount => $_getI64(7);
   @$pb.TagNumber(8)
-  set lnAmount($fixnum.Int64 v) {
-    $_setInt64(7, v);
-  }
-
+  set lnAmount($fixnum.Int64 v) { $_setInt64(7, v); }
   @$pb.TagNumber(8)
   $core.bool hasLnAmount() => $_has(7);
   @$pb.TagNumber(8)
@@ -2795,10 +2168,7 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $fixnum.Int64 get onchainAmount => $_getI64(8);
   @$pb.TagNumber(9)
-  set onchainAmount($fixnum.Int64 v) {
-    $_setInt64(8, v);
-  }
-
+  set onchainAmount($fixnum.Int64 v) { $_setInt64(8, v); }
   @$pb.TagNumber(9)
   $core.bool hasOnchainAmount() => $_has(8);
   @$pb.TagNumber(9)
@@ -2807,10 +2177,7 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $fixnum.Int64 get timeoutBlockHeight => $_getI64(9);
   @$pb.TagNumber(10)
-  set timeoutBlockHeight($fixnum.Int64 v) {
-    $_setInt64(9, v);
-  }
-
+  set timeoutBlockHeight($fixnum.Int64 v) { $_setInt64(9, v); }
   @$pb.TagNumber(10)
   $core.bool hasTimeoutBlockHeight() => $_has(9);
   @$pb.TagNumber(10)
@@ -2819,10 +2186,7 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $fixnum.Int64 get startBlockHeight => $_getI64(10);
   @$pb.TagNumber(11)
-  set startBlockHeight($fixnum.Int64 v) {
-    $_setInt64(10, v);
-  }
-
+  set startBlockHeight($fixnum.Int64 v) { $_setInt64(10, v); }
   @$pb.TagNumber(11)
   $core.bool hasStartBlockHeight() => $_has(10);
   @$pb.TagNumber(11)
@@ -2831,10 +2195,7 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(12)
   $fixnum.Int64 get claimFee => $_getI64(11);
   @$pb.TagNumber(12)
-  set claimFee($fixnum.Int64 v) {
-    $_setInt64(11, v);
-  }
-
+  set claimFee($fixnum.Int64 v) { $_setInt64(11, v); }
   @$pb.TagNumber(12)
   $core.bool hasClaimFee() => $_has(11);
   @$pb.TagNumber(12)
@@ -2843,10 +2204,7 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(13)
   $core.String get claimTxid => $_getSZ(12);
   @$pb.TagNumber(13)
-  set claimTxid($core.String v) {
-    $_setString(12, v);
-  }
-
+  set claimTxid($core.String v) { $_setString(12, v); }
   @$pb.TagNumber(13)
   $core.bool hasClaimTxid() => $_has(12);
   @$pb.TagNumber(13)
@@ -2854,42 +2212,32 @@ class ReverseSwap extends $pb.GeneratedMessage {
 }
 
 class ReverseSwapFees extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ReverseSwapFees',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ReverseSwapFees', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..a<$core.double>(1, 'percentage', $pb.PbFieldType.OD)
     ..aInt64(2, 'lockup')
     ..aInt64(3, 'claim')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   ReverseSwapFees._() : super();
   factory ReverseSwapFees() => create();
-  factory ReverseSwapFees.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ReverseSwapFees.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ReverseSwapFees.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ReverseSwapFees.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   ReverseSwapFees clone() => ReverseSwapFees()..mergeFromMessage(this);
-  ReverseSwapFees copyWith(void Function(ReverseSwapFees) updates) =>
-      super.copyWith((message) => updates(message as ReverseSwapFees));
+  ReverseSwapFees copyWith(void Function(ReverseSwapFees) updates) => super.copyWith((message) => updates(message as ReverseSwapFees));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReverseSwapFees create() => ReverseSwapFees._();
   ReverseSwapFees createEmptyInstance() => create();
-  static $pb.PbList<ReverseSwapFees> createRepeated() =>
-      $pb.PbList<ReverseSwapFees>();
+  static $pb.PbList<ReverseSwapFees> createRepeated() => $pb.PbList<ReverseSwapFees>();
   @$core.pragma('dart2js:noInline')
-  static ReverseSwapFees getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ReverseSwapFees>(create);
+  static ReverseSwapFees getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapFees>(create);
   static ReverseSwapFees _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.double get percentage => $_getN(0);
   @$pb.TagNumber(1)
-  set percentage($core.double v) {
-    $_setDouble(0, v);
-  }
-
+  set percentage($core.double v) { $_setDouble(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasPercentage() => $_has(0);
   @$pb.TagNumber(1)
@@ -2898,10 +2246,7 @@ class ReverseSwapFees extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get lockup => $_getI64(1);
   @$pb.TagNumber(2)
-  set lockup($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set lockup($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasLockup() => $_has(1);
   @$pb.TagNumber(2)
@@ -2910,10 +2255,7 @@ class ReverseSwapFees extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get claim => $_getI64(2);
   @$pb.TagNumber(3)
-  set claim($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set claim($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasClaim() => $_has(2);
   @$pb.TagNumber(3)
@@ -2921,42 +2263,32 @@ class ReverseSwapFees extends $pb.GeneratedMessage {
 }
 
 class ReverseSwapInfo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ReverseSwapInfo',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ReverseSwapInfo', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aInt64(1, 'min')
     ..aInt64(2, 'max')
     ..aOM<ReverseSwapFees>(3, 'fees', subBuilder: ReverseSwapFees.create)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   ReverseSwapInfo._() : super();
   factory ReverseSwapInfo() => create();
-  factory ReverseSwapInfo.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ReverseSwapInfo.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ReverseSwapInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ReverseSwapInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   ReverseSwapInfo clone() => ReverseSwapInfo()..mergeFromMessage(this);
-  ReverseSwapInfo copyWith(void Function(ReverseSwapInfo) updates) =>
-      super.copyWith((message) => updates(message as ReverseSwapInfo));
+  ReverseSwapInfo copyWith(void Function(ReverseSwapInfo) updates) => super.copyWith((message) => updates(message as ReverseSwapInfo));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReverseSwapInfo create() => ReverseSwapInfo._();
   ReverseSwapInfo createEmptyInstance() => create();
-  static $pb.PbList<ReverseSwapInfo> createRepeated() =>
-      $pb.PbList<ReverseSwapInfo>();
+  static $pb.PbList<ReverseSwapInfo> createRepeated() => $pb.PbList<ReverseSwapInfo>();
   @$core.pragma('dart2js:noInline')
-  static ReverseSwapInfo getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ReverseSwapInfo>(create);
+  static ReverseSwapInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapInfo>(create);
   static ReverseSwapInfo _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get min => $_getI64(0);
   @$pb.TagNumber(1)
-  set min($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set min($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMin() => $_has(0);
   @$pb.TagNumber(1)
@@ -2965,10 +2297,7 @@ class ReverseSwapInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get max => $_getI64(1);
   @$pb.TagNumber(2)
-  set max($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set max($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasMax() => $_has(1);
   @$pb.TagNumber(2)
@@ -2977,10 +2306,7 @@ class ReverseSwapInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   ReverseSwapFees get fees => $_getN(2);
   @$pb.TagNumber(3)
-  set fees(ReverseSwapFees v) {
-    setField(3, v);
-  }
-
+  set fees(ReverseSwapFees v) { setField(3, v); }
   @$pb.TagNumber(3)
   $core.bool hasFees() => $_has(2);
   @$pb.TagNumber(3)
@@ -2990,45 +2316,31 @@ class ReverseSwapInfo extends $pb.GeneratedMessage {
 }
 
 class ReverseSwapPaymentRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ReverseSwapPaymentRequest',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ReverseSwapPaymentRequest', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'hash')
-    ..aOM<PushNotificationDetails>(2, 'pushNotificationDetails',
-        subBuilder: PushNotificationDetails.create)
-    ..hasRequiredFields = false;
+    ..aOM<PushNotificationDetails>(2, 'pushNotificationDetails', subBuilder: PushNotificationDetails.create)
+    ..hasRequiredFields = false
+  ;
 
   ReverseSwapPaymentRequest._() : super();
   factory ReverseSwapPaymentRequest() => create();
-  factory ReverseSwapPaymentRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ReverseSwapPaymentRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  ReverseSwapPaymentRequest clone() =>
-      ReverseSwapPaymentRequest()..mergeFromMessage(this);
-  ReverseSwapPaymentRequest copyWith(
-          void Function(ReverseSwapPaymentRequest) updates) =>
-      super
-          .copyWith((message) => updates(message as ReverseSwapPaymentRequest));
+  factory ReverseSwapPaymentRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ReverseSwapPaymentRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  ReverseSwapPaymentRequest clone() => ReverseSwapPaymentRequest()..mergeFromMessage(this);
+  ReverseSwapPaymentRequest copyWith(void Function(ReverseSwapPaymentRequest) updates) => super.copyWith((message) => updates(message as ReverseSwapPaymentRequest));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReverseSwapPaymentRequest create() => ReverseSwapPaymentRequest._();
   ReverseSwapPaymentRequest createEmptyInstance() => create();
-  static $pb.PbList<ReverseSwapPaymentRequest> createRepeated() =>
-      $pb.PbList<ReverseSwapPaymentRequest>();
+  static $pb.PbList<ReverseSwapPaymentRequest> createRepeated() => $pb.PbList<ReverseSwapPaymentRequest>();
   @$core.pragma('dart2js:noInline')
-  static ReverseSwapPaymentRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ReverseSwapPaymentRequest>(create);
+  static ReverseSwapPaymentRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapPaymentRequest>(create);
   static ReverseSwapPaymentRequest _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -3037,10 +2349,7 @@ class ReverseSwapPaymentRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   PushNotificationDetails get pushNotificationDetails => $_getN(1);
   @$pb.TagNumber(2)
-  set pushNotificationDetails(PushNotificationDetails v) {
-    setField(2, v);
-  }
-
+  set pushNotificationDetails(PushNotificationDetails v) { setField(2, v); }
   @$pb.TagNumber(2)
   $core.bool hasPushNotificationDetails() => $_has(1);
   @$pb.TagNumber(2)
@@ -3050,44 +2359,32 @@ class ReverseSwapPaymentRequest extends $pb.GeneratedMessage {
 }
 
 class PushNotificationDetails extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PushNotificationDetails',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PushNotificationDetails', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'deviceId')
     ..aOS(2, 'title')
     ..aOS(3, 'body')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   PushNotificationDetails._() : super();
   factory PushNotificationDetails() => create();
-  factory PushNotificationDetails.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PushNotificationDetails.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  PushNotificationDetails clone() =>
-      PushNotificationDetails()..mergeFromMessage(this);
-  PushNotificationDetails copyWith(
-          void Function(PushNotificationDetails) updates) =>
-      super.copyWith((message) => updates(message as PushNotificationDetails));
+  factory PushNotificationDetails.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PushNotificationDetails.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  PushNotificationDetails clone() => PushNotificationDetails()..mergeFromMessage(this);
+  PushNotificationDetails copyWith(void Function(PushNotificationDetails) updates) => super.copyWith((message) => updates(message as PushNotificationDetails));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PushNotificationDetails create() => PushNotificationDetails._();
   PushNotificationDetails createEmptyInstance() => create();
-  static $pb.PbList<PushNotificationDetails> createRepeated() =>
-      $pb.PbList<PushNotificationDetails>();
+  static $pb.PbList<PushNotificationDetails> createRepeated() => $pb.PbList<PushNotificationDetails>();
   @$core.pragma('dart2js:noInline')
-  static PushNotificationDetails getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<PushNotificationDetails>(create);
+  static PushNotificationDetails getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PushNotificationDetails>(create);
   static PushNotificationDetails _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get deviceId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set deviceId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set deviceId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDeviceId() => $_has(0);
   @$pb.TagNumber(1)
@@ -3096,10 +2393,7 @@ class PushNotificationDetails extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get title => $_getSZ(1);
   @$pb.TagNumber(2)
-  set title($core.String v) {
-    $_setString(1, v);
-  }
-
+  set title($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasTitle() => $_has(1);
   @$pb.TagNumber(2)
@@ -3108,10 +2402,7 @@ class PushNotificationDetails extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get body => $_getSZ(2);
   @$pb.TagNumber(3)
-  set body($core.String v) {
-    $_setString(2, v);
-  }
-
+  set body($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasBody() => $_has(2);
   @$pb.TagNumber(3)
@@ -3119,43 +2410,31 @@ class PushNotificationDetails extends $pb.GeneratedMessage {
 }
 
 class ReverseSwapPaymentStatus extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ReverseSwapPaymentStatus',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ReverseSwapPaymentStatus', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'hash')
     ..a<$core.int>(3, 'eta', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   ReverseSwapPaymentStatus._() : super();
   factory ReverseSwapPaymentStatus() => create();
-  factory ReverseSwapPaymentStatus.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ReverseSwapPaymentStatus.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  ReverseSwapPaymentStatus clone() =>
-      ReverseSwapPaymentStatus()..mergeFromMessage(this);
-  ReverseSwapPaymentStatus copyWith(
-          void Function(ReverseSwapPaymentStatus) updates) =>
-      super.copyWith((message) => updates(message as ReverseSwapPaymentStatus));
+  factory ReverseSwapPaymentStatus.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ReverseSwapPaymentStatus.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  ReverseSwapPaymentStatus clone() => ReverseSwapPaymentStatus()..mergeFromMessage(this);
+  ReverseSwapPaymentStatus copyWith(void Function(ReverseSwapPaymentStatus) updates) => super.copyWith((message) => updates(message as ReverseSwapPaymentStatus));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReverseSwapPaymentStatus create() => ReverseSwapPaymentStatus._();
   ReverseSwapPaymentStatus createEmptyInstance() => create();
-  static $pb.PbList<ReverseSwapPaymentStatus> createRepeated() =>
-      $pb.PbList<ReverseSwapPaymentStatus>();
+  static $pb.PbList<ReverseSwapPaymentStatus> createRepeated() => $pb.PbList<ReverseSwapPaymentStatus>();
   @$core.pragma('dart2js:noInline')
-  static ReverseSwapPaymentStatus getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ReverseSwapPaymentStatus>(create);
+  static ReverseSwapPaymentStatus getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapPaymentStatus>(create);
   static ReverseSwapPaymentStatus _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -3164,10 +2443,7 @@ class ReverseSwapPaymentStatus extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.int get eta => $_getIZ(1);
   @$pb.TagNumber(3)
-  set eta($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set eta($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(3)
   $core.bool hasEta() => $_has(1);
   @$pb.TagNumber(3)
@@ -3175,37 +2451,24 @@ class ReverseSwapPaymentStatus extends $pb.GeneratedMessage {
 }
 
 class ReverseSwapPaymentStatuses extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      'ReverseSwapPaymentStatuses',
-      package: const $pb.PackageName('data'),
-      createEmptyInstance: create)
-    ..pc<ReverseSwapPaymentStatus>(1, 'paymentsStatus', $pb.PbFieldType.PM,
-        subBuilder: ReverseSwapPaymentStatus.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ReverseSwapPaymentStatuses', package: const $pb.PackageName('data'), createEmptyInstance: create)
+    ..pc<ReverseSwapPaymentStatus>(1, 'paymentsStatus', $pb.PbFieldType.PM, subBuilder: ReverseSwapPaymentStatus.create)
+    ..hasRequiredFields = false
+  ;
 
   ReverseSwapPaymentStatuses._() : super();
   factory ReverseSwapPaymentStatuses() => create();
-  factory ReverseSwapPaymentStatuses.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ReverseSwapPaymentStatuses.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  ReverseSwapPaymentStatuses clone() =>
-      ReverseSwapPaymentStatuses()..mergeFromMessage(this);
-  ReverseSwapPaymentStatuses copyWith(
-          void Function(ReverseSwapPaymentStatuses) updates) =>
-      super.copyWith(
-          (message) => updates(message as ReverseSwapPaymentStatuses));
+  factory ReverseSwapPaymentStatuses.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ReverseSwapPaymentStatuses.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  ReverseSwapPaymentStatuses clone() => ReverseSwapPaymentStatuses()..mergeFromMessage(this);
+  ReverseSwapPaymentStatuses copyWith(void Function(ReverseSwapPaymentStatuses) updates) => super.copyWith((message) => updates(message as ReverseSwapPaymentStatuses));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReverseSwapPaymentStatuses create() => ReverseSwapPaymentStatuses._();
   ReverseSwapPaymentStatuses createEmptyInstance() => create();
-  static $pb.PbList<ReverseSwapPaymentStatuses> createRepeated() =>
-      $pb.PbList<ReverseSwapPaymentStatuses>();
+  static $pb.PbList<ReverseSwapPaymentStatuses> createRepeated() => $pb.PbList<ReverseSwapPaymentStatuses>();
   @$core.pragma('dart2js:noInline')
-  static ReverseSwapPaymentStatuses getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ReverseSwapPaymentStatuses>(create);
+  static ReverseSwapPaymentStatuses getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapPaymentStatuses>(create);
   static ReverseSwapPaymentStatuses _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -3213,41 +2476,31 @@ class ReverseSwapPaymentStatuses extends $pb.GeneratedMessage {
 }
 
 class ReverseSwapClaimFee extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ReverseSwapClaimFee',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ReverseSwapClaimFee', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aOS(1, 'hash')
     ..aInt64(2, 'fee')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   ReverseSwapClaimFee._() : super();
   factory ReverseSwapClaimFee() => create();
-  factory ReverseSwapClaimFee.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ReverseSwapClaimFee.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ReverseSwapClaimFee.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ReverseSwapClaimFee.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   ReverseSwapClaimFee clone() => ReverseSwapClaimFee()..mergeFromMessage(this);
-  ReverseSwapClaimFee copyWith(void Function(ReverseSwapClaimFee) updates) =>
-      super.copyWith((message) => updates(message as ReverseSwapClaimFee));
+  ReverseSwapClaimFee copyWith(void Function(ReverseSwapClaimFee) updates) => super.copyWith((message) => updates(message as ReverseSwapClaimFee));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReverseSwapClaimFee create() => ReverseSwapClaimFee._();
   ReverseSwapClaimFee createEmptyInstance() => create();
-  static $pb.PbList<ReverseSwapClaimFee> createRepeated() =>
-      $pb.PbList<ReverseSwapClaimFee>();
+  static $pb.PbList<ReverseSwapClaimFee> createRepeated() => $pb.PbList<ReverseSwapClaimFee>();
   @$core.pragma('dart2js:noInline')
-  static ReverseSwapClaimFee getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ReverseSwapClaimFee>(create);
+  static ReverseSwapClaimFee getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapClaimFee>(create);
   static ReverseSwapClaimFee _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) {
-    $_setString(0, v);
-  }
-
+  set hash($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -3256,10 +2509,7 @@ class ReverseSwapClaimFee extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get fee => $_getI64(1);
   @$pb.TagNumber(2)
-  set fee($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set fee($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasFee() => $_has(1);
   @$pb.TagNumber(2)
@@ -3267,35 +2517,24 @@ class ReverseSwapClaimFee extends $pb.GeneratedMessage {
 }
 
 class ClaimFeeEstimates extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ClaimFeeEstimates',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
-    ..m<$core.int, $fixnum.Int64>(1, 'fees',
-        entryClassName: 'ClaimFeeEstimates.FeesEntry',
-        keyFieldType: $pb.PbFieldType.O3,
-        valueFieldType: $pb.PbFieldType.O6,
-        packageName: const $pb.PackageName('data'))
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ClaimFeeEstimates', package: const $pb.PackageName('data'), createEmptyInstance: create)
+    ..m<$core.int, $fixnum.Int64>(1, 'fees', entryClassName: 'ClaimFeeEstimates.FeesEntry', keyFieldType: $pb.PbFieldType.O3, valueFieldType: $pb.PbFieldType.O6, packageName: const $pb.PackageName('data'))
+    ..hasRequiredFields = false
+  ;
 
   ClaimFeeEstimates._() : super();
   factory ClaimFeeEstimates() => create();
-  factory ClaimFeeEstimates.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ClaimFeeEstimates.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ClaimFeeEstimates.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ClaimFeeEstimates.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   ClaimFeeEstimates clone() => ClaimFeeEstimates()..mergeFromMessage(this);
-  ClaimFeeEstimates copyWith(void Function(ClaimFeeEstimates) updates) =>
-      super.copyWith((message) => updates(message as ClaimFeeEstimates));
+  ClaimFeeEstimates copyWith(void Function(ClaimFeeEstimates) updates) => super.copyWith((message) => updates(message as ClaimFeeEstimates));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ClaimFeeEstimates create() => ClaimFeeEstimates._();
   ClaimFeeEstimates createEmptyInstance() => create();
-  static $pb.PbList<ClaimFeeEstimates> createRepeated() =>
-      $pb.PbList<ClaimFeeEstimates>();
+  static $pb.PbList<ClaimFeeEstimates> createRepeated() => $pb.PbList<ClaimFeeEstimates>();
   @$core.pragma('dart2js:noInline')
-  static ClaimFeeEstimates getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ClaimFeeEstimates>(create);
+  static ClaimFeeEstimates getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ClaimFeeEstimates>(create);
   static ClaimFeeEstimates _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -3303,44 +2542,32 @@ class ClaimFeeEstimates extends $pb.GeneratedMessage {
 }
 
 class UnspendLockupInformation extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('UnspendLockupInformation',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('UnspendLockupInformation', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..a<$core.int>(1, 'heightHint', $pb.PbFieldType.OU3)
     ..a<$core.List<$core.int>>(2, 'lockupScript', $pb.PbFieldType.OY)
     ..a<$core.List<$core.int>>(3, 'claimTxHash', $pb.PbFieldType.OY)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   UnspendLockupInformation._() : super();
   factory UnspendLockupInformation() => create();
-  factory UnspendLockupInformation.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory UnspendLockupInformation.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  UnspendLockupInformation clone() =>
-      UnspendLockupInformation()..mergeFromMessage(this);
-  UnspendLockupInformation copyWith(
-          void Function(UnspendLockupInformation) updates) =>
-      super.copyWith((message) => updates(message as UnspendLockupInformation));
+  factory UnspendLockupInformation.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory UnspendLockupInformation.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  UnspendLockupInformation clone() => UnspendLockupInformation()..mergeFromMessage(this);
+  UnspendLockupInformation copyWith(void Function(UnspendLockupInformation) updates) => super.copyWith((message) => updates(message as UnspendLockupInformation));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static UnspendLockupInformation create() => UnspendLockupInformation._();
   UnspendLockupInformation createEmptyInstance() => create();
-  static $pb.PbList<UnspendLockupInformation> createRepeated() =>
-      $pb.PbList<UnspendLockupInformation>();
+  static $pb.PbList<UnspendLockupInformation> createRepeated() => $pb.PbList<UnspendLockupInformation>();
   @$core.pragma('dart2js:noInline')
-  static UnspendLockupInformation getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<UnspendLockupInformation>(create);
+  static UnspendLockupInformation getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UnspendLockupInformation>(create);
   static UnspendLockupInformation _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get heightHint => $_getIZ(0);
   @$pb.TagNumber(1)
-  set heightHint($core.int v) {
-    $_setUnsignedInt32(0, v);
-  }
-
+  set heightHint($core.int v) { $_setUnsignedInt32(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasHeightHint() => $_has(0);
   @$pb.TagNumber(1)
@@ -3349,10 +2576,7 @@ class UnspendLockupInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.List<$core.int> get lockupScript => $_getN(1);
   @$pb.TagNumber(2)
-  set lockupScript($core.List<$core.int> v) {
-    $_setBytes(1, v);
-  }
-
+  set lockupScript($core.List<$core.int> v) { $_setBytes(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasLockupScript() => $_has(1);
   @$pb.TagNumber(2)
@@ -3361,10 +2585,7 @@ class UnspendLockupInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.List<$core.int> get claimTxHash => $_getN(2);
   @$pb.TagNumber(3)
-  set claimTxHash($core.List<$core.int> v) {
-    $_setBytes(2, v);
-  }
-
+  set claimTxHash($core.List<$core.int> v) { $_setBytes(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasClaimTxHash() => $_has(2);
   @$pb.TagNumber(3)
@@ -3372,42 +2593,32 @@ class UnspendLockupInformation extends $pb.GeneratedMessage {
 }
 
 class TransactionDetails extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('TransactionDetails',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('TransactionDetails', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..a<$core.List<$core.int>>(1, 'tx', $pb.PbFieldType.OY)
     ..aOS(2, 'txHash')
     ..aInt64(3, 'fees')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   TransactionDetails._() : super();
   factory TransactionDetails() => create();
-  factory TransactionDetails.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TransactionDetails.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory TransactionDetails.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TransactionDetails.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   TransactionDetails clone() => TransactionDetails()..mergeFromMessage(this);
-  TransactionDetails copyWith(void Function(TransactionDetails) updates) =>
-      super.copyWith((message) => updates(message as TransactionDetails));
+  TransactionDetails copyWith(void Function(TransactionDetails) updates) => super.copyWith((message) => updates(message as TransactionDetails));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static TransactionDetails create() => TransactionDetails._();
   TransactionDetails createEmptyInstance() => create();
-  static $pb.PbList<TransactionDetails> createRepeated() =>
-      $pb.PbList<TransactionDetails>();
+  static $pb.PbList<TransactionDetails> createRepeated() => $pb.PbList<TransactionDetails>();
   @$core.pragma('dart2js:noInline')
-  static TransactionDetails getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<TransactionDetails>(create);
+  static TransactionDetails getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransactionDetails>(create);
   static TransactionDetails _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get tx => $_getN(0);
   @$pb.TagNumber(1)
-  set tx($core.List<$core.int> v) {
-    $_setBytes(0, v);
-  }
-
+  set tx($core.List<$core.int> v) { $_setBytes(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTx() => $_has(0);
   @$pb.TagNumber(1)
@@ -3416,10 +2627,7 @@ class TransactionDetails extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get txHash => $_getSZ(1);
   @$pb.TagNumber(2)
-  set txHash($core.String v) {
-    $_setString(1, v);
-  }
-
+  set txHash($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasTxHash() => $_has(1);
   @$pb.TagNumber(2)
@@ -3428,10 +2636,7 @@ class TransactionDetails extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get fees => $_getI64(2);
   @$pb.TagNumber(3)
-  set fees($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set fees($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasFees() => $_has(2);
   @$pb.TagNumber(3)
@@ -3439,49 +2644,31 @@ class TransactionDetails extends $pb.GeneratedMessage {
 }
 
 class SweepAllCoinsTransactions extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('SweepAllCoinsTransactions',
-      package: const $pb.PackageName('data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('SweepAllCoinsTransactions', package: const $pb.PackageName('data'), createEmptyInstance: create)
     ..aInt64(1, 'amt')
-    ..m<$core.int, TransactionDetails>(2, 'transactions',
-        entryClassName: 'SweepAllCoinsTransactions.TransactionsEntry',
-        keyFieldType: $pb.PbFieldType.O3,
-        valueFieldType: $pb.PbFieldType.OM,
-        valueCreator: TransactionDetails.create,
-        packageName: const $pb.PackageName('data'))
-    ..hasRequiredFields = false;
+    ..m<$core.int, TransactionDetails>(2, 'transactions', entryClassName: 'SweepAllCoinsTransactions.TransactionsEntry', keyFieldType: $pb.PbFieldType.O3, valueFieldType: $pb.PbFieldType.OM, valueCreator: TransactionDetails.create, packageName: const $pb.PackageName('data'))
+    ..hasRequiredFields = false
+  ;
 
   SweepAllCoinsTransactions._() : super();
   factory SweepAllCoinsTransactions() => create();
-  factory SweepAllCoinsTransactions.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SweepAllCoinsTransactions.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  SweepAllCoinsTransactions clone() =>
-      SweepAllCoinsTransactions()..mergeFromMessage(this);
-  SweepAllCoinsTransactions copyWith(
-          void Function(SweepAllCoinsTransactions) updates) =>
-      super
-          .copyWith((message) => updates(message as SweepAllCoinsTransactions));
+  factory SweepAllCoinsTransactions.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SweepAllCoinsTransactions.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  SweepAllCoinsTransactions clone() => SweepAllCoinsTransactions()..mergeFromMessage(this);
+  SweepAllCoinsTransactions copyWith(void Function(SweepAllCoinsTransactions) updates) => super.copyWith((message) => updates(message as SweepAllCoinsTransactions));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SweepAllCoinsTransactions create() => SweepAllCoinsTransactions._();
   SweepAllCoinsTransactions createEmptyInstance() => create();
-  static $pb.PbList<SweepAllCoinsTransactions> createRepeated() =>
-      $pb.PbList<SweepAllCoinsTransactions>();
+  static $pb.PbList<SweepAllCoinsTransactions> createRepeated() => $pb.PbList<SweepAllCoinsTransactions>();
   @$core.pragma('dart2js:noInline')
-  static SweepAllCoinsTransactions getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<SweepAllCoinsTransactions>(create);
+  static SweepAllCoinsTransactions getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SweepAllCoinsTransactions>(create);
   static SweepAllCoinsTransactions _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get amt => $_getI64(0);
   @$pb.TagNumber(1)
-  set amt($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set amt($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasAmt() => $_has(0);
   @$pb.TagNumber(1)
@@ -3490,3 +2677,4 @@ class SweepAllCoinsTransactions extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.Map<$core.int, TransactionDetails> get transactions => $_getMap(1);
 }
+

--- a/lib/services/breezlib/data/rpc.pbenum.dart
+++ b/lib/services/breezlib/data/rpc.pbenum.dart
@@ -7,19 +7,16 @@
 
 // ignore_for_file: UNDEFINED_SHOWN_NAME,UNUSED_SHOWN_NAME
 import 'dart:core' as $core;
-
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class SwapError extends $pb.ProtobufEnum {
   static const SwapError NO_ERROR = SwapError._(0, 'NO_ERROR');
-  static const SwapError FUNDS_EXCEED_LIMIT =
-      SwapError._(1, 'FUNDS_EXCEED_LIMIT');
+  static const SwapError FUNDS_EXCEED_LIMIT = SwapError._(1, 'FUNDS_EXCEED_LIMIT');
   static const SwapError TX_TOO_SMALL = SwapError._(2, 'TX_TOO_SMALL');
-  static const SwapError INVOICE_AMOUNT_MISMATCH =
-      SwapError._(3, 'INVOICE_AMOUNT_MISMATCH');
+  static const SwapError INVOICE_AMOUNT_MISMATCH = SwapError._(3, 'INVOICE_AMOUNT_MISMATCH');
   static const SwapError SWAP_EXPIRED = SwapError._(4, 'SWAP_EXPIRED');
 
-  static const $core.List<SwapError> values = <SwapError>[
+  static const $core.List<SwapError> values = <SwapError> [
     NO_ERROR,
     FUNDS_EXCEED_LIMIT,
     TX_TOO_SMALL,
@@ -27,50 +24,39 @@ class SwapError extends $pb.ProtobufEnum {
     SWAP_EXPIRED,
   ];
 
-  static final $core.Map<$core.int, SwapError> _byValue =
-      $pb.ProtobufEnum.initByValue(values);
+  static final $core.Map<$core.int, SwapError> _byValue = $pb.ProtobufEnum.initByValue(values);
   static SwapError valueOf($core.int value) => _byValue[value];
 
   const SwapError._($core.int v, $core.String n) : super(v, n);
 }
 
 class Account_AccountStatus extends $pb.ProtobufEnum {
-  static const Account_AccountStatus DISCONNECTED =
-      Account_AccountStatus._(0, 'DISCONNECTED');
-  static const Account_AccountStatus PROCESSING_CONNECTION =
-      Account_AccountStatus._(1, 'PROCESSING_CONNECTION');
-  static const Account_AccountStatus CLOSING_CONNECTION =
-      Account_AccountStatus._(2, 'CLOSING_CONNECTION');
-  static const Account_AccountStatus CONNECTED =
-      Account_AccountStatus._(3, 'CONNECTED');
+  static const Account_AccountStatus DISCONNECTED = Account_AccountStatus._(0, 'DISCONNECTED');
+  static const Account_AccountStatus PROCESSING_CONNECTION = Account_AccountStatus._(1, 'PROCESSING_CONNECTION');
+  static const Account_AccountStatus CLOSING_CONNECTION = Account_AccountStatus._(2, 'CLOSING_CONNECTION');
+  static const Account_AccountStatus CONNECTED = Account_AccountStatus._(3, 'CONNECTED');
 
-  static const $core.List<Account_AccountStatus> values =
-      <Account_AccountStatus>[
+  static const $core.List<Account_AccountStatus> values = <Account_AccountStatus> [
     DISCONNECTED,
     PROCESSING_CONNECTION,
     CLOSING_CONNECTION,
     CONNECTED,
   ];
 
-  static final $core.Map<$core.int, Account_AccountStatus> _byValue =
-      $pb.ProtobufEnum.initByValue(values);
+  static final $core.Map<$core.int, Account_AccountStatus> _byValue = $pb.ProtobufEnum.initByValue(values);
   static Account_AccountStatus valueOf($core.int value) => _byValue[value];
 
   const Account_AccountStatus._($core.int v, $core.String n) : super(v, n);
 }
 
 class Payment_PaymentType extends $pb.ProtobufEnum {
-  static const Payment_PaymentType DEPOSIT =
-      Payment_PaymentType._(0, 'DEPOSIT');
-  static const Payment_PaymentType WITHDRAWAL =
-      Payment_PaymentType._(1, 'WITHDRAWAL');
+  static const Payment_PaymentType DEPOSIT = Payment_PaymentType._(0, 'DEPOSIT');
+  static const Payment_PaymentType WITHDRAWAL = Payment_PaymentType._(1, 'WITHDRAWAL');
   static const Payment_PaymentType SENT = Payment_PaymentType._(2, 'SENT');
-  static const Payment_PaymentType RECEIVED =
-      Payment_PaymentType._(3, 'RECEIVED');
-  static const Payment_PaymentType CLOSED_CHANNEL =
-      Payment_PaymentType._(4, 'CLOSED_CHANNEL');
+  static const Payment_PaymentType RECEIVED = Payment_PaymentType._(3, 'RECEIVED');
+  static const Payment_PaymentType CLOSED_CHANNEL = Payment_PaymentType._(4, 'CLOSED_CHANNEL');
 
-  static const $core.List<Payment_PaymentType> values = <Payment_PaymentType>[
+  static const $core.List<Payment_PaymentType> values = <Payment_PaymentType> [
     DEPOSIT,
     WITHDRAWAL,
     SENT,
@@ -78,55 +64,34 @@ class Payment_PaymentType extends $pb.ProtobufEnum {
     CLOSED_CHANNEL,
   ];
 
-  static final $core.Map<$core.int, Payment_PaymentType> _byValue =
-      $pb.ProtobufEnum.initByValue(values);
+  static final $core.Map<$core.int, Payment_PaymentType> _byValue = $pb.ProtobufEnum.initByValue(values);
   static Payment_PaymentType valueOf($core.int value) => _byValue[value];
 
   const Payment_PaymentType._($core.int v, $core.String n) : super(v, n);
 }
 
 class NotificationEvent_NotificationType extends $pb.ProtobufEnum {
-  static const NotificationEvent_NotificationType READY =
-      NotificationEvent_NotificationType._(0, 'READY');
-  static const NotificationEvent_NotificationType INITIALIZATION_FAILED =
-      NotificationEvent_NotificationType._(1, 'INITIALIZATION_FAILED');
-  static const NotificationEvent_NotificationType ACCOUNT_CHANGED =
-      NotificationEvent_NotificationType._(2, 'ACCOUNT_CHANGED');
-  static const NotificationEvent_NotificationType PAYMENT_SENT =
-      NotificationEvent_NotificationType._(3, 'PAYMENT_SENT');
-  static const NotificationEvent_NotificationType INVOICE_PAID =
-      NotificationEvent_NotificationType._(4, 'INVOICE_PAID');
-  static const NotificationEvent_NotificationType LIGHTNING_SERVICE_DOWN =
-      NotificationEvent_NotificationType._(5, 'LIGHTNING_SERVICE_DOWN');
-  static const NotificationEvent_NotificationType FUND_ADDRESS_CREATED =
-      NotificationEvent_NotificationType._(6, 'FUND_ADDRESS_CREATED');
-  static const NotificationEvent_NotificationType FUND_ADDRESS_UNSPENT_CHANGED =
-      NotificationEvent_NotificationType._(7, 'FUND_ADDRESS_UNSPENT_CHANGED');
-  static const NotificationEvent_NotificationType BACKUP_SUCCESS =
-      NotificationEvent_NotificationType._(8, 'BACKUP_SUCCESS');
-  static const NotificationEvent_NotificationType BACKUP_FAILED =
-      NotificationEvent_NotificationType._(9, 'BACKUP_FAILED');
-  static const NotificationEvent_NotificationType BACKUP_AUTH_FAILED =
-      NotificationEvent_NotificationType._(10, 'BACKUP_AUTH_FAILED');
-  static const NotificationEvent_NotificationType BACKUP_NODE_CONFLICT =
-      NotificationEvent_NotificationType._(11, 'BACKUP_NODE_CONFLICT');
-  static const NotificationEvent_NotificationType BACKUP_REQUEST =
-      NotificationEvent_NotificationType._(12, 'BACKUP_REQUEST');
-  static const NotificationEvent_NotificationType PAYMENT_FAILED =
-      NotificationEvent_NotificationType._(13, 'PAYMENT_FAILED');
-  static const NotificationEvent_NotificationType PAYMENT_SUCCEEDED =
-      NotificationEvent_NotificationType._(14, 'PAYMENT_SUCCEEDED');
-  static const NotificationEvent_NotificationType REVERSE_SWAP_CLAIM_STARTED =
-      NotificationEvent_NotificationType._(15, 'REVERSE_SWAP_CLAIM_STARTED');
-  static const NotificationEvent_NotificationType REVERSE_SWAP_CLAIM_SUCCEEDED =
-      NotificationEvent_NotificationType._(16, 'REVERSE_SWAP_CLAIM_SUCCEEDED');
-  static const NotificationEvent_NotificationType REVERSE_SWAP_CLAIM_FAILED =
-      NotificationEvent_NotificationType._(17, 'REVERSE_SWAP_CLAIM_FAILED');
-  static const NotificationEvent_NotificationType REVERSE_SWAP_CLAIM_CONFIRMED =
-      NotificationEvent_NotificationType._(18, 'REVERSE_SWAP_CLAIM_CONFIRMED');
+  static const NotificationEvent_NotificationType READY = NotificationEvent_NotificationType._(0, 'READY');
+  static const NotificationEvent_NotificationType INITIALIZATION_FAILED = NotificationEvent_NotificationType._(1, 'INITIALIZATION_FAILED');
+  static const NotificationEvent_NotificationType ACCOUNT_CHANGED = NotificationEvent_NotificationType._(2, 'ACCOUNT_CHANGED');
+  static const NotificationEvent_NotificationType PAYMENT_SENT = NotificationEvent_NotificationType._(3, 'PAYMENT_SENT');
+  static const NotificationEvent_NotificationType INVOICE_PAID = NotificationEvent_NotificationType._(4, 'INVOICE_PAID');
+  static const NotificationEvent_NotificationType LIGHTNING_SERVICE_DOWN = NotificationEvent_NotificationType._(5, 'LIGHTNING_SERVICE_DOWN');
+  static const NotificationEvent_NotificationType FUND_ADDRESS_CREATED = NotificationEvent_NotificationType._(6, 'FUND_ADDRESS_CREATED');
+  static const NotificationEvent_NotificationType FUND_ADDRESS_UNSPENT_CHANGED = NotificationEvent_NotificationType._(7, 'FUND_ADDRESS_UNSPENT_CHANGED');
+  static const NotificationEvent_NotificationType BACKUP_SUCCESS = NotificationEvent_NotificationType._(8, 'BACKUP_SUCCESS');
+  static const NotificationEvent_NotificationType BACKUP_FAILED = NotificationEvent_NotificationType._(9, 'BACKUP_FAILED');
+  static const NotificationEvent_NotificationType BACKUP_AUTH_FAILED = NotificationEvent_NotificationType._(10, 'BACKUP_AUTH_FAILED');
+  static const NotificationEvent_NotificationType BACKUP_NODE_CONFLICT = NotificationEvent_NotificationType._(11, 'BACKUP_NODE_CONFLICT');
+  static const NotificationEvent_NotificationType BACKUP_REQUEST = NotificationEvent_NotificationType._(12, 'BACKUP_REQUEST');
+  static const NotificationEvent_NotificationType PAYMENT_FAILED = NotificationEvent_NotificationType._(13, 'PAYMENT_FAILED');
+  static const NotificationEvent_NotificationType PAYMENT_SUCCEEDED = NotificationEvent_NotificationType._(14, 'PAYMENT_SUCCEEDED');
+  static const NotificationEvent_NotificationType REVERSE_SWAP_CLAIM_STARTED = NotificationEvent_NotificationType._(15, 'REVERSE_SWAP_CLAIM_STARTED');
+  static const NotificationEvent_NotificationType REVERSE_SWAP_CLAIM_SUCCEEDED = NotificationEvent_NotificationType._(16, 'REVERSE_SWAP_CLAIM_SUCCEEDED');
+  static const NotificationEvent_NotificationType REVERSE_SWAP_CLAIM_FAILED = NotificationEvent_NotificationType._(17, 'REVERSE_SWAP_CLAIM_FAILED');
+  static const NotificationEvent_NotificationType REVERSE_SWAP_CLAIM_CONFIRMED = NotificationEvent_NotificationType._(18, 'REVERSE_SWAP_CLAIM_CONFIRMED');
 
-  static const $core.List<NotificationEvent_NotificationType> values =
-      <NotificationEvent_NotificationType>[
+  static const $core.List<NotificationEvent_NotificationType> values = <NotificationEvent_NotificationType> [
     READY,
     INITIALIZATION_FAILED,
     ACCOUNT_CHANGED,
@@ -148,11 +113,9 @@ class NotificationEvent_NotificationType extends $pb.ProtobufEnum {
     REVERSE_SWAP_CLAIM_CONFIRMED,
   ];
 
-  static final $core.Map<$core.int, NotificationEvent_NotificationType>
-      _byValue = $pb.ProtobufEnum.initByValue(values);
-  static NotificationEvent_NotificationType valueOf($core.int value) =>
-      _byValue[value];
+  static final $core.Map<$core.int, NotificationEvent_NotificationType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static NotificationEvent_NotificationType valueOf($core.int value) => _byValue[value];
 
-  const NotificationEvent_NotificationType._($core.int v, $core.String n)
-      : super(v, n);
+  const NotificationEvent_NotificationType._($core.int v, $core.String n) : super(v, n);
 }
+

--- a/lib/services/breezlib/data/rpc.pbjson.dart
+++ b/lib/services/breezlib/data/rpc.pbjson.dart
@@ -30,58 +30,15 @@ const Account$json = const {
     const {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
     const {'1': 'balance', '3': 2, '4': 1, '5': 3, '10': 'balance'},
     const {'1': 'walletBalance', '3': 3, '4': 1, '5': 3, '10': 'walletBalance'},
-    const {
-      '1': 'status',
-      '3': 4,
-      '4': 1,
-      '5': 14,
-      '6': '.data.Account.AccountStatus',
-      '10': 'status'
-    },
-    const {
-      '1': 'maxAllowedToReceive',
-      '3': 5,
-      '4': 1,
-      '5': 3,
-      '10': 'maxAllowedToReceive'
-    },
-    const {
-      '1': 'maxAllowedToPay',
-      '3': 6,
-      '4': 1,
-      '5': 3,
-      '10': 'maxAllowedToPay'
-    },
-    const {
-      '1': 'maxPaymentAmount',
-      '3': 7,
-      '4': 1,
-      '5': 3,
-      '10': 'maxPaymentAmount'
-    },
-    const {
-      '1': 'routingNodeFee',
-      '3': 8,
-      '4': 1,
-      '5': 3,
-      '10': 'routingNodeFee'
-    },
+    const {'1': 'status', '3': 4, '4': 1, '5': 14, '6': '.data.Account.AccountStatus', '10': 'status'},
+    const {'1': 'maxAllowedToReceive', '3': 5, '4': 1, '5': 3, '10': 'maxAllowedToReceive'},
+    const {'1': 'maxAllowedToPay', '3': 6, '4': 1, '5': 3, '10': 'maxAllowedToPay'},
+    const {'1': 'maxPaymentAmount', '3': 7, '4': 1, '5': 3, '10': 'maxPaymentAmount'},
+    const {'1': 'routingNodeFee', '3': 8, '4': 1, '5': 3, '10': 'routingNodeFee'},
     const {'1': 'enabled', '3': 9, '4': 1, '5': 8, '10': 'enabled'},
-    const {
-      '1': 'maxChanReserve',
-      '3': 10,
-      '4': 1,
-      '5': 3,
-      '10': 'maxChanReserve'
-    },
+    const {'1': 'maxChanReserve', '3': 10, '4': 1, '5': 3, '10': 'maxChanReserve'},
     const {'1': 'channelPoint', '3': 11, '4': 1, '5': 9, '10': 'channelPoint'},
-    const {
-      '1': 'readyForPayments',
-      '3': 12,
-      '4': 1,
-      '5': 8,
-      '10': 'readyForPayments'
-    },
+    const {'1': 'readyForPayments', '3': 12, '4': 1, '5': 8, '10': 'readyForPayments'},
     const {'1': 'tipHeight', '3': 13, '4': 1, '5': 3, '10': 'tipHeight'},
   ],
   '4': const [Account_AccountStatus$json],
@@ -100,77 +57,21 @@ const Account_AccountStatus$json = const {
 const Payment$json = const {
   '1': 'Payment',
   '2': const [
-    const {
-      '1': 'type',
-      '3': 1,
-      '4': 1,
-      '5': 14,
-      '6': '.data.Payment.PaymentType',
-      '10': 'type'
-    },
+    const {'1': 'type', '3': 1, '4': 1, '5': 14, '6': '.data.Payment.PaymentType', '10': 'type'},
     const {'1': 'amount', '3': 3, '4': 1, '5': 3, '10': 'amount'},
-    const {
-      '1': 'creationTimestamp',
-      '3': 4,
-      '4': 1,
-      '5': 3,
-      '10': 'creationTimestamp'
-    },
-    const {
-      '1': 'invoiceMemo',
-      '3': 6,
-      '4': 1,
-      '5': 11,
-      '6': '.data.InvoiceMemo',
-      '10': 'invoiceMemo'
-    },
+    const {'1': 'creationTimestamp', '3': 4, '4': 1, '5': 3, '10': 'creationTimestamp'},
+    const {'1': 'invoiceMemo', '3': 6, '4': 1, '5': 11, '6': '.data.InvoiceMemo', '10': 'invoiceMemo'},
     const {'1': 'redeemTxID', '3': 7, '4': 1, '5': 9, '10': 'redeemTxID'},
     const {'1': 'paymentHash', '3': 8, '4': 1, '5': 9, '10': 'paymentHash'},
     const {'1': 'destination', '3': 9, '4': 1, '5': 9, '10': 'destination'},
-    const {
-      '1': 'PendingExpirationHeight',
-      '3': 10,
-      '4': 1,
-      '5': 13,
-      '10': 'PendingExpirationHeight'
-    },
-    const {
-      '1': 'PendingExpirationTimestamp',
-      '3': 11,
-      '4': 1,
-      '5': 3,
-      '10': 'PendingExpirationTimestamp'
-    },
+    const {'1': 'PendingExpirationHeight', '3': 10, '4': 1, '5': 13, '10': 'PendingExpirationHeight'},
+    const {'1': 'PendingExpirationTimestamp', '3': 11, '4': 1, '5': 3, '10': 'PendingExpirationTimestamp'},
     const {'1': 'fee', '3': 12, '4': 1, '5': 3, '10': 'fee'},
     const {'1': 'preimage', '3': 13, '4': 1, '5': 9, '10': 'preimage'},
-    const {
-      '1': 'closedChannelPoint',
-      '3': 14,
-      '4': 1,
-      '5': 9,
-      '10': 'closedChannelPoint'
-    },
-    const {
-      '1': 'isChannelPending',
-      '3': 15,
-      '4': 1,
-      '5': 8,
-      '10': 'isChannelPending'
-    },
-    const {
-      '1': 'isChannelCloseConfimed',
-      '3': 16,
-      '4': 1,
-      '5': 8,
-      '10': 'isChannelCloseConfimed'
-    },
-    const {
-      '1': 'closedChannelTxID',
-      '3': 17,
-      '4': 1,
-      '5': 9,
-      '10': 'closedChannelTxID'
-    },
+    const {'1': 'closedChannelPoint', '3': 14, '4': 1, '5': 9, '10': 'closedChannelPoint'},
+    const {'1': 'isChannelPending', '3': 15, '4': 1, '5': 8, '10': 'isChannelPending'},
+    const {'1': 'isChannelCloseConfimed', '3': 16, '4': 1, '5': 8, '10': 'isChannelCloseConfimed'},
+    const {'1': 'closedChannelTxID', '3': 17, '4': 1, '5': 9, '10': 'closedChannelTxID'},
   ],
   '4': const [Payment_PaymentType$json],
 };
@@ -189,14 +90,7 @@ const Payment_PaymentType$json = const {
 const PaymentsList$json = const {
   '1': 'PaymentsList',
   '2': const [
-    const {
-      '1': 'paymentsList',
-      '3': 1,
-      '4': 3,
-      '5': 11,
-      '6': '.data.Payment',
-      '10': 'paymentsList'
-    },
+    const {'1': 'paymentsList', '3': 1, '4': 3, '5': 11, '6': '.data.Payment', '10': 'paymentsList'},
   ],
 };
 
@@ -220,13 +114,16 @@ const PayInvoiceRequest$json = const {
   '1': 'PayInvoiceRequest',
   '2': const [
     const {'1': 'amount', '3': 1, '4': 1, '5': 3, '10': 'amount'},
-    const {
-      '1': 'paymentRequest',
-      '3': 2,
-      '4': 1,
-      '5': 9,
-      '10': 'paymentRequest'
-    },
+    const {'1': 'paymentRequest', '3': 2, '4': 1, '5': 9, '10': 'paymentRequest'},
+  ],
+};
+
+const SpontaneousPaymentRequest$json = const {
+  '1': 'SpontaneousPaymentRequest',
+  '2': const [
+    const {'1': 'amount', '3': 1, '4': 1, '5': 3, '10': 'amount'},
+    const {'1': 'destNode', '3': 2, '4': 1, '5': 9, '10': 'destNode'},
+    const {'1': 'description', '3': 3, '4': 1, '5': 9, '10': 'description'},
   ],
 };
 
@@ -239,13 +136,7 @@ const InvoiceMemo$json = const {
     const {'1': 'payeeImageURL', '3': 4, '4': 1, '5': 9, '10': 'payeeImageURL'},
     const {'1': 'payerName', '3': 5, '4': 1, '5': 9, '10': 'payerName'},
     const {'1': 'payerImageURL', '3': 6, '4': 1, '5': 9, '10': 'payerImageURL'},
-    const {
-      '1': 'transferRequest',
-      '3': 7,
-      '4': 1,
-      '5': 8,
-      '10': 'transferRequest'
-    },
+    const {'1': 'transferRequest', '3': 7, '4': 1, '5': 8, '10': 'transferRequest'},
     const {'1': 'expiry', '3': 8, '4': 1, '5': 3, '10': 'expiry'},
   ],
 };
@@ -253,14 +144,7 @@ const InvoiceMemo$json = const {
 const Invoice$json = const {
   '1': 'Invoice',
   '2': const [
-    const {
-      '1': 'memo',
-      '3': 1,
-      '4': 1,
-      '5': 11,
-      '6': '.data.InvoiceMemo',
-      '10': 'memo'
-    },
+    const {'1': 'memo', '3': 1, '4': 1, '5': 11, '6': '.data.InvoiceMemo', '10': 'memo'},
     const {'1': 'settled', '3': 2, '4': 1, '5': 8, '10': 'settled'},
     const {'1': 'amtPaid', '3': 3, '4': 1, '5': 3, '10': 'amtPaid'},
   ],
@@ -269,14 +153,7 @@ const Invoice$json = const {
 const NotificationEvent$json = const {
   '1': 'NotificationEvent',
   '2': const [
-    const {
-      '1': 'type',
-      '3': 1,
-      '4': 1,
-      '5': 14,
-      '6': '.data.NotificationEvent.NotificationType',
-      '10': 'type'
-    },
+    const {'1': 'type', '3': 1, '4': 1, '5': 14, '6': '.data.NotificationEvent.NotificationType', '10': 'type'},
     const {'1': 'data', '3': 2, '4': 3, '5': 9, '10': 'data'},
   ],
   '4': const [NotificationEvent_NotificationType$json],
@@ -311,22 +188,10 @@ const AddFundInitReply$json = const {
   '1': 'AddFundInitReply',
   '2': const [
     const {'1': 'address', '3': 1, '4': 1, '5': 9, '10': 'address'},
-    const {
-      '1': 'maxAllowedDeposit',
-      '3': 2,
-      '4': 1,
-      '5': 3,
-      '10': 'maxAllowedDeposit'
-    },
+    const {'1': 'maxAllowedDeposit', '3': 2, '4': 1, '5': 3, '10': 'maxAllowedDeposit'},
     const {'1': 'errorMessage', '3': 3, '4': 1, '5': 9, '10': 'errorMessage'},
     const {'1': 'backupJson', '3': 4, '4': 1, '5': 9, '10': 'backupJson'},
-    const {
-      '1': 'requiredReserve',
-      '3': 5,
-      '4': 1,
-      '5': 3,
-      '10': 'requiredReserve'
-    },
+    const {'1': 'requiredReserve', '3': 5, '4': 1, '5': 3, '10': 'requiredReserve'},
   ],
 };
 
@@ -350,14 +215,7 @@ const RefundRequest$json = const {
 const AddFundError$json = const {
   '1': 'AddFundError',
   '2': const [
-    const {
-      '1': 'swapAddressInfo',
-      '3': 1,
-      '4': 1,
-      '5': 11,
-      '6': '.data.SwapAddressInfo',
-      '10': 'swapAddressInfo'
-    },
+    const {'1': 'swapAddressInfo', '3': 1, '4': 1, '5': 11, '6': '.data.SwapAddressInfo', '10': 'swapAddressInfo'},
     const {'1': 'hoursToUnlock', '3': 2, '4': 1, '5': 2, '10': 'hoursToUnlock'},
   ],
 };
@@ -365,30 +223,9 @@ const AddFundError$json = const {
 const FundStatusReply$json = const {
   '1': 'FundStatusReply',
   '2': const [
-    const {
-      '1': 'unConfirmedAddresses',
-      '3': 1,
-      '4': 3,
-      '5': 11,
-      '6': '.data.SwapAddressInfo',
-      '10': 'unConfirmedAddresses'
-    },
-    const {
-      '1': 'confirmedAddresses',
-      '3': 2,
-      '4': 3,
-      '5': 11,
-      '6': '.data.SwapAddressInfo',
-      '10': 'confirmedAddresses'
-    },
-    const {
-      '1': 'refundableAddresses',
-      '3': 3,
-      '4': 3,
-      '5': 11,
-      '6': '.data.SwapAddressInfo',
-      '10': 'refundableAddresses'
-    },
+    const {'1': 'unConfirmedAddresses', '3': 1, '4': 3, '5': 11, '6': '.data.SwapAddressInfo', '10': 'unConfirmedAddresses'},
+    const {'1': 'confirmedAddresses', '3': 2, '4': 3, '5': 11, '6': '.data.SwapAddressInfo', '10': 'confirmedAddresses'},
+    const {'1': 'refundableAddresses', '3': 3, '4': 3, '5': 11, '6': '.data.SwapAddressInfo', '10': 'refundableAddresses'},
   ],
 };
 
@@ -413,60 +250,22 @@ const SwapAddressInfo$json = const {
   '2': const [
     const {'1': 'address', '3': 1, '4': 1, '5': 9, '10': 'address'},
     const {'1': 'PaymentHash', '3': 2, '4': 1, '5': 9, '10': 'PaymentHash'},
-    const {
-      '1': 'ConfirmedAmount',
-      '3': 3,
-      '4': 1,
-      '5': 3,
-      '10': 'ConfirmedAmount'
-    },
-    const {
-      '1': 'ConfirmedTransactionIds',
-      '3': 4,
-      '4': 3,
-      '5': 9,
-      '10': 'ConfirmedTransactionIds'
-    },
+    const {'1': 'ConfirmedAmount', '3': 3, '4': 1, '5': 3, '10': 'ConfirmedAmount'},
+    const {'1': 'ConfirmedTransactionIds', '3': 4, '4': 3, '5': 9, '10': 'ConfirmedTransactionIds'},
     const {'1': 'PaidAmount', '3': 5, '4': 1, '5': 3, '10': 'PaidAmount'},
     const {'1': 'lockHeight', '3': 6, '4': 1, '5': 13, '10': 'lockHeight'},
     const {'1': 'errorMessage', '3': 7, '4': 1, '5': 9, '10': 'errorMessage'},
-    const {
-      '1': 'lastRefundTxID',
-      '3': 8,
-      '4': 1,
-      '5': 9,
-      '10': 'lastRefundTxID'
-    },
-    const {
-      '1': 'swapError',
-      '3': 9,
-      '4': 1,
-      '5': 14,
-      '6': '.data.SwapError',
-      '10': 'swapError'
-    },
+    const {'1': 'lastRefundTxID', '3': 8, '4': 1, '5': 9, '10': 'lastRefundTxID'},
+    const {'1': 'swapError', '3': 9, '4': 1, '5': 14, '6': '.data.SwapError', '10': 'swapError'},
     const {'1': 'FundingTxID', '3': 10, '4': 1, '5': 9, '10': 'FundingTxID'},
-    const {
-      '1': 'hoursToUnlock',
-      '3': 11,
-      '4': 1,
-      '5': 2,
-      '10': 'hoursToUnlock'
-    },
+    const {'1': 'hoursToUnlock', '3': 11, '4': 1, '5': 2, '10': 'hoursToUnlock'},
   ],
 };
 
 const SwapAddressList$json = const {
   '1': 'SwapAddressList',
   '2': const [
-    const {
-      '1': 'addresses',
-      '3': 1,
-      '4': 3,
-      '5': 11,
-      '6': '.data.SwapAddressInfo',
-      '10': 'addresses'
-    },
+    const {'1': 'addresses', '3': 1, '4': 3, '5': 11, '6': '.data.SwapAddressInfo', '10': 'addresses'},
   ],
 };
 
@@ -518,13 +317,7 @@ const RatchetDecryptRequest$json = const {
   '1': 'RatchetDecryptRequest',
   '2': const [
     const {'1': 'sessionID', '3': 1, '4': 1, '5': 9, '10': 'sessionID'},
-    const {
-      '1': 'encryptedMessage',
-      '3': 2,
-      '4': 1,
-      '5': 9,
-      '10': 'encryptedMessage'
-    },
+    const {'1': 'encryptedMessage', '3': 2, '4': 1, '5': 9, '10': 'encryptedMessage'},
   ],
 };
 
@@ -564,14 +357,7 @@ const rate$json = const {
 const Rates$json = const {
   '1': 'Rates',
   '2': const [
-    const {
-      '1': 'rates',
-      '3': 1,
-      '4': 3,
-      '5': 11,
-      '6': '.data.rate',
-      '10': 'rates'
-    },
+    const {'1': 'rates', '3': 1, '4': 3, '5': 11, '6': '.data.rate', '10': 'rates'},
   ],
 };
 
@@ -582,23 +368,11 @@ const LSPInformation$json = const {
     const {'1': 'widget_url', '3': 2, '4': 1, '5': 9, '10': 'widgetUrl'},
     const {'1': 'pubkey', '3': 3, '4': 1, '5': 9, '10': 'pubkey'},
     const {'1': 'host', '3': 4, '4': 1, '5': 9, '10': 'host'},
-    const {
-      '1': 'channel_capacity',
-      '3': 5,
-      '4': 1,
-      '5': 3,
-      '10': 'channelCapacity'
-    },
+    const {'1': 'channel_capacity', '3': 5, '4': 1, '5': 3, '10': 'channelCapacity'},
     const {'1': 'target_conf', '3': 6, '4': 1, '5': 5, '10': 'targetConf'},
     const {'1': 'base_fee_msat', '3': 7, '4': 1, '5': 3, '10': 'baseFeeMsat'},
     const {'1': 'fee_rate', '3': 8, '4': 1, '5': 1, '10': 'feeRate'},
-    const {
-      '1': 'time_lock_delta',
-      '3': 9,
-      '4': 1,
-      '5': 13,
-      '10': 'timeLockDelta'
-    },
+    const {'1': 'time_lock_delta', '3': 9, '4': 1, '5': 13, '10': 'timeLockDelta'},
     const {'1': 'min_htlc_msat', '3': 10, '4': 1, '5': 3, '10': 'minHtlcMsat'},
   ],
 };
@@ -606,14 +380,7 @@ const LSPInformation$json = const {
 const LSPList$json = const {
   '1': 'LSPList',
   '2': const [
-    const {
-      '1': 'lsps',
-      '3': 1,
-      '4': 3,
-      '5': 11,
-      '6': '.data.LSPList.LspsEntry',
-      '10': 'lsps'
-    },
+    const {'1': 'lsps', '3': 1, '4': 3, '5': 11, '6': '.data.LSPList.LspsEntry', '10': 'lsps'},
   ],
   '3': const [LSPList_LspsEntry$json],
 };
@@ -622,14 +389,7 @@ const LSPList_LspsEntry$json = const {
   '1': 'LspsEntry',
   '2': const [
     const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {
-      '1': 'value',
-      '3': 2,
-      '4': 1,
-      '5': 11,
-      '6': '.data.LSPInformation',
-      '10': 'value'
-    },
+    const {'1': 'value', '3': 2, '4': 1, '5': 11, '6': '.data.LSPInformation', '10': 'value'},
   ],
   '7': const {'7': true},
 };
@@ -637,24 +397,8 @@ const LSPList_LspsEntry$json = const {
 const LNUrlResponse$json = const {
   '1': 'LNUrlResponse',
   '2': const [
-    const {
-      '1': 'withdraw',
-      '3': 1,
-      '4': 1,
-      '5': 11,
-      '6': '.data.LNUrlWithdraw',
-      '9': 0,
-      '10': 'withdraw'
-    },
-    const {
-      '1': 'channel',
-      '3': 2,
-      '4': 1,
-      '5': 11,
-      '6': '.data.LNURLChannel',
-      '9': 0,
-      '10': 'channel'
-    },
+    const {'1': 'withdraw', '3': 1, '4': 1, '5': 11, '6': '.data.LNUrlWithdraw', '9': 0, '10': 'withdraw'},
+    const {'1': 'channel', '3': 2, '4': 1, '5': 11, '6': '.data.LNURLChannel', '9': 0, '10': 'channel'},
   ],
   '8': const [
     const {'1': 'action'},
@@ -666,13 +410,7 @@ const LNUrlWithdraw$json = const {
   '2': const [
     const {'1': 'min_amount', '3': 1, '4': 1, '5': 3, '10': 'minAmount'},
     const {'1': 'max_amount', '3': 2, '4': 1, '5': 3, '10': 'maxAmount'},
-    const {
-      '1': 'default_description',
-      '3': 3,
-      '4': 1,
-      '5': 9,
-      '10': 'defaultDescription'
-    },
+    const {'1': 'default_description', '3': 3, '4': 1, '5': 9, '10': 'defaultDescription'},
   ],
 };
 
@@ -699,38 +437,14 @@ const ReverseSwap$json = const {
     const {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
     const {'1': 'invoice', '3': 2, '4': 1, '5': 9, '10': 'invoice'},
     const {'1': 'script', '3': 3, '4': 1, '5': 9, '10': 'script'},
-    const {
-      '1': 'lockup_address',
-      '3': 4,
-      '4': 1,
-      '5': 9,
-      '10': 'lockupAddress'
-    },
+    const {'1': 'lockup_address', '3': 4, '4': 1, '5': 9, '10': 'lockupAddress'},
     const {'1': 'preimage', '3': 5, '4': 1, '5': 9, '10': 'preimage'},
     const {'1': 'key', '3': 6, '4': 1, '5': 9, '10': 'key'},
     const {'1': 'claim_address', '3': 7, '4': 1, '5': 9, '10': 'claimAddress'},
     const {'1': 'ln_amount', '3': 8, '4': 1, '5': 3, '10': 'lnAmount'},
-    const {
-      '1': 'onchain_amount',
-      '3': 9,
-      '4': 1,
-      '5': 3,
-      '10': 'onchainAmount'
-    },
-    const {
-      '1': 'timeout_block_height',
-      '3': 10,
-      '4': 1,
-      '5': 3,
-      '10': 'timeoutBlockHeight'
-    },
-    const {
-      '1': 'start_block_height',
-      '3': 11,
-      '4': 1,
-      '5': 3,
-      '10': 'startBlockHeight'
-    },
+    const {'1': 'onchain_amount', '3': 9, '4': 1, '5': 3, '10': 'onchainAmount'},
+    const {'1': 'timeout_block_height', '3': 10, '4': 1, '5': 3, '10': 'timeoutBlockHeight'},
+    const {'1': 'start_block_height', '3': 11, '4': 1, '5': 3, '10': 'startBlockHeight'},
     const {'1': 'claim_fee', '3': 12, '4': 1, '5': 3, '10': 'claimFee'},
     const {'1': 'claim_txid', '3': 13, '4': 1, '5': 9, '10': 'claimTxid'},
   ],
@@ -750,14 +464,7 @@ const ReverseSwapInfo$json = const {
   '2': const [
     const {'1': 'min', '3': 1, '4': 1, '5': 3, '10': 'min'},
     const {'1': 'max', '3': 2, '4': 1, '5': 3, '10': 'max'},
-    const {
-      '1': 'fees',
-      '3': 3,
-      '4': 1,
-      '5': 11,
-      '6': '.data.ReverseSwapFees',
-      '10': 'fees'
-    },
+    const {'1': 'fees', '3': 3, '4': 1, '5': 11, '6': '.data.ReverseSwapFees', '10': 'fees'},
   ],
 };
 
@@ -765,14 +472,7 @@ const ReverseSwapPaymentRequest$json = const {
   '1': 'ReverseSwapPaymentRequest',
   '2': const [
     const {'1': 'hash', '3': 1, '4': 1, '5': 9, '10': 'hash'},
-    const {
-      '1': 'push_notification_details',
-      '3': 2,
-      '4': 1,
-      '5': 11,
-      '6': '.data.PushNotificationDetails',
-      '10': 'pushNotificationDetails'
-    },
+    const {'1': 'push_notification_details', '3': 2, '4': 1, '5': 11, '6': '.data.PushNotificationDetails', '10': 'pushNotificationDetails'},
   ],
 };
 
@@ -796,14 +496,7 @@ const ReverseSwapPaymentStatus$json = const {
 const ReverseSwapPaymentStatuses$json = const {
   '1': 'ReverseSwapPaymentStatuses',
   '2': const [
-    const {
-      '1': 'payments_status',
-      '3': 1,
-      '4': 3,
-      '5': 11,
-      '6': '.data.ReverseSwapPaymentStatus',
-      '10': 'paymentsStatus'
-    },
+    const {'1': 'payments_status', '3': 1, '4': 3, '5': 11, '6': '.data.ReverseSwapPaymentStatus', '10': 'paymentsStatus'},
   ],
 };
 
@@ -818,14 +511,7 @@ const ReverseSwapClaimFee$json = const {
 const ClaimFeeEstimates$json = const {
   '1': 'ClaimFeeEstimates',
   '2': const [
-    const {
-      '1': 'fees',
-      '3': 1,
-      '4': 3,
-      '5': 11,
-      '6': '.data.ClaimFeeEstimates.FeesEntry',
-      '10': 'fees'
-    },
+    const {'1': 'fees', '3': 1, '4': 3, '5': 11, '6': '.data.ClaimFeeEstimates.FeesEntry', '10': 'fees'},
   ],
   '3': const [ClaimFeeEstimates_FeesEntry$json],
 };
@@ -861,14 +547,7 @@ const SweepAllCoinsTransactions$json = const {
   '1': 'SweepAllCoinsTransactions',
   '2': const [
     const {'1': 'amt', '3': 1, '4': 1, '5': 3, '10': 'amt'},
-    const {
-      '1': 'transactions',
-      '3': 2,
-      '4': 3,
-      '5': 11,
-      '6': '.data.SweepAllCoinsTransactions.TransactionsEntry',
-      '10': 'transactions'
-    },
+    const {'1': 'transactions', '3': 2, '4': 3, '5': 11, '6': '.data.SweepAllCoinsTransactions.TransactionsEntry', '10': 'transactions'},
   ],
   '3': const [SweepAllCoinsTransactions_TransactionsEntry$json],
 };
@@ -877,14 +556,8 @@ const SweepAllCoinsTransactions_TransactionsEntry$json = const {
   '1': 'TransactionsEntry',
   '2': const [
     const {'1': 'key', '3': 1, '4': 1, '5': 5, '10': 'key'},
-    const {
-      '1': 'value',
-      '3': 2,
-      '4': 1,
-      '5': 11,
-      '6': '.data.TransactionDetails',
-      '10': 'value'
-    },
+    const {'1': 'value', '3': 2, '4': 1, '5': 11, '6': '.data.TransactionDetails', '10': 'value'},
   ],
   '7': const {'7': true},
 };
+

--- a/lib/utils/node_id.dart
+++ b/lib/utils/node_id.dart
@@ -1,0 +1,4 @@
+
+bool isValidNodeId(String nodeId) {
+  return nodeId?.length == 66;
+}

--- a/lib/widgets/collapsible_list_item.dart
+++ b/lib/widgets/collapsible_list_item.dart
@@ -1,0 +1,112 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:breez/services/injector.dart';
+import 'package:flutter/material.dart';
+import 'package:share_extend/share_extend.dart';
+
+import 'flushbar.dart';
+
+class CollapsibleListItem extends StatelessWidget {
+  final String title;
+  final String sharedValue;
+  final AutoSizeGroup labelGroup;
+  final Color color;
+
+  const CollapsibleListItem(
+      {Key key, this.title, this.sharedValue, this.labelGroup, this.color})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    TextStyle userStyle = TextStyle(color: this.color);
+    return ListTileTheme(
+      contentPadding: EdgeInsets.zero,
+      textColor: this.color,
+      iconColor: this.color,
+      child: Theme(
+        data: ThemeData(
+          dividerColor: Colors.transparent,
+          unselectedWidgetColor: color,
+          accentColor: color
+        ),
+        child: ExpansionTile(
+            title: AutoSizeText(
+              title,
+              style:
+                  Theme.of(context).primaryTextTheme.headline4.merge(userStyle),
+              maxLines: 1,
+              group: labelGroup,
+            ),
+            children: [
+              Row(
+                mainAxisSize: MainAxisSize.max,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Expanded(
+                    child: Padding(
+                      padding: EdgeInsets.only(left: 16.0, right: 0.0),
+                      child: Text('$sharedValue',
+                          textAlign: TextAlign.left,
+                          overflow: TextOverflow.clip,
+                          maxLines: 4,
+                          style: Theme.of(context)
+                              .primaryTextTheme
+                              .headline3
+                              .copyWith(fontSize: 10)
+                              .merge(userStyle)),
+                    ),
+                  ),
+                  Expanded(
+                    flex: 0,
+                    child: Padding(
+                        padding: EdgeInsets.zero,
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          children: <Widget>[
+                            IconButton(
+                              alignment: Alignment.centerRight,
+                              padding: EdgeInsets.only(right: 8.0),
+                              tooltip: "Copy $title",
+                              iconSize: 16.0,
+                              color: this.color ??
+                                  Theme.of(context)
+                                      .primaryTextTheme
+                                      .button
+                                      .color,
+                              icon: Icon(
+                                IconData(0xe90b, fontFamily: 'icomoon'),
+                              ),
+                              onPressed: () {
+                                ServiceInjector()
+                                    .device
+                                    .setClipboardText(sharedValue);
+                                Navigator.pop(context);
+                                showFlushbar(context,
+                                    message:
+                                        "$title was copied to your clipboard.",
+                                    duration: Duration(seconds: 4));
+                              },
+                            ),
+                            IconButton(
+                              padding: EdgeInsets.only(right: 8.0),
+                              iconSize: 16.0,
+                              color: this.color ??
+                                  Theme.of(context)
+                                      .primaryTextTheme
+                                      .button
+                                      .color,
+                              icon: Icon(Icons.share),
+                              onPressed: () {
+                                ShareExtend.share(sharedValue, "text");
+                              },
+                            ),
+                          ],
+                        )),
+                  ),
+                ],
+              )
+            ]),
+      ),
+    );
+  }
+}

--- a/lib/widgets/payment_request_dialog.dart
+++ b/lib/widgets/payment_request_dialog.dart
@@ -76,10 +76,9 @@ class PaymentRequestDialogState extends State<PaymentRequestDialog> {
     if (_state == PaymentRequestState.PROCESSING_PAYMENT) {
       return ProcessingPaymentDialog(
           widget.context,
-          widget.invoice,
+          widget.invoice.paymentHash,
           widget.accountBloc,
           widget.firstPaymentItemKey,
-          widget.scrollController,
           _initialDialogSize,
           _onStateChange);
     } else if (_state == PaymentRequestState.WAITING_FOR_CONFIRMATION) {


### PR DESCRIPTION
This PR allows a user to send spontaneous payments to those nodes that are configured to accept such payments.
Spontaneous payments do not require a payment request and only a node ID is needed.
Breez detects automatically the node id in the clipboard and user can paste it via the bottom sheet (of Send action) or the left menu.
Once pasted the "Spontaneous Payment" view is shown.