### PR TITLE
Add fiat value instead of balance

### DIFF
--- a/lib/routes/home/account_page.dart
+++ b/lib/routes/home/account_page.dart
@@ -240,7 +240,7 @@ class WalletDashboardHeaderDelegate extends SliverPersistentHeaderDelegate {
 
                 return Stack(overflow: Overflow.visible, children: <Widget>[
                   WalletDashboard(settingSnapshot.data, snapshot.data, height,
-                      heightFactor, _userProfileBloc.currencySink.add)
+                      heightFactor, _userProfileBloc.currencySink.add, _userProfileBloc.fiatConversionSink.add)
                 ]);
               });
         });

--- a/lib/routes/home/wallet_dashboard.dart
+++ b/lib/routes/home/wallet_dashboard.dart
@@ -69,37 +69,6 @@ class WalletDashboardState extends State<WalletDashboard> {
                   child: StatusIndicator(context, widget._accountModel))
               : SizedBox(),
           Positioned(
-              top: 70 - BALANCE_OFFSET_TRANSITION * widget._offsetFactor,
-              child: Center(
-                child: widget._accountModel != null &&
-                        !widget._accountModel.initial &&
-                        (widget._accountModel.fiatConversionList.isNotEmpty ||
-                            widget._accountModel.fiatCurrency != null) &&
-                        isAboveMinAmount(widget._accountModel.fiatCurrency)
-                    ? FlatButton(
-                        onPressed: () {
-                          var nextFiatCurrencyIndex = widget
-                                  ._accountModel.fiatConversionList
-                                  .indexOf(widget._accountModel.fiatCurrency) +
-                              1;
-                          findNextValidFiatConversion(nextFiatCurrencyIndex %
-                              widget._accountModel.fiatConversionList.length);
-                        },
-                        child: Text(
-                            "${widget._accountModel.formattedFiatBalance}",
-                            style: Theme.of(context)
-                                .textTheme
-                                .subtitle2
-                                .copyWith(
-                                    color: Theme.of(context)
-                                        .textTheme
-                                        .subtitle2
-                                        .color
-                                        .withOpacity(pow(
-                                            0.95 - widget._offsetFactor, 8)))))
-                    : SizedBox(),
-              )),
-          Positioned(
             top: 30 - BALANCE_OFFSET_TRANSITION * widget._offsetFactor,
             child: Center(
               child: widget._accountModel != null &&
@@ -133,7 +102,38 @@ class WalletDashboardState extends State<WalletDashboard> {
                                               widget._offsetFactor)))
                   : SizedBox(),
             ),
-          )
+          ),
+          Positioned(
+              top: 70 - BALANCE_OFFSET_TRANSITION * widget._offsetFactor,
+              child: Center(
+                child: widget._accountModel != null &&
+                        !widget._accountModel.initial &&
+                        (widget._accountModel.fiatConversionList.isNotEmpty ||
+                            widget._accountModel.fiatCurrency != null) &&
+                        isAboveMinAmount(widget._accountModel.fiatCurrency)
+                    ? FlatButton(
+                        onPressed: () {
+                          var nextFiatCurrencyIndex = widget
+                                  ._accountModel.fiatConversionList
+                                  .indexOf(widget._accountModel.fiatCurrency) +
+                              1;
+                          findNextValidFiatConversion(nextFiatCurrencyIndex %
+                              widget._accountModel.fiatConversionList.length);
+                        },
+                        child: Text(
+                            "${widget._accountModel.formattedFiatBalance}",
+                            style: Theme.of(context)
+                                .textTheme
+                                .subtitle2
+                                .copyWith(
+                                    color: Theme.of(context)
+                                        .textTheme
+                                        .subtitle2
+                                        .color
+                                        .withOpacity(pow(
+                                            0.95 - widget._offsetFactor, 8)))))
+                    : SizedBox(),
+              )),
         ],
       ),
       behavior: HitTestBehavior.translucent,

--- a/lib/routes/home/wallet_dashboard.dart
+++ b/lib/routes/home/wallet_dashboard.dart
@@ -150,14 +150,15 @@ class WalletDashboardState extends State<WalletDashboard> {
     );
   }
 
-  void findNextValidFiatConversion(int nextIndex) {
+  void findNextValidFiatConversion(int nextIndex, {int retries = 0}) {
     var nextFiatConversion =
         widget._accountModel.fiatConversionList.elementAt(nextIndex);
     if (isAboveMinAmount(nextFiatConversion)) {
       widget._onFiatCurrencyChange(nextFiatConversion.currencyData.shortName);
-    } else {
+    } else if (retries < widget._accountModel.fiatConversionList.length * 5) {
       findNextValidFiatConversion(
-          (nextIndex + 1) % widget._accountModel.fiatConversionList.length);
+          (nextIndex + 1) % widget._accountModel.fiatConversionList.length,
+          retries: retries++);
     }
   }
 

--- a/lib/routes/home/wallet_dashboard.dart
+++ b/lib/routes/home/wallet_dashboard.dart
@@ -108,9 +108,7 @@ class WalletDashboardState extends State<WalletDashboard> {
               child: Center(
                 child: widget._accountModel != null &&
                         !widget._accountModel.initial &&
-                        (widget._accountModel.fiatConversionList.isNotEmpty ||
-                            widget._accountModel.fiatCurrency != null) &&
-                        isAboveMinAmount(widget._accountModel.fiatCurrency)
+                        isAboveMinAmount(widget._accountModel?.fiatCurrency)
                     ? FlatButton(
                         onPressed: () {
                           var newFiatConversion = nextValidFiatConversion();

--- a/lib/routes/home/wallet_dashboard.dart
+++ b/lib/routes/home/wallet_dashboard.dart
@@ -155,7 +155,7 @@ class WalletDashboardState extends State<WalletDashboard> {
         widget._accountModel.fiatConversionList.elementAt(nextIndex);
     if (isAboveMinAmount(nextFiatConversion)) {
       widget._onFiatCurrencyChange(nextFiatConversion.currencyData.shortName);
-    } else if (retries < widget._accountModel.fiatConversionList.length * 5) {
+    } else if (retries < widget._accountModel.fiatConversionList.length) {
       findNextValidFiatConversion(
           (nextIndex + 1) % widget._accountModel.fiatConversionList.length,
           retries: retries++);

--- a/lib/routes/home/wallet_dashboard.dart
+++ b/lib/routes/home/wallet_dashboard.dart
@@ -113,12 +113,10 @@ class WalletDashboardState extends State<WalletDashboard> {
                         isAboveMinAmount(widget._accountModel.fiatCurrency)
                     ? FlatButton(
                         onPressed: () {
-                          var nextFiatCurrencyIndex = widget
-                                  ._accountModel.fiatConversionList
-                                  .indexOf(widget._accountModel.fiatCurrency) +
-                              1;
-                          findNextValidFiatConversion(nextFiatCurrencyIndex %
-                              widget._accountModel.fiatConversionList.length);
+                          var newFiatConversion = nextValidFiatConversion();
+                          if (newFiatConversion != null)
+                            widget._onFiatCurrencyChange(
+                                newFiatConversion.currencyData.shortName);
                         },
                         child: Text(
                             "${widget._accountModel.formattedFiatBalance}",
@@ -150,16 +148,18 @@ class WalletDashboardState extends State<WalletDashboard> {
     );
   }
 
-  void findNextValidFiatConversion(int nextIndex, {int retries = 0}) {
-    var nextFiatConversion =
-        widget._accountModel.fiatConversionList.elementAt(nextIndex);
-    if (isAboveMinAmount(nextFiatConversion)) {
-      widget._onFiatCurrencyChange(nextFiatConversion.currencyData.shortName);
-    } else if (retries < widget._accountModel.fiatConversionList.length) {
-      findNextValidFiatConversion(
-          (nextIndex + 1) % widget._accountModel.fiatConversionList.length,
-          retries: retries++);
+  FiatConversion nextValidFiatConversion() {
+    var currentIndex = widget._accountModel.fiatConversionList
+        .indexOf(widget._accountModel.fiatCurrency);
+    for (var i = 1; i < widget._accountModel.fiatConversionList.length; i++) {
+      var nextIndex =
+          (i + currentIndex) % widget._accountModel.fiatConversionList.length;
+      if (isAboveMinAmount(
+          widget._accountModel.fiatConversionList[nextIndex])) {
+        return widget._accountModel.fiatConversionList[nextIndex];
+      }
     }
+    return null;
   }
 
   bool isAboveMinAmount(FiatConversion fiatConversion) {


### PR DESCRIPTION
This PR addresses [BU-228](https://breeztech.atlassian.net/browse/BU-228).

- Balance title is removed from wallet dashboard.
- Fiat equivalent of balance is shown under balance and users can switch between fiat currencies by clicking on this field.
- This field is only shown if the amount is bigger than minimal value, e.g. "< $0.01"
- Clicking on the fiat value will look up the next fiat currency that's above minimal value.