### PR TITLE
Use cross-platform plugin for nfc stream

### DIFF
--- a/android/app/src/main/java/com/breez/client/NfcHandler.java
+++ b/android/app/src/main/java/com/breez/client/NfcHandler.java
@@ -77,6 +77,15 @@ public class NfcHandler implements MethodChannel.MethodCallHandler, NfcAdapter.R
                 result.success(false);
             }
         }
+        if (call.method.equals("checkIfStartedWithNfc")) {
+            Log.d(TAG, "Called: checkIfStartedWithNfc");
+            try {
+                String nfcStartedWith = getNfcStartedWith(m_mainActivity.getIntent());
+                result.success(nfcStartedWith);
+            } catch (Exception e) {
+                result.success("false");
+            }
+        }
 
     }
 
@@ -291,6 +300,42 @@ public class NfcHandler implements MethodChannel.MethodCallHandler, NfcAdapter.R
         } else {
             m_mainActivity.startActivity(new Intent(android.provider.Settings.ACTION_WIRELESS_SETTINGS));
         }
+    }
+
+    protected String getNfcStartedWith(Intent intent) {
+        /* Handle these cases individually:
+         * NfcAdapter.ACTION_TECH_DISCOVERED
+         * NfcAdapter.ACTION_TAG_DISCOVERED
+         * NfcAdapter.ACTION_NDEF_DISCOVERED
+         */
+        Log.d(TAG, "Discovered an NDEF tag...");
+        Parcelable[] rawMessages = intent.getParcelableArrayExtra(NfcAdapter.EXTRA_NDEF_MESSAGES);
+        if (rawMessages != null) {
+            Log.d(TAG, "Discovered raw messages...");
+            NdefMessage[] messages = new NdefMessage[rawMessages.length];
+            for (int i = 0; i < rawMessages.length; i++) {
+                messages[i] = (NdefMessage) rawMessages[i];
+            }
+            try {
+                byte[] payload = messages[0].getRecords()[0].getPayload();
+                //Get the Text Encoding
+                String textEncoding = ((payload[0] & 0200) == 0) ? "UTF-8" : "UTF-16";
+                //Get the Language Code
+                int languageCodeLength = payload[0] & 0077;
+                String languageCode = new String(payload, 1, languageCodeLength, "US-ASCII");
+                //Get the Text
+                String lnLink = new String(payload, languageCodeLength + 1, payload.length - languageCodeLength - 1, textEncoding);
+                if (lnLink != null && lnLink.startsWith("lightning:")) {
+                    Log.d(TAG, "Discovered Lightning Link...");
+                    return lnLink;
+                }
+            } catch (UnsupportedEncodingException exc) {
+                Log.e(TAG, "Error", exc);
+                return "";
+            }
+        }
+
+        return "";
     }
 
     void logError(String str, String str2) {

--- a/lib/services/nfc.dart
+++ b/lib/services/nfc.dart
@@ -90,6 +90,7 @@ class NFCService {
   }
 
   NFCService() {
+    /*
     int fnCalls = 0;
     _checkNfcStartedWithTimer =
         Timer.periodic(Duration(milliseconds: 100), (Timer t) {
@@ -100,6 +101,7 @@ class NFCService {
       fnCalls++;
       _checkNfcStartedWith();
     });
+    */
     _listenLnLinks();
     _platform.setMethodCallHandler((MethodCall call) {
       if (call.method == 'receivedBreezId') {

--- a/lib/services/nfc.dart
+++ b/lib/services/nfc.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 
 import 'package:breez/logger.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_nfc_plugin/models/nfc_event.dart';
-import 'package:flutter_nfc_plugin/nfc_plugin.dart';
+import 'package:nfc_in_flutter/nfc_in_flutter.dart';
 
 class NFCService {
   static const _platform = MethodChannel('com.breez.client/nfc');
@@ -91,7 +90,6 @@ class NFCService {
   }
 
   NFCService() {
-    NfcPlugin nfcPlugin = NfcPlugin();
     int fnCalls = 0;
     _checkNfcStartedWithTimer =
         Timer.periodic(Duration(milliseconds: 100), (Timer t) {
@@ -102,7 +100,7 @@ class NFCService {
       fnCalls++;
       _checkNfcStartedWith();
     });
-    _listenLnLinks(nfcPlugin);
+    _listenLnLinks();
     _platform.setMethodCallHandler((MethodCall call) {
       if (call.method == 'receivedBreezId') {
         log.info("Received a Breez ID: " + call.arguments);
@@ -141,15 +139,13 @@ class NFCService {
     });
   }
 
-  _listenLnLinks(NfcPlugin nfcPlugin) {
-    _lnLinkListener = nfcPlugin.onNfcMessage.listen((NfcEvent event) {
-      if (event.error != null && event.error.isNotEmpty) {
-        print('NFC read error: ${event.error}');
-      } else if (event.message.payload != null) {
-        String lnLink = event.message.payload[0].toString();
+  _listenLnLinks() {
+    _lnLinkListener = NFC.readNDEF().listen(
+      (message) {
+        String lnLink = message.payload;
         if (lnLink.startsWith("lightning:")) _lnLinkController.add(lnLink);
-      }
-    });
+      },
+    );
   }
 
   close() {

--- a/lib/services/nfc.dart
+++ b/lib/services/nfc.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:breez/logger.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_nfc_plugin/models/nfc_event.dart';
 import 'package:flutter_nfc_plugin/nfc_plugin.dart';
 
@@ -101,7 +100,7 @@ class NFCService {
         return;
       }
       fnCalls++;
-      _checkNfcStartedWith(nfcPlugin);
+      _checkNfcStartedWith();
     });
     _listenLnLinks(nfcPlugin);
     _platform.setMethodCallHandler((MethodCall call) {
@@ -133,17 +132,13 @@ class NFCService {
     });
   }
 
-  _checkNfcStartedWith(NfcPlugin nfcPlugin) async {
-    // Check for deep link on startup
-    try {
-      final NfcEvent _nfcEventStartedWith = await nfcPlugin.nfcStartedWith;
-      if (_nfcEventStartedWith != null) {
-        _lnLinkController.add(_nfcEventStartedWith.message.payload[0]);
+  _checkNfcStartedWith() async {
+    _platform.invokeMethod("checkIfStartedWithNfc").then((lnLink) {
+      if (lnLink != null && lnLink.toString().isNotEmpty) {
+        _lnLinkController.add(lnLink);
         _checkNfcStartedWithTimer.cancel();
       }
-    } on PlatformException {
-      print('Method "NFC event started with" exception was thrown');
-    }
+    });
   }
 
   _listenLnLinks(NfcPlugin nfcPlugin) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
   cupertino_icons: ^0.1.0
   image_cropper: ^1.1.1
   uni_links: ^0.2.0
-  flutter_nfc_plugin: ^0.0.6
+  nfc_in_flutter: ^2.0.4
   flutter_webview_plugin:
     git:
       url: https://github.com/breez/flutter_webview_plugin.git


### PR DESCRIPTION
Our previous solution, [flutter_nfc_plugin](https://pub.dev/packages/flutter_nfc_plugin) is the only plugin that you could check for app startup intent data. We later realized that it is only supported on Android.

We decided to handle the startup intent data natively and use a plugin that supports both iOS and Android for listening NFC stream while the app is open.