### PR TITLE
flutter_downloader plugin notifications

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,7 +68,9 @@ dependencies:
     git:
       url: https://github.com/breez/flutter_typeahead.git
   csv: ^4.0.3
-  flutter_downloader: ^1.4.4
+  flutter_downloader:
+    git:
+      url: https://github.com/breez/flutter_downloader.git
   local_auth:
     git:
       url: https://github.com/breez/local_auth.git


### PR DESCRIPTION
This PR addresses #361 


[Plugin Changes](https://github.com/breez/flutter_downloader/commit/9e570dfc4cbd4295c3e9e4f760ee49c79cb395e6)
- Plugins local notifications are removed from iOS.