### PR TITLE
Payment list flashing bug

### DIFF
--- a/lib/routes/home/account_page.dart
+++ b/lib/routes/home/account_page.dart
@@ -130,8 +130,11 @@ class AccountPageState extends State<AccountPage>
     }
 
     if (paymentsModel.nonFilteredItems.length > 0) {
-      slivers.add(PaymentsList(paymentsModel.paymentsList,
-          PAYMENT_LIST_ITEM_HEIGHT, widget.firstPaymentItemKey));
+      slivers.add(PaymentsList(
+          paymentsModel.paymentsList,
+          PAYMENT_LIST_ITEM_HEIGHT,
+          widget.firstPaymentItemKey,
+          widget.scrollController));
       slivers.add(SliverPersistentHeader(
           pinned: true,
           delegate:

--- a/lib/routes/home/payment_item.dart
+++ b/lib/routes/home/payment_item.dart
@@ -8,6 +8,9 @@ import 'flip_transition.dart';
 import 'payment_item_avatar.dart';
 import 'success_avatar.dart';
 
+const PAYMENT_LIST_ITEM_HEIGHT = 72.0;
+const AVATAR_RADIUS = 20.0;
+
 class PaymentItem extends StatelessWidget {
   final PaymentInfo _paymentInfo;
   final int _itemIndex;
@@ -28,7 +31,7 @@ class PaymentItem extends StatelessWidget {
         leading: AnimatedOpacity(
           duration: Duration(milliseconds: 200),
           opacity:
-              (_scrollController.offset - (72 + 9 + (_itemIndex + 1) * 72) > 0)
+              (_scrollController.offset - (PAYMENT_LIST_ITEM_HEIGHT + AVATAR_RADIUS / 2 + (_itemIndex + 1) * PAYMENT_LIST_ITEM_HEIGHT) > 0)
                   ? 0.0
                   : 1.0,
           child: Container(

--- a/lib/routes/home/payment_item.dart
+++ b/lib/routes/home/payment_item.dart
@@ -32,6 +32,9 @@ class PaymentItem extends StatelessWidget {
             : theme.customData[theme.themeId].paymentListAlternateBgColor,
         leading: AnimatedOpacity(
           duration: Duration(milliseconds: 200),
+          // when the transaction list is fully expanded
+          // fade away the avatar of the item that's
+          // one third visible behind filter sliver
           opacity: (_scrollController.offset -
                       (DASHBOARD_MAX_HEIGHT - DASHBOARD_MIN_HEIGHT) -
                       (PAYMENT_LIST_ITEM_HEIGHT * (_itemIndex + 1) -

--- a/lib/routes/home/payment_item.dart
+++ b/lib/routes/home/payment_item.dart
@@ -57,10 +57,21 @@ class PaymentItem extends StatelessWidget {
               child: _buildPaymentItemAvatar()),
         ),
         key: _firstItem ? firstPaymentItemKey : null,
-        title: Text(
-          _paymentInfo.title,
-          style: Theme.of(context).accentTextTheme.subtitle2,
-          overflow: TextOverflow.ellipsis,
+        title: Opacity(
+          // set title text to transparent when it leaves viewport
+          opacity: (_scrollController.offset -
+                      (DASHBOARD_MAX_HEIGHT - DASHBOARD_MIN_HEIGHT) -
+                      (PAYMENT_LIST_ITEM_HEIGHT * (_itemIndex + 1) -
+                          FILTER_MAX_SIZE +
+                          AVATAR_DIAMETER / 2) >
+                  0)
+              ? 0.0
+              : 1.0,
+          child: Text(
+            _paymentInfo.title,
+            style: Theme.of(context).accentTextTheme.subtitle2,
+            overflow: TextOverflow.ellipsis,
+          ),
         ),
         subtitle: Row(
             mainAxisAlignment: MainAxisAlignment.start,
@@ -87,15 +98,27 @@ class PaymentItem extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
-                  Text(
-                    (_paymentInfo.type == PaymentType.SENT ||
-                                _paymentInfo.type == PaymentType.WITHDRAWAL ||
-                                _paymentInfo.type == PaymentType.CLOSED_CHANNEL
-                            ? "- "
-                            : "+ ") +
-                        _paymentInfo.currency.format(_paymentInfo.amount,
-                            includeDisplayName: false),
-                    style: Theme.of(context).accentTextTheme.headline6,
+                  Opacity(
+                    // set amount text to transparent when it leaves viewport
+                    opacity: (_scrollController.offset -
+                                (DASHBOARD_MAX_HEIGHT - DASHBOARD_MIN_HEIGHT) -
+                                (PAYMENT_LIST_ITEM_HEIGHT * (_itemIndex + 1) -
+                                    FILTER_MAX_SIZE +
+                                    AVATAR_DIAMETER / 2) >
+                            0)
+                        ? 0.0
+                        : 1.0,
+                    child: Text(
+                      (_paymentInfo.type == PaymentType.SENT ||
+                                  _paymentInfo.type == PaymentType.WITHDRAWAL ||
+                                  _paymentInfo.type ==
+                                      PaymentType.CLOSED_CHANNEL
+                              ? "- "
+                              : "+ ") +
+                          _paymentInfo.currency.format(_paymentInfo.amount,
+                              includeDisplayName: false),
+                      style: Theme.of(context).accentTextTheme.headline6,
+                    ),
                   )
                 ]),
             Padding(
@@ -117,11 +140,23 @@ class PaymentItem extends StatelessWidget {
         ),
         onTap: () => showPaymentDetailsDialog(context, _paymentInfo),
       ),
-      Divider(
-        height: 0.0,
-        thickness: 1,
-        color: theme.customData[theme.themeId].paymentListDividerColor,
-        indent: 72.0,
+      Opacity(
+        // set bottom divider to transparent when it leaves viewport
+        opacity: (_scrollController.offset -
+                    (DASHBOARD_MAX_HEIGHT - DASHBOARD_MIN_HEIGHT) -
+                    (PAYMENT_LIST_ITEM_HEIGHT * (_itemIndex + 1) -
+                        FILTER_MAX_SIZE +
+                        AVATAR_DIAMETER +
+                        16) >
+                0)
+            ? 0.0
+            : 1.0,
+        child: Divider(
+          height: 0.0,
+          thickness: 1,
+          color: theme.customData[theme.themeId].paymentListDividerColor,
+          indent: 72.0,
+        ),
       ),
     ]);
   }

--- a/lib/routes/home/payment_item.dart
+++ b/lib/routes/home/payment_item.dart
@@ -13,9 +13,10 @@ class PaymentItem extends StatelessWidget {
   final int _itemIndex;
   final bool _firstItem;
   final GlobalKey firstPaymentItemKey;
+  final ScrollController _scrollController;
 
   PaymentItem(this._paymentInfo, this._itemIndex, this._firstItem,
-      this.firstPaymentItemKey);
+      this.firstPaymentItemKey, this._scrollController);
 
   @override
   Widget build(BuildContext context) {
@@ -24,18 +25,25 @@ class PaymentItem extends StatelessWidget {
         tileColor: (_itemIndex % 2 == 0)
             ? theme.customData[theme.themeId].paymentListBgColor
             : theme.customData[theme.themeId].paymentListAlternateBgColor,
-        leading: Container(
-            decoration: BoxDecoration(
-              color: Colors.white,
-              shape: BoxShape.circle,
-              boxShadow: [
-                BoxShadow(
-                    color: Colors.black.withOpacity(0.1),
-                    offset: Offset(0.5, 0.5),
-                    blurRadius: 5.0),
-              ],
-            ),
-            child: _buildPaymentItemAvatar()),
+        leading: AnimatedOpacity(
+          duration: Duration(milliseconds: 200),
+          opacity:
+              (_scrollController.offset - (72 + 9 + (_itemIndex + 1) * 72) > 0)
+                  ? 0.0
+                  : 1.0,
+          child: Container(
+              decoration: BoxDecoration(
+                color: Colors.white,
+                shape: BoxShape.circle,
+                boxShadow: [
+                  BoxShadow(
+                      color: Colors.black.withOpacity(0.1),
+                      offset: Offset(0.5, 0.5),
+                      blurRadius: 5.0),
+                ],
+              ),
+              child: _buildPaymentItemAvatar()),
+        ),
         key: _firstItem ? firstPaymentItemKey : null,
         title: Text(
           _paymentInfo.title,

--- a/lib/routes/home/payment_item.dart
+++ b/lib/routes/home/payment_item.dart
@@ -8,8 +8,10 @@ import 'flip_transition.dart';
 import 'payment_item_avatar.dart';
 import 'success_avatar.dart';
 
+const DASHBOARD_MAX_HEIGHT = 176.25;
+const DASHBOARD_MIN_HEIGHT = 70.0;
+const FILTER_MAX_SIZE = 56.0;
 const PAYMENT_LIST_ITEM_HEIGHT = 72.0;
-const AVATAR_RADIUS = 20.0;
 
 class PaymentItem extends StatelessWidget {
   final PaymentInfo _paymentInfo;
@@ -30,10 +32,13 @@ class PaymentItem extends StatelessWidget {
             : theme.customData[theme.themeId].paymentListAlternateBgColor,
         leading: AnimatedOpacity(
           duration: Duration(milliseconds: 200),
-          opacity:
-              (_scrollController.offset - (PAYMENT_LIST_ITEM_HEIGHT + AVATAR_RADIUS / 2 + (_itemIndex + 1) * PAYMENT_LIST_ITEM_HEIGHT) > 0)
-                  ? 0.0
-                  : 1.0,
+          opacity: (_scrollController.offset -
+                      (DASHBOARD_MAX_HEIGHT - DASHBOARD_MIN_HEIGHT) -
+                      (PAYMENT_LIST_ITEM_HEIGHT * (_itemIndex + 1) -
+                          PAYMENT_LIST_ITEM_HEIGHT / 3) >
+                  0)
+              ? 0.0
+              : 1.0,
           child: Container(
               decoration: BoxDecoration(
                 color: Colors.white,

--- a/lib/routes/home/payment_item.dart
+++ b/lib/routes/home/payment_item.dart
@@ -12,6 +12,7 @@ const DASHBOARD_MAX_HEIGHT = 176.25;
 const DASHBOARD_MIN_HEIGHT = 70.0;
 const FILTER_MAX_SIZE = 56.0;
 const PAYMENT_LIST_ITEM_HEIGHT = 72.0;
+const AVATAR_DIAMETER = 40.0;
 
 class PaymentItem extends StatelessWidget {
   final PaymentInfo _paymentInfo;
@@ -30,15 +31,15 @@ class PaymentItem extends StatelessWidget {
         tileColor: (_itemIndex % 2 == 0)
             ? theme.customData[theme.themeId].paymentListBgColor
             : theme.customData[theme.themeId].paymentListAlternateBgColor,
-        leading: AnimatedOpacity(
-          duration: Duration(milliseconds: 200),
+        leading: Opacity(
           // when the transaction list is fully expanded
-          // fade away the avatar of the item that's
-          // one third visible behind filter sliver
+          // set opacity the avatar of the item that's
+          // no longer visible to transparent
           opacity: (_scrollController.offset -
                       (DASHBOARD_MAX_HEIGHT - DASHBOARD_MIN_HEIGHT) -
                       (PAYMENT_LIST_ITEM_HEIGHT * (_itemIndex + 1) -
-                          PAYMENT_LIST_ITEM_HEIGHT / 3) >
+                          FILTER_MAX_SIZE +
+                          AVATAR_DIAMETER) >
                   0)
               ? 0.0
               : 1.0,

--- a/lib/routes/home/payments_list.dart
+++ b/lib/routes/home/payments_list.dart
@@ -3,21 +3,46 @@ import 'package:flutter/material.dart';
 
 import 'payment_item.dart';
 
-class PaymentsList extends StatelessWidget {
+class PaymentsList extends StatefulWidget {
   final List<PaymentInfo> _payments;
   final double _itemHeight;
   final GlobalKey firstPaymentItemKey;
+  final ScrollController scrollController;
 
-  PaymentsList(this._payments, this._itemHeight, this.firstPaymentItemKey);
+  PaymentsList(this._payments, this._itemHeight, this.firstPaymentItemKey,
+      this.scrollController);
+
+  @override
+  State<StatefulWidget> createState() {
+    return PaymentsListState();
+  }
+}
+
+class PaymentsListState extends State<PaymentsList> {
+  @override
+  void initState() {
+    super.initState();
+    widget.scrollController.addListener(onScroll);
+  }
+
+  @override
+  void dispose() {
+    widget.scrollController.removeListener(onScroll);
+    super.dispose();
+  }
+
+  void onScroll() {
+    setState(() {});
+  }
 
   @override
   Widget build(BuildContext context) {
     return SliverFixedExtentList(
-      itemExtent: _itemHeight,
+      itemExtent: widget._itemHeight,
       delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
-        return PaymentItem(
-            _payments[index], index, 0 == index, firstPaymentItemKey);
-      }, childCount: _payments.length),
+        return PaymentItem(widget._payments[index], index, 0 == index,
+            widget.firstPaymentItemKey, widget.scrollController);
+      }, childCount: widget._payments.length),
     );
   }
 }


### PR DESCRIPTION
This PR addresses [BU-256](https://breeztech.atlassian.net/browse/BU-256)

I couldn't reproduce the bug on any physical or virtual device so we decided to go with this workaround where the avatar fades away as it's leaving the viewport.

 - Title, amount text and bottom divider fades away too.

Concerns: Using Opacity is costly, we may revert to using this trick for avatar only if performance issues arises for our users. I had the same frame rate while scrolling on my tests with and without this workaround.