### PR TITLE
Currency text direction support

### DIFF
--- a/lib/bloc/account/fiat_conversion.dart
+++ b/lib/bloc/account/fiat_conversion.dart
@@ -44,6 +44,7 @@ class FiatConversion {
 
   String formatFiat(
     double fiatAmount, {
+    bool includeDisplayName = false,
     bool addCurrencySymbol = true,
     bool removeTrailingZeros = false,
     bool allowBelowMin = false,
@@ -71,6 +72,8 @@ class FiatConversion {
       formattedAmount = (this.currencyData.position == 1)
           ? formattedAmount + symbol
           : symbol + formattedAmount;
+    } else if (includeDisplayName) {
+      formattedAmount += this.currencyData.shortName;
     }
     if (removeTrailingZeros) {
       RegExp removeTrailingZeros = RegExp(r"([.]0*)(?!.*\d)");

--- a/lib/bloc/account/fiat_conversion.dart
+++ b/lib/bloc/account/fiat_conversion.dart
@@ -53,7 +53,7 @@ class FiatConversion {
 
     String formattedAmount = "";
     String spacing = " " * this.currencyData.spacing;
-    String symbol = (this.currencyData.rtl)
+    String symbol = (this.currencyData.position == 1)
         ? spacing + '${this.currencyData.symbol}'
         : '${this.currencyData.symbol}' + spacing;
     // if conversion result is less than the minimum it doesn't make sense to display
@@ -68,7 +68,7 @@ class FiatConversion {
       formattedAmount = formatter.format(fiatAmount);
     }
     if (addCurrencySymbol) {
-      formattedAmount = (this.currencyData.rtl)
+      formattedAmount = (this.currencyData.position == 1)
           ? formattedAmount + symbol
           : symbol + formattedAmount;
     }

--- a/lib/bloc/user_profile/currency.dart
+++ b/lib/bloc/user_profile/currency.dart
@@ -19,11 +19,13 @@ class Currency extends Object {
 
   String format(
     Int64 sat, {
+    includeCurrencySymbol = false,
     includeDisplayName = true,
     removeTrailingZeros = false,
     userInput = false,
   }) =>
       _CurrencyFormatter().format(sat, this,
+          addCurrencySymbol: includeCurrencySymbol,
           addCurrencySuffix: includeDisplayName,
           removeTrailingZeros: removeTrailingZeros,
           userInput: userInput);
@@ -65,6 +67,7 @@ class _CurrencyFormatter {
 
   String format(satoshies, Currency currency,
       {bool addCurrencySuffix = true,
+      bool addCurrencySymbol = false,
       removeTrailingZeros = false,
       userInput = false}) {
     String formattedAmount = formatter.format(satoshies);
@@ -85,7 +88,9 @@ class _CurrencyFormatter {
         formattedAmount = formatter.format(satoshies);
         break;
     }
-    if (addCurrencySuffix) {
+    if (addCurrencySymbol) {
+      formattedAmount = currency.symbol + formattedAmount;
+    } else if (addCurrencySuffix) {
       formattedAmount += ' ${currency.displayName}';
     }
 

--- a/lib/routes/charge/currency_wrapper.dart
+++ b/lib/routes/charge/currency_wrapper.dart
@@ -57,16 +57,19 @@ class CurrencyWrapper {
     double value, {
     userInput = false,
     bool includeCurrencySymbol = false,
+    bool includeDisplayName = false,
     removeTrailingZeros = false,
   }) {
     if (btc != null) {
       var satValue = btc.toSats(value);
       return btc.format(satValue,
           userInput: userInput,
-          includeDisplayName: includeCurrencySymbol,
+          includeDisplayName: includeDisplayName,
+          includeCurrencySymbol: includeCurrencySymbol,
           removeTrailingZeros: removeTrailingZeros);
     }
     return fiat.formatFiat(value,
+        includeDisplayName: includeDisplayName,
         addCurrencySymbol: includeCurrencySymbol,
         allowBelowMin: true,
         removeTrailingZeros: removeTrailingZeros);

--- a/lib/routes/charge/currency_wrapper.dart
+++ b/lib/routes/charge/currency_wrapper.dart
@@ -34,6 +34,8 @@ class CurrencyWrapper {
 
   String get symbol => btc?.symbol ?? fiat.currencyData.symbol;
 
+  bool get rtl => fiat?.currencyData?.rtl ?? false;
+
   String get chargeSuffix => btc?.displayName ?? fiat.currencyData.shortName;
 
   int get fractionSize {

--- a/lib/routes/charge/sale_view.dart
+++ b/lib/routes/charge/sale_view.dart
@@ -385,19 +385,6 @@ class SaleLineWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var currency =
-        CurrencyWrapper.fromShortName(saleLine.currency, accountModel);
-    double priceInFiat = saleLine.pricePerItem * saleLine.quantity;
-    double priceInSats = currency.satConversionRate * priceInFiat;
-    String priceInSaleCurrency = "";
-    if (saleCurrency.symbol != currency.symbol) {
-      String salePrice = saleCurrency.format(
-          priceInSats / saleCurrency.satConversionRate,
-          includeCurrencySymbol: true,
-          removeTrailingZeros: true);
-      priceInSaleCurrency = " ($salePrice)";
-    }
-
     var iconColor = theme.themeId == "BLUE"
         ? Colors.black.withOpacity(0.3)
         : ListTileTheme.of(context).iconColor.withOpacity(0.5);
@@ -409,12 +396,12 @@ class SaleLineWidget extends StatelessWidget {
             saleLine.itemName,
             //style: TextStyle(fontWeight: FontWeight.bold),
           ),
-          subtitle: Text(
-              "${currency.symbol}${currency.format(priceInFiat, removeTrailingZeros: true)}$priceInSaleCurrency",
-              style: TextStyle(
-                  color: ListTileTheme.of(context)
-                      .textColor
-                      .withOpacity(theme.themeId == "BLUE" ? 0.75 : 0.5))),
+          subtitle: CurrencyDisplay(
+            currency:
+                CurrencyWrapper.fromShortName(saleLine.currency, accountModel),
+            saleLine: saleLine,
+            saleCurrency: saleCurrency,
+          ),
           trailing: Row(
             mainAxisAlignment: MainAxisAlignment.end,
             mainAxisSize: MainAxisSize.min,
@@ -451,5 +438,76 @@ class SaleLineWidget extends StatelessWidget {
             ],
           )),
     );
+  }
+}
+
+class CurrencyDisplay extends StatelessWidget {
+  final CurrencyWrapper currency;
+  final SaleLine saleLine;
+  final CurrencyWrapper saleCurrency;
+
+  const CurrencyDisplay({
+    Key key,
+    @required this.currency,
+    @required this.saleLine,
+    @required this.saleCurrency,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    double priceInFiat = saleLine.pricePerItem * saleLine.quantity;
+    double priceInSats = currency.satConversionRate * priceInFiat;
+    String priceInSaleCurrency = "";
+    if (saleCurrency.symbol != currency.symbol) {
+      String salePrice = saleCurrency.format(
+          priceInSats / saleCurrency.satConversionRate,
+          includeCurrencySymbol: true,
+          removeTrailingZeros: true);
+      priceInSaleCurrency = " ($salePrice)";
+    }
+    TextStyle textStyle = TextStyle(
+        color: ListTileTheme.of(context)
+            .textColor
+            .withOpacity(theme.themeId == "BLUE" ? 0.75 : 0.5));
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.baseline,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CurrencyText(
+                text:
+                    "${currency.format(priceInFiat, includeCurrencySymbol: true, removeTrailingZeros: true)}",
+                currency: currency,
+                style: textStyle),
+            CurrencyText(
+                text: priceInSaleCurrency,
+                currency: saleCurrency,
+                style: textStyle),
+          ]),
+    );
+  }
+}
+
+class CurrencyText extends StatelessWidget {
+  const CurrencyText({
+    Key key,
+    @required this.text,
+    @required this.currency,
+    this.style,
+  }) : super(key: key);
+
+  final String text;
+  final CurrencyWrapper currency;
+  final TextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(text,
+        maxLines: 1,
+        textDirection: currency.rtl ? TextDirection.rtl : TextDirection.ltr,
+        textAlign: currency.rtl ? TextAlign.end : TextAlign.start,
+        style: style ?? DefaultTextStyle.of(context).style);
   }
 }

--- a/lib/routes/charge/sale_view.dart
+++ b/lib/routes/charge/sale_view.dart
@@ -393,8 +393,9 @@ class SaleLineWidget extends StatelessWidget {
     if (saleCurrency.symbol != currency.symbol) {
       String salePrice = saleCurrency.format(
           priceInSats / saleCurrency.satConversionRate,
+          includeCurrencySymbol: true,
           removeTrailingZeros: true);
-      priceInSaleCurrency = " (${saleCurrency.symbol}$salePrice)";
+      priceInSaleCurrency = " ($salePrice)";
     }
 
     var iconColor = theme.themeId == "BLUE"

--- a/lib/services/currency_data.dart
+++ b/lib/services/currency_data.dart
@@ -10,6 +10,7 @@ class CurrencyData {
   int fractionSize;
   String symbol;
   bool rtl;
+  int position;
   int spacing;
 
   CurrencyData(
@@ -18,6 +19,7 @@ class CurrencyData {
       this.fractionSize,
       this.symbol,
       this.rtl,
+      this.position,
       this.spacing});
 
   factory CurrencyData.fromJson(String shortName, Map<String, dynamic> json) =>
@@ -27,6 +29,7 @@ class CurrencyData {
         fractionSize: json["fractionSize"] ?? 0,
         symbol: json["symbol"] != null ? json["symbol"]["grapheme"] : shortName,
         rtl: json["symbol"] != null ? json["symbol"]["rtl"] : false,
+        position: json["symbol"] != null ? json["symbol"]["position"] ?? 0 : 0,
         spacing: json["spacing"] ?? 1,
       );
 }

--- a/src/json/currencies.json
+++ b/src/json/currencies.json
@@ -447,7 +447,8 @@
     "symbol": {
       "grapheme": "Kč",
       "template": "1 $",
-      "rtl": false
+      "rtl": false,
+      "position": 1
     },
     "uniqSymbol": {
       "grapheme": "Kč",

--- a/src/json/currencies.json
+++ b/src/json/currencies.json
@@ -3,7 +3,7 @@
     "name": "UAE Dirham",
     "fractionSize": 2,
     "symbol": {
-      "grapheme": ".د.إ",
+      "grapheme": "د.إ",
       "template": "1 $",
       "rtl": true
     },
@@ -1451,7 +1451,8 @@
     "symbol": {
       "grapheme": "₽",
       "template": "1 $",
-      "rtl": true
+      "rtl": false,
+      "position": 1
     },
     "uniqSymbol": {
       "grapheme": "₽",
@@ -1529,7 +1530,8 @@
     "symbol": {
       "grapheme": "kr",
       "template": "1 $",
-      "rtl": true
+      "rtl": false,
+      "position": 1
     },
     "uniqSymbol": null
   },
@@ -1863,7 +1865,8 @@
     "symbol": {
       "grapheme": "₫",
       "template": "1 $",
-      "rtl": true
+      "rtl": false,
+      "position": 1
     },
     "uniqSymbol": {
       "grapheme": "₫",


### PR DESCRIPTION
- Add position variable to currencies for symbol placement.
- Make distinction between displayName and currencySymbol on format method.
- If there are two currency texts with opposite text directions next to each other, use text-direction aware CurrencyText wrapped in CurrencyDisplay.
- Users can now scroll overflowing currency text on Sale View thanks to CurrencyDisplay.