### PR TITLE
Multiline field support

### DIFF
--- a/lib/routes/home/payment_item.dart
+++ b/lib/routes/home/payment_item.dart
@@ -68,7 +68,7 @@ class PaymentItem extends StatelessWidget {
               ? 0.0
               : 1.0,
           child: Text(
-            _paymentInfo.title,
+            _paymentInfo.title.replaceAll("\n", " "),
             style: Theme.of(context).accentTextTheme.subtitle2,
             overflow: TextOverflow.ellipsis,
           ),

--- a/lib/widgets/payment_details_dialog.dart
+++ b/lib/widgets/payment_details_dialog.dart
@@ -88,13 +88,21 @@ Future<Null> showPaymentDetailsDialog(
               ? Container()
               : Padding(
                   padding: EdgeInsets.only(left: 16.0, right: 16.0),
-                  child: AutoSizeText(
-                    paymentInfo.description,
-                    style: Theme.of(context).primaryTextTheme.headline4,
-                    textAlign: paymentInfo.description.length > 40
-                        ? TextAlign.justify
-                        : TextAlign.center,
-                    maxLines: 3,
+                  child: Container(
+                    constraints: BoxConstraints(
+                        maxHeight: 54, minWidth: double.infinity),
+                    child: Scrollbar(
+                      child: SingleChildScrollView(
+                        child: AutoSizeText(
+                          paymentInfo.description,
+                          style: Theme.of(context).primaryTextTheme.headline4,
+                          textAlign: paymentInfo.description.length > 40 &&
+                                  !paymentInfo.description.contains("\n")
+                              ? TextAlign.start
+                              : TextAlign.center,
+                        ),
+                      ),
+                    ),
                   ),
                 ),
           paymentInfo.amount == null

--- a/lib/widgets/payment_details_dialog.dart
+++ b/lib/widgets/payment_details_dialog.dart
@@ -78,9 +78,10 @@ Future<Null> showPaymentDetailsDialog(
                           ? 16
                           : 8),
                   child: AutoSizeText(
-                    paymentInfo.dialogTitle,
+                    paymentInfo.dialogTitle.replaceAll("\n", " "),
                     style: Theme.of(context).primaryTextTheme.headline5,
                     textAlign: TextAlign.center,
+                    overflow: TextOverflow.ellipsis,
                     maxLines: 1,
                   ),
                 ),

--- a/lib/widgets/payment_request_info_dialog.dart
+++ b/lib/widgets/payment_request_info_dialog.dart
@@ -226,16 +226,24 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
         ? null
         : Padding(
             padding: EdgeInsets.only(top: 8.0, left: 16.0, right: 16.0),
-            child: AutoSizeText(
-              widget.invoice.description,
-              style: Theme.of(context)
-                  .primaryTextTheme
-                  .headline3
-                  .copyWith(fontSize: 16),
-              textAlign: widget.invoice.description.length > 40
-                  ? TextAlign.justify
-                  : TextAlign.center,
-              maxLines: 3,
+            child: Container(
+              constraints:
+                  BoxConstraints(maxHeight: 200, minWidth: double.infinity),
+              child: Scrollbar(
+                child: SingleChildScrollView(
+                  child: AutoSizeText(
+                    widget.invoice.description,
+                    style: Theme.of(context)
+                        .primaryTextTheme
+                        .headline3
+                        .copyWith(fontSize: 16),
+                    textAlign: widget.invoice.description.length > 40 &&
+                            !widget.invoice.description.contains("\n")
+                        ? TextAlign.start
+                        : TextAlign.center,
+                  ),
+                ),
+              ),
             ),
           );
   }


### PR DESCRIPTION
This PR addresses [BU-269](https://breeztech.atlassian.net/browse/BU-269)

Previously description fields on payment request and payment details dialog had a maximum line property, which cropped description if it was longer than 3 lines. Now those are replaced with a scrollable area that shows 10, 3 lines at a time respectively showing the full description without cropping.
Transaction titles with new lines was producing an unwanted look, new lines on this field is now replaced with space character.