### PR TITLE
Show add funds message on low balance

### DIFF
--- a/lib/bloc/podcast_payments/payment_options.dart
+++ b/lib/bloc/podcast_payments/payment_options.dart
@@ -1,0 +1,5 @@
+class PaymentOptions {
+  List get boostAmountList => [100, 500, 1000, 5000, 10000, 50000];
+
+  List get satsPerMinuteIntervalsList => [0, 10, 25, 50, 100, 250, 500, 1000];
+}

--- a/lib/bloc/podcast_payments/podcast_payments_bloc.dart
+++ b/lib/bloc/podcast_payments/podcast_payments_bloc.dart
@@ -8,6 +8,7 @@ import 'package:anytime/ui/widgets/transport_controls.dart';
 import 'package:breez/bloc/account/account_bloc.dart';
 import 'package:breez/bloc/async_actions_handler.dart';
 import 'package:breez/bloc/podcast_payments/actions.dart';
+import 'package:breez/bloc/podcast_payments/payment_options.dart';
 import 'package:breez/logger.dart';
 import 'package:breez/services/breezlib/breez_bridge.dart';
 import 'package:breez/services/injector.dart';
@@ -24,6 +25,10 @@ class PodcastPaymentsBloc with AsyncActionsHandler {
 
   final _amountController = BehaviorSubject<int>();
 
+  final _paymentOptionsController = BehaviorSubject<PaymentOptions>();
+  Stream<PaymentOptions> get paymentOptionsStream =>
+      _paymentOptionsController.stream;
+
   Episode _currentPaidEpisode;
   BreezBridge _breezLib;
   Timer _paymentTimer;
@@ -32,6 +37,7 @@ class PodcastPaymentsBloc with AsyncActionsHandler {
   PodcastPaymentsBloc(this.accountBloc, this.audioBloc, this.repository) {
     ServiceInjector injector = ServiceInjector();
     _breezLib = injector.breezBridge;
+    _paymentOptionsController.add(PaymentOptions());
     listenAudioState();
     registerAsyncHandlers({
       PayBoost: _payBoost,
@@ -176,6 +182,10 @@ class PodcastPaymentsBloc with AsyncActionsHandler {
         .map(((pi) => pi.fee))
         .first
         .timeout(Duration(seconds: 1), onTimeout: () => Int64.ZERO);
+  }
+
+  close() {
+    _paymentOptionsController.close();
   }
 }
 

--- a/lib/bloc/user_profile/breez_user_model.dart
+++ b/lib/bloc/user_profile/breez_user_model.dart
@@ -25,6 +25,8 @@ class BreezUserModel {
   final String posCurrencyShortName;
   final List<String> preferredCurrencies;
   final AppMode appMode;
+  final int preferredBoostValue;
+  final int preferredSatsPerMinValue;
 
   BreezUserModel._(
     this.userID,
@@ -46,6 +48,8 @@ class BreezUserModel {
     this.posCurrencyShortName = "SAT",
     this.preferredCurrencies,
     this.appMode = AppMode.balance,
+    this.preferredBoostValue = 5000,
+    this.preferredSatsPerMinValue = 50,
   });
 
   BreezUserModel copyWith({
@@ -68,6 +72,8 @@ class BreezUserModel {
     String posCurrencyShortName,
     List<String> preferredCurrencies,
     AppMode appMode,
+    int preferredBoostValue,
+    int preferredSatsPerMinValue,
   }) {
     return BreezUserModel._(
       userID ?? this.userID,
@@ -91,6 +97,9 @@ class BreezUserModel {
       posCurrencyShortName: posCurrencyShortName ?? this.posCurrencyShortName,
       preferredCurrencies: preferredCurrencies ?? this.preferredCurrencies,
       appMode: appMode ?? this.appMode,
+      preferredBoostValue: preferredBoostValue ?? this.preferredBoostValue,
+      preferredSatsPerMinValue:
+          preferredSatsPerMinValue ?? this.preferredSatsPerMinValue,
     );
   }
 
@@ -135,7 +144,9 @@ class BreezUserModel {
         preferredCurrencies =
             (json['preferredCurrencies'] as List<dynamic>)?.cast<String>() ??
                 <String>['USD', 'EUR', 'GBP', 'JPY'],
-        appMode = AppMode.values[json["appMode"] ?? 0];
+        appMode = AppMode.values[json["appMode"] ?? 0],
+        preferredBoostValue = json["preferredBoostValue"] ?? 5000,
+        preferredSatsPerMinValue = json["preferredSatsPerMinValue"] ?? 50;
 
   Map<String, dynamic> toJson() => {
         'userID': userID,
@@ -156,5 +167,7 @@ class BreezUserModel {
         'businessAddress': businessAddress,
         'preferredCurrencies': preferredCurrencies,
         'appMode': appMode.index,
+        'preferredBoostValue': preferredBoostValue,
+        'preferredSatsPerMinValue': preferredSatsPerMinValue,
       };
 }

--- a/lib/bloc/user_profile/user_actions.dart
+++ b/lib/bloc/user_profile/user_actions.dart
@@ -82,3 +82,15 @@ class SetPOSCurrency extends AsyncAction {
 
   SetPOSCurrency(this.shortName);
 }
+
+class SetBoostAmount extends AsyncAction {
+  final int boostAmount;
+
+  SetBoostAmount(this.boostAmount);
+}
+
+class SetSatsPerMinAmount extends AsyncAction {
+  final int satsPerMin;
+
+  SetSatsPerMinAmount(this.satsPerMin);
+}

--- a/lib/bloc/user_profile/user_profile_bloc.dart
+++ b/lib/bloc/user_profile/user_profile_bloc.dart
@@ -85,6 +85,8 @@ class UserProfileBloc {
       VerifyAdminPassword: _verifyAdminPassword,
       UploadProfilePicture: _uploadProfilePicture,
       SetPOSCurrency: _setPOSCurrency,
+      SetBoostAmount: _setBoostAmount,
+      SetSatsPerMinAmount: _setSatsPerMinAmount,
     };
     print("UserProfileBloc started");
 
@@ -190,6 +192,18 @@ class UserProfileBloc {
     _saveChanges(await _preferences,
         _currentUser.copyWith(posCurrencyShortName: action.shortName));
     action.resolve(action.shortName);
+  }
+
+  Future _setBoostAmount(SetBoostAmount action) async {
+    _saveChanges(await _preferences,
+        _currentUser.copyWith(preferredBoostValue: action.boostAmount));
+    action.resolve(action.boostAmount);
+  }
+
+  Future _setSatsPerMinAmount(SetSatsPerMinAmount action) async {
+    _saveChanges(await _preferences,
+        _currentUser.copyWith(preferredSatsPerMinValue: action.satsPerMin));
+    action.resolve(action.satsPerMin);
   }
 
   Future _uploadProfilePicture(UploadProfilePicture action) async {

--- a/lib/routes/home/bottom_actions_bar.dart
+++ b/lib/routes/home/bottom_actions_bar.dart
@@ -46,7 +46,7 @@ class BottomActionsBar extends StatelessWidget {
               width: 64,
             ),
             _Action(
-              onPress: () => _showReceiveOptions(context),
+              onPress: () => showReceiveOptions(context, account),
               group: actionsGroup,
               text: "RECEIVE",
               iconAssetPath: "src/icon/receive-action.png",
@@ -185,100 +185,6 @@ class BottomActionsBar extends StatelessWidget {
               });
         });
   }
-
-  Future _showReceiveOptions(BuildContext context) {
-    AddFundsBloc addFundsBloc = BlocProvider.of<AddFundsBloc>(context);
-    LSPBloc lspBloc = AppBlocsProvider.of<LSPBloc>(context);
-
-    return showModalBottomSheet(
-        context: context,
-        builder: (ctx) {
-          return StreamBuilder<LSPStatus>(
-              stream: lspBloc.lspStatusStream,
-              builder: (context, lspSnapshot) {
-                return StreamBuilder<List<AddFundVendorModel>>(
-                    stream: addFundsBloc.availableVendorsStream,
-                    builder: (context, snapshot) {
-                      if (snapshot.data == null) {
-                        return SizedBox();
-                      }
-
-                      List<Widget> children =
-                          snapshot.data.where((v) => v.isAllowed).map((v) {
-                        return Column(
-                          children: [
-                            Divider(
-                              height: 0.0,
-                              color: Colors.white.withOpacity(0.2),
-                              indent: 72.0,
-                            ),
-                            ListTile(
-                                enabled: v.enabled &&
-                                    (account.connected ||
-                                        !v.requireActiveChannel),
-                                leading: _ActionImage(
-                                    iconAssetPath: v.icon,
-                                    enabled: account.connected ||
-                                        !v.requireActiveChannel),
-                                title: Text(
-                                  v.shortName ?? v.name,
-                                  style: theme.bottomSheetTextStyle,
-                                ),
-                                onTap: () {
-                                  Navigator.of(context).pop();
-                                  if (v.showLSPFee) {
-                                    promptLSPFeeAndNavigate(context, account,
-                                        lspSnapshot.data.currentLSP, v.route);
-                                  } else {
-                                    Navigator.of(context).pushNamed(v.route);
-                                  }
-                                }),
-                          ],
-                        );
-                      }).toList();
-
-                      return Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: <Widget>[
-                          SizedBox(height: 8.0),
-                          ListTile(
-                              enabled: true,
-                              leading: _ActionImage(
-                                  iconAssetPath: "src/icon/paste.png",
-                                  enabled: true),
-                              title: Text(
-                                "Receive via Invoice",
-                                style: theme.bottomSheetTextStyle,
-                              ),
-                              onTap: () {
-                                Navigator.of(context).pop();
-                                Navigator.of(context)
-                                    .pushNamed("/create_invoice");
-                              }),
-                          ...children,
-                          account.warningMaxChanReserveAmount == 0
-                              ? SizedBox(height: 8.0)
-                              : WarningBox(
-                                  boxPadding: EdgeInsets.all(16),
-                                  contentPadding: EdgeInsets.all(8),
-                                  child: AutoSizeText(
-                                    "Breez requires you to keep ${account.currency.format(account.warningMaxChanReserveAmount, removeTrailingZeros: true)} in your balance.",
-                                    maxLines: 1,
-                                    maxFontSize: Theme.of(context)
-                                        .textTheme
-                                        .subtitle1
-                                        .fontSize,
-                                    style:
-                                        Theme.of(context).textTheme.headline6,
-                                    textAlign: TextAlign.center,
-                                  ),
-                                )
-                        ],
-                      );
-                    });
-              });
-        });
-  }
 }
 
 class _Action extends StatelessWidget {
@@ -335,4 +241,97 @@ class _ActionImage extends StatelessWidget {
       height: 24.0,
     );
   }
+}
+
+Future showReceiveOptions(BuildContext context, AccountModel account) {
+  AddFundsBloc addFundsBloc = BlocProvider.of<AddFundsBloc>(context);
+  LSPBloc lspBloc = AppBlocsProvider.of<LSPBloc>(context);
+
+  return showModalBottomSheet(
+      context: context,
+      builder: (ctx) {
+        return StreamBuilder<LSPStatus>(
+            stream: lspBloc.lspStatusStream,
+            builder: (context, lspSnapshot) {
+              return StreamBuilder<List<AddFundVendorModel>>(
+                  stream: addFundsBloc.availableVendorsStream,
+                  builder: (context, snapshot) {
+                    if (snapshot.data == null) {
+                      return SizedBox();
+                    }
+
+                    List<Widget> children =
+                    snapshot.data.where((v) => v.isAllowed).map((v) {
+                      return Column(
+                        children: [
+                          Divider(
+                            height: 0.0,
+                            color: Colors.white.withOpacity(0.2),
+                            indent: 72.0,
+                          ),
+                          ListTile(
+                              enabled: v.enabled &&
+                                  (account.connected ||
+                                      !v.requireActiveChannel),
+                              leading: _ActionImage(
+                                  iconAssetPath: v.icon,
+                                  enabled: account.connected ||
+                                      !v.requireActiveChannel),
+                              title: Text(
+                                v.shortName ?? v.name,
+                                style: theme.bottomSheetTextStyle,
+                              ),
+                              onTap: () {
+                                Navigator.of(context).pop();
+                                if (v.showLSPFee) {
+                                  promptLSPFeeAndNavigate(context, account,
+                                      lspSnapshot.data.currentLSP, v.route);
+                                } else {
+                                  Navigator.of(context).pushNamed(v.route);
+                                }
+                              }),
+                        ],
+                      );
+                    }).toList();
+
+                    return Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        SizedBox(height: 8.0),
+                        ListTile(
+                            enabled: true,
+                            leading: _ActionImage(
+                                iconAssetPath: "src/icon/paste.png",
+                                enabled: true),
+                            title: Text(
+                              "Receive via Invoice",
+                              style: theme.bottomSheetTextStyle,
+                            ),
+                            onTap: () {
+                              Navigator.of(context).pop();
+                              Navigator.of(context)
+                                  .pushNamed("/create_invoice");
+                            }),
+                        ...children,
+                        account.warningMaxChanReserveAmount == 0
+                            ? SizedBox(height: 8.0)
+                            : WarningBox(
+                          boxPadding: EdgeInsets.all(16),
+                          contentPadding: EdgeInsets.all(8),
+                          child: AutoSizeText(
+                            "Breez requires you to keep ${account.currency.format(account.warningMaxChanReserveAmount, removeTrailingZeros: true)} in your balance.",
+                            maxLines: 1,
+                            maxFontSize: Theme.of(context)
+                                .textTheme
+                                .subtitle1
+                                .fontSize,
+                            style: Theme.of(context).textTheme.headline6,
+                            textAlign: TextAlign.center,
+                          ),
+                        )
+                      ],
+                    );
+                  });
+            });
+      });
 }

--- a/lib/routes/podcast/add_funds_message.dart
+++ b/lib/routes/podcast/add_funds_message.dart
@@ -1,9 +1,11 @@
+import 'package:breez/bloc/account/account_model.dart';
+import 'package:breez/routes/home/bottom_actions_bar.dart';
 import 'package:flutter/material.dart';
 
 class AddFundsMessage extends StatefulWidget {
-  final int total;
+  final AccountModel accountModel;
 
-  const AddFundsMessage({Key key, this.total}) : super(key: key);
+  const AddFundsMessage({Key key, this.accountModel}) : super(key: key);
 
   @override
   State<StatefulWidget> createState() {
@@ -27,7 +29,7 @@ class AddFundsMessageState extends State<AddFundsMessage> {
           ),
           RaisedButton(
               onPressed: () {
-                Navigator.of(context).pushNamed("/create_invoice");
+                showReceiveOptions(context, widget.accountModel);
               },
               color: Theme.of(context).primaryColor,
               child: Text(

--- a/lib/routes/podcast/add_funds_message.dart
+++ b/lib/routes/podcast/add_funds_message.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+class AddFundsMessage extends StatefulWidget {
+  final int total;
+
+  const AddFundsMessage({Key key, this.total}) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() {
+    return AddFundsMessageState();
+  }
+}
+
+class AddFundsMessageState extends State<AddFundsMessage> {
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 16.0, horizontal: 16),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              "Add funds to your balance to send payments to this podcast.",
+              style: Theme.of(context).textTheme.bodyText2,
+              textAlign: TextAlign.start,
+            ),
+          ),
+          RaisedButton(
+              onPressed: () {
+                Navigator.of(context).pushNamed("/create_invoice");
+              },
+              color: Theme.of(context).primaryColor,
+              child: Text(
+                "Add Funds",
+                style: Theme.of(context).accentTextTheme.bodyText2,
+              )),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/routes/podcast/boost.dart
+++ b/lib/routes/podcast/boost.dart
@@ -1,18 +1,27 @@
+import 'package:breez/bloc/user_profile/breez_user_model.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class BoostWidget extends StatefulWidget {
-  final List amountList;
-  final ValueChanged<String> onBoost;
+  final BreezUserModel userModel;
+  final List boostAmountList;
+  final ValueChanged<int> onBoost;
 
-  BoostWidget({this.amountList, this.onBoost});
+  BoostWidget({this.userModel, this.boostAmountList, this.onBoost});
 
   @override
   _BoostWidgetState createState() => _BoostWidgetState();
 }
 
 class _BoostWidgetState extends State<BoostWidget> {
-  int selectedBoostIndex = 3;
+  int selectedBoostIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    selectedBoostIndex =
+        widget.boostAmountList.indexOf(widget.userModel.preferredBoostValue);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -21,34 +30,36 @@ class _BoostWidgetState extends State<BoostWidget> {
         SizedBox(
           width: 48,
           child: FlatButton(
-            padding: EdgeInsets.zero,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                Padding(
-                  padding: EdgeInsets.zero,
-                  child: ImageIcon(
-                    AssetImage("src/icon/boost.png"),
-                    size: 24,
-                    color: Theme.of(context).appBarTheme.actionsIconTheme.color,
-                  ),
-                ),
-                Padding(
-                  padding: EdgeInsets.zero,
-                  child: Text(
-                    "Boost!",
-                    style: TextStyle(
-                      fontSize: 12.0,
-                      fontWeight: FontWeight.normal,
-                      color: Theme.of(context).buttonColor,
+              padding: EdgeInsets.zero,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  Padding(
+                    padding: EdgeInsets.zero,
+                    child: ImageIcon(
+                      AssetImage("src/icon/boost.png"),
+                      size: 24,
+                      color:
+                          Theme.of(context).appBarTheme.actionsIconTheme.color,
                     ),
                   ),
-                ),
-              ],
-            ),
-            onPressed: () =>
-                widget.onBoost(widget.amountList[selectedBoostIndex]),
-          ),
+                  Padding(
+                    padding: EdgeInsets.zero,
+                    child: Text(
+                      "Boost!",
+                      style: TextStyle(
+                        fontSize: 12.0,
+                        fontWeight: FontWeight.normal,
+                        color: Theme.of(context).buttonColor,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              onPressed: () {
+                widget.onBoost(
+                    widget.boostAmountList.elementAt(selectedBoostIndex));
+              }),
         ),
         IconButton(
           icon: Icon(
@@ -78,7 +89,9 @@ class _BoostWidgetState extends State<BoostWidget> {
               child: Padding(
                 padding: EdgeInsets.zero,
                 child: Text(
-                  widget.amountList[selectedBoostIndex],
+                  widget.boostAmountList
+                      .elementAt(selectedBoostIndex)
+                      .toString(),
                   textAlign: TextAlign.center,
                   style: TextStyle(
                     fontSize: 12.0,
@@ -105,8 +118,8 @@ class _BoostWidgetState extends State<BoostWidget> {
           ),
           onPressed: () {
             setState(() {
-              (selectedBoostIndex == widget.amountList.length - 1)
-                  ? selectedBoostIndex = widget.amountList.length - 1
+              (selectedBoostIndex == widget.boostAmountList.length - 1)
+                  ? selectedBoostIndex = widget.boostAmountList.length - 1
                   : selectedBoostIndex++;
             });
           },

--- a/lib/routes/podcast/boost.dart
+++ b/lib/routes/podcast/boost.dart
@@ -1,6 +1,7 @@
 import 'package:breez/bloc/user_profile/breez_user_model.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 class BoostWidget extends StatefulWidget {
   final BreezUserModel userModel;
@@ -89,9 +90,8 @@ class _BoostWidgetState extends State<BoostWidget> {
               child: Padding(
                 padding: EdgeInsets.zero,
                 child: Text(
-                  widget.boostAmountList
-                      .elementAt(selectedBoostIndex)
-                      .toString(),
+                  NumberFormat.compact().format(
+                      widget.boostAmountList.elementAt(selectedBoostIndex)),
                   textAlign: TextAlign.center,
                   style: TextStyle(
                     fontSize: 12.0,

--- a/lib/routes/podcast/payment_adjuster.dart
+++ b/lib/routes/podcast/payment_adjuster.dart
@@ -1,17 +1,26 @@
+import 'package:breez/bloc/user_profile/breez_user_model.dart';
 import 'package:flutter/material.dart';
 
 class PaymentAdjuster extends StatefulWidget {
+  final BreezUserModel userModel;
   final List satsPerMinuteList;
-  final ValueChanged<String> onChanged;
+  final ValueChanged<int> onChanged;
 
-  PaymentAdjuster({this.satsPerMinuteList, this.onChanged});
+  PaymentAdjuster({this.userModel, this.satsPerMinuteList, this.onChanged});
 
   @override
   _PaymentAdjusterState createState() => _PaymentAdjusterState();
 }
 
 class _PaymentAdjusterState extends State<PaymentAdjuster> {
-  int selectedSatsPerMinuteIndex = 3;
+  int selectedSatsPerMinuteIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    selectedSatsPerMinuteIndex = widget.satsPerMinuteList
+        .indexOf(widget.userModel.preferredSatsPerMinValue);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -28,7 +37,8 @@ class _PaymentAdjusterState extends State<PaymentAdjuster> {
               (selectedSatsPerMinuteIndex == 0)
                   ? selectedSatsPerMinuteIndex = 0
                   : selectedSatsPerMinuteIndex--;
-              widget.onChanged(widget.satsPerMinuteList[selectedSatsPerMinuteIndex]);
+              widget.onChanged(widget.satsPerMinuteList
+                  .elementAt(selectedSatsPerMinuteIndex));
             });
           },
           padding: EdgeInsets.zero,
@@ -44,7 +54,9 @@ class _PaymentAdjusterState extends State<PaymentAdjuster> {
           child: Padding(
             padding: EdgeInsets.zero,
             child: Text(
-              widget.satsPerMinuteList[selectedSatsPerMinuteIndex],
+              widget.satsPerMinuteList
+                  .elementAt(selectedSatsPerMinuteIndex)
+                  .toString(),
               textAlign: TextAlign.center,
               style: TextStyle(
                 fontSize: 12.0,
@@ -95,10 +107,13 @@ class _PaymentAdjusterState extends State<PaymentAdjuster> {
           ),
           onPressed: () {
             setState(() {
-              (selectedSatsPerMinuteIndex == widget.satsPerMinuteList.length - 1)
-                  ? selectedSatsPerMinuteIndex = widget.satsPerMinuteList.length - 1
+              (selectedSatsPerMinuteIndex ==
+                      widget.satsPerMinuteList.length - 1)
+                  ? selectedSatsPerMinuteIndex =
+                      widget.satsPerMinuteList.length - 1
                   : selectedSatsPerMinuteIndex++;
-              widget.onChanged(widget.satsPerMinuteList[selectedSatsPerMinuteIndex]);
+              widget.onChanged(widget.satsPerMinuteList
+                  .elementAt(selectedSatsPerMinuteIndex));
             });
           },
           padding: EdgeInsets.zero,

--- a/lib/routes/podcast/payment_adjuster.dart
+++ b/lib/routes/podcast/payment_adjuster.dart
@@ -1,5 +1,6 @@
 import 'package:breez/bloc/user_profile/breez_user_model.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 class PaymentAdjuster extends StatefulWidget {
   final BreezUserModel userModel;
@@ -54,9 +55,8 @@ class _PaymentAdjusterState extends State<PaymentAdjuster> {
           child: Padding(
             padding: EdgeInsets.zero,
             child: Text(
-              widget.satsPerMinuteList
-                  .elementAt(selectedSatsPerMinuteIndex)
-                  .toString(),
+              NumberFormat.compact().format(widget.satsPerMinuteList
+                  .elementAt(selectedSatsPerMinuteIndex)),
               textAlign: TextAlign.center,
               style: TextStyle(
                 fontSize: 12.0,

--- a/lib/routes/podcast/payment_adjustment.dart
+++ b/lib/routes/podcast/payment_adjustment.dart
@@ -2,10 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:breez/bloc/blocs_provider.dart';
 import 'package:breez/bloc/podcast_payments/actions.dart';
+import 'package:breez/bloc/podcast_payments/payment_options.dart';
 import 'package:breez/bloc/podcast_payments/podcast_payments_bloc.dart';
+import 'package:breez/bloc/user_profile/breez_user_model.dart';
+import 'package:breez/bloc/user_profile/user_actions.dart';
+import 'package:breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:breez/routes/podcast/boost.dart';
 import 'package:breez/routes/podcast/payment_adjuster.dart';
+import 'package:breez/widgets/loader.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -21,55 +27,58 @@ class PaymentAdjustment extends StatefulWidget {
 }
 
 class PaymentAdjustmentState extends State<PaymentAdjustment> {
-  Map<int, String> boostAmountMap = {
-    100: '100',
-    500: '500',
-    1000: '1K',
-    5000: '5K',
-    10000: '10K',
-    50000: '50K',
-  };
-
-  Map<int, String> satsPerMinuteIntervalsMap = {
-    0: '0',
-    10: '10',
-    25: '25',
-    50: '50',
-    100: '100',
-    250: '250',
-    500: '500',
-    1000: '1K',
-  };
-
   @override
   Widget build(BuildContext context) {
     final paymentsBloc = Provider.of<PodcastPaymentsBloc>(context);
+    final userProfileBloc = AppBlocsProvider.of<UserProfileBloc>(context);
 
-    return Padding(
-      padding: EdgeInsets.symmetric(
-        horizontal: 32.0,
-        vertical: 4.0,
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: <Widget>[
-          BoostWidget(
-            amountList: boostAmountMap.values.toList(),
-            onBoost: (String value) {
-              int boostAmount = boostAmountMap.keys
-                  .firstWhere((element) => boostAmountMap[element] == value);
-              paymentsBloc.actionsSink.add(PayBoost(boostAmount));
-            },
-          ),
-          PaymentAdjuster(
-              satsPerMinuteList: satsPerMinuteIntervalsMap.values.toList(),
-              onChanged: (String value) {
-                int satsPerMinute = satsPerMinuteIntervalsMap.keys.firstWhere(
-                    (element) => satsPerMinuteIntervalsMap[element] == value);
-                paymentsBloc.actionsSink.add(AdjustAmount(satsPerMinute));
-              }),
-        ],
-      ),
-    );
+    return StreamBuilder<PaymentOptions>(
+        stream: paymentsBloc.paymentOptionsStream,
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return Center(child: Loader());
+          }
+
+          var paymentOptions = snapshot.data;
+
+          return StreamBuilder<BreezUserModel>(
+              stream: userProfileBloc.userStream,
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) {
+                  return Center(child: Loader());
+                }
+                var userModel = snapshot.data;
+                return Padding(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: 32.0,
+                    vertical: 4.0,
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: <Widget>[
+                      BoostWidget(
+                        userModel: userModel,
+                        boostAmountList: paymentOptions.boostAmountList,
+                        onBoost: (int boostAmount) {
+                          paymentsBloc.actionsSink.add(PayBoost(boostAmount));
+                          userProfileBloc.userActionsSink
+                              .add(SetBoostAmount(boostAmount));
+                        },
+                      ),
+                      PaymentAdjuster(
+                          userModel: userModel,
+                          satsPerMinuteList:
+                              paymentOptions.satsPerMinuteIntervalsList,
+                          onChanged: (int satsPerMinute) {
+                            paymentsBloc.actionsSink
+                                .add(AdjustAmount(satsPerMinute));
+                            userProfileBloc.userActionsSink
+                                .add(SetSatsPerMinAmount(satsPerMinute));
+                          }),
+                    ],
+                  ),
+                );
+              });
+        });
   }
 }

--- a/lib/routes/podcast/podcast_page.dart
+++ b/lib/routes/podcast/podcast_page.dart
@@ -172,7 +172,7 @@ class NowPlayingTransport extends StatelessWidget {
         // 50 is default sats/min value. We will later persist users sats/min selection and use it here.
         // We'll also show add funds message if user tries to boost and has no balance
         if (snapshot.data.balance < 50) {
-          widgets.add(AddFundsMessage());
+          widgets.add(AddFundsMessage(accountModel:snapshot.data));
           widgets.add(Divider(height: 0.0));
         }
         widgets.add(PlayerPositionControls());

--- a/lib/user_app.dart
+++ b/lib/user_app.dart
@@ -195,8 +195,10 @@ class UserApp extends StatelessWidget {
                                       );
                                     case '/deposit_btc_address':
                                       return FadeInRoute(
-                                        builder: (_) => DepositToBTCAddressPage(
-                                            accountBloc),
+                                        builder: (_) => withBreezTheme(
+                                          context,
+                                          DepositToBTCAddressPage(accountBloc),
+                                        ),
                                         settings: settings,
                                       );
                                     case '/buy_bitcoin':

--- a/lib/user_app.dart
+++ b/lib/user_app.dart
@@ -229,7 +229,10 @@ class UserApp extends StatelessWidget {
                                       );
                                     case '/create_invoice':
                                       return FadeInRoute(
-                                        builder: (_) => CreateInvoicePage(),
+                                        builder: (_) => withBreezTheme(
+                                          context,
+                                          CreateInvoicePage(),
+                                        ),
                                         settings: settings,
                                       );
                                     case '/fiat_currency':


### PR DESCRIPTION
This PR addresses [BU-285](https://breeztech.atlassian.net/browse/BU-285) and it's subtask [BU-296](https://breeztech.atlassian.net/browse/BU-296)

When the user has low balance, we display a message on top of player controls with a call to action button for users to add funds to their wallet. Pressing this button opens receive options much like on Balance modes, home page. _The routes to these options are now rendered with breez theme._


<img src="https://user-images.githubusercontent.com/4012752/108905694-12740300-7631-11eb-9d29-9e8edb916d8d.jpg" width="256">

 - Sats per minute and boost amount intervals are moved to PaymentOptions.
- Users podcast payment preferences now persist between different app sessions.