### PR TITLE
Add ability to add custom boost & sats per min amounts

### DIFF
--- a/lib/bloc/podcast_payments/payment_options.dart
+++ b/lib/bloc/podcast_payments/payment_options.dart
@@ -49,7 +49,10 @@ class PaymentOptions {
     List boostAmountList = presetBoostAmountsList;
     if (customBoostValue != null) boostAmountList.add(customBoostValue);
     boostAmountList.sort();
-    return boostAmountList;
+    // short-hand for toSet().toList() which removes duplicates
+    return [
+      ...{...boostAmountList}
+    ];
   }
 
   List get presetSatsPerMinuteAmountsList =>
@@ -60,6 +63,9 @@ class PaymentOptions {
     if (customSatsPerMinValue != null)
       satsPerMinuteIntervalsList.add(customSatsPerMinValue);
     satsPerMinuteIntervalsList.sort();
-    return satsPerMinuteIntervalsList;
+    // short-hand for toSet().toList() which removes duplicates
+    return [
+      ...{...satsPerMinuteIntervalsList}
+    ];
   }
 }

--- a/lib/bloc/podcast_payments/payment_options.dart
+++ b/lib/bloc/podcast_payments/payment_options.dart
@@ -1,5 +1,65 @@
 class PaymentOptions {
-  List get boostAmountList => [100, 500, 1000, 5000, 10000, 50000];
+  final int preferredBoostValue;
+  final int preferredSatsPerMinValue;
+  final int customBoostValue;
+  final int customSatsPerMinValue;
 
-  List get satsPerMinuteIntervalsList => [0, 10, 25, 50, 100, 250, 500, 1000];
+  PaymentOptions._({
+    this.preferredBoostValue = 5000,
+    this.preferredSatsPerMinValue = 0,
+    this.customBoostValue,
+    this.customSatsPerMinValue,
+  });
+
+  PaymentOptions.initial()
+      : this._(preferredBoostValue: 5000, preferredSatsPerMinValue: 0);
+
+  PaymentOptions copyWith({
+    int preferredBoostValue,
+    int preferredSatsPerMinValue,
+    int customBoostValue,
+    int customSatsPerMinValue,
+  }) {
+    return PaymentOptions._(
+      preferredBoostValue: preferredBoostValue ?? this.preferredBoostValue,
+      preferredSatsPerMinValue:
+          preferredSatsPerMinValue ?? this.preferredSatsPerMinValue,
+      customBoostValue: customBoostValue ?? this.customBoostValue,
+      customSatsPerMinValue:
+          customSatsPerMinValue ?? this.customSatsPerMinValue,
+    );
+  }
+
+  PaymentOptions.fromJson(Map<String, dynamic> json)
+      : preferredBoostValue = json['preferredBoostValue'] ?? 5000,
+        preferredSatsPerMinValue = json['preferredSatsPerMinValue'] ?? 0,
+        customBoostValue = json['customBoostValue'],
+        customSatsPerMinValue = json['customSatsPerMinValue'];
+
+  Map<String, dynamic> toJson() => {
+        'preferredBoostValue': preferredBoostValue,
+        'preferredSatsPerMinValue': preferredSatsPerMinValue,
+        'customBoostValue': customBoostValue,
+        'customSatsPerMinValue': customSatsPerMinValue,
+      };
+
+  List get presetBoostAmountsList => [100, 500, 1000, 5000, 10000, 50000];
+
+  List get boostAmountList {
+    List boostAmountList = presetBoostAmountsList;
+    if (customBoostValue != null) boostAmountList.add(customBoostValue);
+    boostAmountList.sort();
+    return boostAmountList;
+  }
+
+  List get presetSatsPerMinuteAmountsList =>
+      [0, 10, 25, 50, 100, 250, 500, 1000];
+
+  List get satsPerMinuteIntervalsList {
+    List satsPerMinuteIntervalsList = presetSatsPerMinuteAmountsList;
+    if (customSatsPerMinValue != null)
+      satsPerMinuteIntervalsList.add(customSatsPerMinValue);
+    satsPerMinuteIntervalsList.sort();
+    return satsPerMinuteIntervalsList;
+  }
 }

--- a/lib/bloc/user_profile/breez_user_model.dart
+++ b/lib/bloc/user_profile/breez_user_model.dart
@@ -1,3 +1,4 @@
+import 'package:breez/bloc/podcast_payments/payment_options.dart';
 import 'package:breez/bloc/user_profile/currency.dart';
 import 'package:breez/bloc/user_profile/security_model.dart';
 
@@ -26,8 +27,7 @@ class BreezUserModel {
   final String posCurrencyShortName;
   final List<String> preferredCurrencies;
   final AppMode appMode;
-  final int preferredBoostValue;
-  final int preferredSatsPerMinValue;
+  final PaymentOptions paymentOptions;
   final SeenTutorials seenTutorials;
 
   BreezUserModel._(
@@ -50,8 +50,7 @@ class BreezUserModel {
     this.posCurrencyShortName = "SAT",
     this.preferredCurrencies,
     this.appMode = AppMode.balance,
-    this.preferredBoostValue = 5000,
-    this.preferredSatsPerMinValue = 0,
+    this.paymentOptions,
     this.seenTutorials,
   });
 
@@ -75,8 +74,7 @@ class BreezUserModel {
     String posCurrencyShortName,
     List<String> preferredCurrencies,
     AppMode appMode,
-    int preferredBoostValue,
-    int preferredSatsPerMinValue,
+    PaymentOptions paymentOptions,
     SeenTutorials seenTutorials,
   }) {
     return BreezUserModel._(
@@ -101,9 +99,7 @@ class BreezUserModel {
       posCurrencyShortName: posCurrencyShortName ?? this.posCurrencyShortName,
       preferredCurrencies: preferredCurrencies ?? this.preferredCurrencies,
       appMode: appMode ?? this.appMode,
-      preferredBoostValue: preferredBoostValue ?? this.preferredBoostValue,
-      preferredSatsPerMinValue:
-          preferredSatsPerMinValue ?? this.preferredSatsPerMinValue,
+      paymentOptions: paymentOptions ?? this.paymentOptions,
       seenTutorials: seenTutorials ?? this.seenTutorials,
     );
   }
@@ -150,8 +146,9 @@ class BreezUserModel {
             (json['preferredCurrencies'] as List<dynamic>)?.cast<String>() ??
                 <String>['USD', 'EUR', 'GBP', 'JPY'],
         appMode = AppMode.values[json["appMode"] ?? 0],
-        preferredBoostValue = json["preferredBoostValue"] ?? 5000,
-        preferredSatsPerMinValue = json["preferredSatsPerMinValue"] ?? 0,
+        paymentOptions = json["paymentOptions"] == null
+            ? PaymentOptions.initial()
+            : PaymentOptions.fromJson(json["paymentOptions"]),
         seenTutorials = json["seenTutorials"] == null
             ? SeenTutorials.initial()
             : SeenTutorials.fromJson(json["seenTutorials"]);
@@ -175,8 +172,7 @@ class BreezUserModel {
         'businessAddress': businessAddress,
         'preferredCurrencies': preferredCurrencies,
         'appMode': appMode.index,
-        'preferredBoostValue': preferredBoostValue,
-        'preferredSatsPerMinValue': preferredSatsPerMinValue,
+        'paymentOptions': paymentOptions,
         'seenTutorials': seenTutorials,
       };
 }

--- a/lib/bloc/user_profile/user_actions.dart
+++ b/lib/bloc/user_profile/user_actions.dart
@@ -95,6 +95,18 @@ class SetSatsPerMinAmount extends AsyncAction {
   SetSatsPerMinAmount(this.satsPerMin);
 }
 
+class SetCustomBoostAmount extends AsyncAction {
+  final int boostAmount;
+
+  SetCustomBoostAmount(this.boostAmount);
+}
+
+class SetCustomSatsPerMinAmount extends AsyncAction {
+  final int satsPerMin;
+
+  SetCustomSatsPerMinAmount(this.satsPerMin);
+}
+
 class SetSeenPodcastTutorial extends AsyncAction {
   final bool seen;
 

--- a/lib/bloc/user_profile/user_actions.dart
+++ b/lib/bloc/user_profile/user_actions.dart
@@ -1,4 +1,5 @@
 import 'package:breez/bloc/async_action.dart';
+import 'package:breez/bloc/podcast_payments/payment_options.dart';
 
 import 'breez_user_model.dart';
 import 'security_model.dart';
@@ -83,28 +84,10 @@ class SetPOSCurrency extends AsyncAction {
   SetPOSCurrency(this.shortName);
 }
 
-class SetBoostAmount extends AsyncAction {
-  final int boostAmount;
+class SetPaymentOptions extends AsyncAction {
+  final PaymentOptions paymentOptions;
 
-  SetBoostAmount(this.boostAmount);
-}
-
-class SetSatsPerMinAmount extends AsyncAction {
-  final int satsPerMin;
-
-  SetSatsPerMinAmount(this.satsPerMin);
-}
-
-class SetCustomBoostAmount extends AsyncAction {
-  final int boostAmount;
-
-  SetCustomBoostAmount(this.boostAmount);
-}
-
-class SetCustomSatsPerMinAmount extends AsyncAction {
-  final int satsPerMin;
-
-  SetCustomSatsPerMinAmount(this.satsPerMin);
+  SetPaymentOptions(this.paymentOptions);
 }
 
 class SetSeenPodcastTutorial extends AsyncAction {

--- a/lib/bloc/user_profile/user_profile_bloc.dart
+++ b/lib/bloc/user_profile/user_profile_bloc.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:breez/bloc/async_action.dart';
+import 'package:breez/bloc/podcast_payments/payment_options.dart';
 import 'package:breez/bloc/user_profile/breez_user_model.dart';
 import 'package:breez/bloc/user_profile/currency.dart';
 import 'package:breez/bloc/user_profile/default_profile_generator.dart';
@@ -87,6 +88,8 @@ class UserProfileBloc {
       SetPOSCurrency: _setPOSCurrency,
       SetBoostAmount: _setBoostAmount,
       SetSatsPerMinAmount: _setSatsPerMinAmount,
+      SetCustomBoostAmount: _setCustomBoostAmount,
+      SetCustomSatsPerMinAmount: _setCustomSatsPerMinAmount,
       SetSeenPodcastTutorial: _setSeenPodcastTutorial,
       SetSeenPaymentStripTutorial: _setSeenPaymentStripTutorial,
     };
@@ -197,14 +200,63 @@ class UserProfileBloc {
   }
 
   Future _setBoostAmount(SetBoostAmount action) async {
-    _saveChanges(await _preferences,
-        _currentUser.copyWith(preferredBoostValue: action.boostAmount));
+    _saveChanges(
+        await _preferences,
+        _currentUser.copyWith(
+            paymentOptions: _currentUser.paymentOptions
+                .copyWith(preferredBoostValue: action.boostAmount)));
     action.resolve(action.boostAmount);
   }
 
   Future _setSatsPerMinAmount(SetSatsPerMinAmount action) async {
-    _saveChanges(await _preferences,
-        _currentUser.copyWith(preferredSatsPerMinValue: action.satsPerMin));
+    _saveChanges(
+        await _preferences,
+        _currentUser.copyWith(
+            paymentOptions: _currentUser.paymentOptions
+                .copyWith(preferredSatsPerMinValue: action.satsPerMin)));
+    action.resolve(action.satsPerMin);
+  }
+
+  Future _setCustomBoostAmount(SetCustomBoostAmount action) async {
+    if (!_currentUser.paymentOptions.presetBoostAmountsList
+        .contains(action.boostAmount)) {
+      _saveChanges(
+          await _preferences,
+          _currentUser.copyWith(
+              paymentOptions: _currentUser.paymentOptions
+                  .copyWith(customBoostValue: action.boostAmount)));
+    } else {
+      _saveChanges(
+          await _preferences,
+          _currentUser.copyWith(
+              paymentOptions: PaymentOptions.initial().copyWith(
+                  preferredBoostValue:
+                      _currentUser.paymentOptions.preferredBoostValue,
+                  preferredSatsPerMinValue:
+                      _currentUser.paymentOptions.preferredSatsPerMinValue)));
+    }
+
+    action.resolve(action.boostAmount);
+  }
+
+  Future _setCustomSatsPerMinAmount(SetCustomSatsPerMinAmount action) async {
+    if (!_currentUser.paymentOptions.presetSatsPerMinuteAmountsList
+        .contains(action.satsPerMin)) {
+      _saveChanges(
+          await _preferences,
+          _currentUser.copyWith(
+              paymentOptions: _currentUser.paymentOptions
+                  .copyWith(customSatsPerMinValue: action.satsPerMin)));
+    } else {
+      _saveChanges(
+          await _preferences,
+          _currentUser.copyWith(
+              paymentOptions: PaymentOptions.initial().copyWith(
+                  preferredBoostValue:
+                      _currentUser.paymentOptions.preferredBoostValue,
+                  preferredSatsPerMinValue:
+                      _currentUser.paymentOptions.preferredSatsPerMinValue)));
+    }
     action.resolve(action.satsPerMin);
   }
 

--- a/lib/bloc/user_profile/user_profile_bloc.dart
+++ b/lib/bloc/user_profile/user_profile_bloc.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:breez/bloc/async_action.dart';
-import 'package:breez/bloc/podcast_payments/payment_options.dart';
 import 'package:breez/bloc/user_profile/breez_user_model.dart';
 import 'package:breez/bloc/user_profile/currency.dart';
 import 'package:breez/bloc/user_profile/default_profile_generator.dart';
@@ -86,10 +85,7 @@ class UserProfileBloc {
       VerifyAdminPassword: _verifyAdminPassword,
       UploadProfilePicture: _uploadProfilePicture,
       SetPOSCurrency: _setPOSCurrency,
-      SetBoostAmount: _setBoostAmount,
-      SetSatsPerMinAmount: _setSatsPerMinAmount,
-      SetCustomBoostAmount: _setCustomBoostAmount,
-      SetCustomSatsPerMinAmount: _setCustomSatsPerMinAmount,
+      SetPaymentOptions: _setPaymentOptions,
       SetSeenPodcastTutorial: _setSeenPodcastTutorial,
       SetSeenPaymentStripTutorial: _setSeenPaymentStripTutorial,
     };
@@ -199,65 +195,10 @@ class UserProfileBloc {
     action.resolve(action.shortName);
   }
 
-  Future _setBoostAmount(SetBoostAmount action) async {
-    _saveChanges(
-        await _preferences,
-        _currentUser.copyWith(
-            paymentOptions: _currentUser.paymentOptions
-                .copyWith(preferredBoostValue: action.boostAmount)));
-    action.resolve(action.boostAmount);
-  }
-
-  Future _setSatsPerMinAmount(SetSatsPerMinAmount action) async {
-    _saveChanges(
-        await _preferences,
-        _currentUser.copyWith(
-            paymentOptions: _currentUser.paymentOptions
-                .copyWith(preferredSatsPerMinValue: action.satsPerMin)));
-    action.resolve(action.satsPerMin);
-  }
-
-  Future _setCustomBoostAmount(SetCustomBoostAmount action) async {
-    if (!_currentUser.paymentOptions.presetBoostAmountsList
-        .contains(action.boostAmount)) {
-      _saveChanges(
-          await _preferences,
-          _currentUser.copyWith(
-              paymentOptions: _currentUser.paymentOptions
-                  .copyWith(customBoostValue: action.boostAmount)));
-    } else {
-      _saveChanges(
-          await _preferences,
-          _currentUser.copyWith(
-              paymentOptions: PaymentOptions.initial().copyWith(
-                  preferredBoostValue:
-                      _currentUser.paymentOptions.preferredBoostValue,
-                  preferredSatsPerMinValue:
-                      _currentUser.paymentOptions.preferredSatsPerMinValue)));
-    }
-
-    action.resolve(action.boostAmount);
-  }
-
-  Future _setCustomSatsPerMinAmount(SetCustomSatsPerMinAmount action) async {
-    if (!_currentUser.paymentOptions.presetSatsPerMinuteAmountsList
-        .contains(action.satsPerMin)) {
-      _saveChanges(
-          await _preferences,
-          _currentUser.copyWith(
-              paymentOptions: _currentUser.paymentOptions
-                  .copyWith(customSatsPerMinValue: action.satsPerMin)));
-    } else {
-      _saveChanges(
-          await _preferences,
-          _currentUser.copyWith(
-              paymentOptions: PaymentOptions.initial().copyWith(
-                  preferredBoostValue:
-                      _currentUser.paymentOptions.preferredBoostValue,
-                  preferredSatsPerMinValue:
-                      _currentUser.paymentOptions.preferredSatsPerMinValue)));
-    }
-    action.resolve(action.satsPerMin);
+  Future _setPaymentOptions(SetPaymentOptions action) async {
+    _saveChanges(await _preferences,
+        _currentUser.copyWith(paymentOptions: action.paymentOptions));
+    action.resolve(action.paymentOptions);
   }
 
   Future _uploadProfilePicture(UploadProfilePicture action) async {

--- a/lib/routes/podcast/boost.dart
+++ b/lib/routes/podcast/boost.dart
@@ -141,7 +141,8 @@ class _BoostWidgetState extends State<BoostWidget> {
                               builder: (c) => CustomAmountDialog(
                                 widget
                                     .userModel.paymentOptions.customBoostValue,
-                                widget.userModel.paymentOptions.boostAmountList,
+                                widget.userModel.paymentOptions
+                                    .presetBoostAmountsList,
                                 (int boostAmount) {
                                   userBloc.userActionsSink.add(
                                       SetPaymentOptions(widget

--- a/lib/routes/podcast/boost.dart
+++ b/lib/routes/podcast/boost.dart
@@ -16,8 +16,10 @@ import 'custom_amount_dialog.dart';
 class BoostWidget extends StatefulWidget {
   final BreezUserModel userModel;
   final ValueChanged<int> onBoost;
+  final ValueChanged<int> onChanged;
 
-  BoostWidget({Key key, this.userModel, this.onBoost}) : super(key: key);
+  BoostWidget({Key key, this.userModel, this.onBoost, this.onChanged})
+      : super(key: key);
 
   @override
   _BoostWidgetState createState() => _BoostWidgetState();
@@ -113,9 +115,7 @@ class _BoostWidgetState extends State<BoostWidget> {
                               child: InkWell(
                                 borderRadius: BorderRadius.circular(32),
                                 onTap: () {
-                                  userBloc.userActionsSink.add(
-                                    SetBoostAmount(_getPreviousAmount()),
-                                  );
+                                  widget.onChanged(_getPreviousAmount());
                                 },
                                 splashColor: Theme.of(context).splashColor,
                                 highlightColor: Colors.transparent,
@@ -143,11 +143,12 @@ class _BoostWidgetState extends State<BoostWidget> {
                                     .userModel.paymentOptions.customBoostValue,
                                 widget.userModel.paymentOptions.boostAmountList,
                                 (int boostAmount) {
-                                  userBloc.userActionsSink
-                                      .add(SetCustomBoostAmount(boostAmount));
                                   userBloc.userActionsSink.add(
-                                    SetBoostAmount(boostAmount),
-                                  );
+                                      SetPaymentOptions(widget
+                                          .userModel.paymentOptions
+                                          .copyWith(
+                                              preferredBoostValue: boostAmount,
+                                              customBoostValue: boostAmount)));
                                 },
                               ),
                             ),
@@ -206,9 +207,7 @@ class _BoostWidgetState extends State<BoostWidget> {
                                 child: InkWell(
                                   borderRadius: BorderRadius.circular(32),
                                   onTap: () {
-                                    userBloc.userActionsSink.add(
-                                      SetBoostAmount(_getNextAmount()),
-                                    );
+                                    widget.onChanged(_getNextAmount());
                                   },
                                   splashColor: Theme.of(context).splashColor,
                                   highlightColor: Colors.transparent,

--- a/lib/routes/podcast/boost.dart
+++ b/lib/routes/podcast/boost.dart
@@ -113,30 +113,9 @@ class _BoostWidgetState extends State<BoostWidget> {
                               child: InkWell(
                                 borderRadius: BorderRadius.circular(32),
                                 onTap: () {
-                                  if (widget
-                                      .userModel.paymentOptions.boostAmountList
-                                      .contains(widget.userModel.paymentOptions
-                                          .preferredBoostValue)) {
-                                    var nextIndex = (selectedIndex == 0)
-                                        ? selectedIndex
-                                        : selectedIndex - 1;
-                                    final nextAmount = widget.userModel
-                                        .paymentOptions.boostAmountList
-                                        .elementAt(nextIndex);
-                                    userBloc.userActionsSink.add(
-                                      SetBoostAmount(nextAmount),
-                                    );
-                                  } else {
-                                    userBloc.userActionsSink.add(
-                                      SetBoostAmount(
-                                        _getClosestBoostAmount(
-                                            widget.userModel.paymentOptions
-                                                .preferredBoostValue,
-                                            widget.userModel.paymentOptions
-                                                .boostAmountList),
-                                      ),
-                                    );
-                                  }
+                                  userBloc.userActionsSink.add(
+                                    SetBoostAmount(_getPreviousAmount()),
+                                  );
                                 },
                                 splashColor: Theme.of(context).splashColor,
                                 highlightColor: Colors.transparent,
@@ -227,40 +206,9 @@ class _BoostWidgetState extends State<BoostWidget> {
                                 child: InkWell(
                                   borderRadius: BorderRadius.circular(32),
                                   onTap: () {
-                                    print("LOL");
-                                    print(widget.userModel.paymentOptions
-                                        .boostAmountList);
-                                    if (widget.userModel.paymentOptions
-                                        .boostAmountList
-                                        .contains(widget
-                                            .userModel
-                                            .paymentOptions
-                                            .preferredBoostValue)) {
-                                      var nextIndex = (selectedIndex >=
-                                              widget.userModel.paymentOptions
-                                                      .boostAmountList.length -
-                                                  1)
-                                          ? selectedIndex
-                                          : selectedIndex + 1;
-                                      final nextAmount = widget.userModel
-                                          .paymentOptions.boostAmountList
-                                          .elementAt(nextIndex);
-                                      userBloc.userActionsSink.add(
-                                        SetBoostAmount(nextAmount),
-                                      );
-                                    } else {
-                                      userBloc.userActionsSink.add(
-                                        SetBoostAmount(
-                                          _getClosestBoostAmount(
-                                            widget.userModel.paymentOptions
-                                                .preferredBoostValue,
-                                            widget.userModel.paymentOptions
-                                                .boostAmountList,
-                                            bigger: true,
-                                          ),
-                                        ),
-                                      );
-                                    }
+                                    userBloc.userActionsSink.add(
+                                      SetBoostAmount(_getNextAmount()),
+                                    );
                                   },
                                   splashColor: Theme.of(context).splashColor,
                                   highlightColor: Colors.transparent,
@@ -287,14 +235,23 @@ class _BoostWidgetState extends State<BoostWidget> {
         });
   }
 
-  static int _getClosestBoostAmount(int customAmount, List presetAmountList,
-      {bool bigger = false}) {
+  int _getPreviousAmount() {
+    var currentAmount = widget.userModel.paymentOptions.preferredBoostValue;
+    var amountList = widget.userModel.paymentOptions.boostAmountList;
     try {
-      return presetAmountList[presetAmountList
-              .indexWhere((presetAmount) => customAmount < presetAmount) -
-          (bigger ? 0 : 1)];
+      return amountList[amountList.indexOf(currentAmount) - 1];
     } catch (RangeError) {
-      return presetAmountList.last;
+      return amountList.first;
+    }
+  }
+
+  int _getNextAmount() {
+    var currentAmount = widget.userModel.paymentOptions.preferredBoostValue;
+    var amountList = widget.userModel.paymentOptions.boostAmountList;
+    try {
+      return amountList[amountList.indexOf(currentAmount) + 1];
+    } catch (RangeError) {
+      return amountList.last;
     }
   }
 }

--- a/lib/routes/podcast/boost.dart
+++ b/lib/routes/podcast/boost.dart
@@ -11,6 +11,8 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+import 'custom_amount_dialog.dart';
+
 class BoostWidget extends StatefulWidget {
   final BreezUserModel userModel;
   final List boostAmountList;
@@ -55,13 +57,14 @@ class _BoostWidgetState extends State<BoostWidget> {
                           padding:
                               EdgeInsets.symmetric(vertical: 8, horizontal: 8),
                           shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(6.0),
-                              side: BorderSide(
-                                  color: Theme.of(context).brightness ==
-                                          Brightness.light
-                                      ? Color(0xFF0085fb)
-                                      : Colors.white70,
-                                  width: 1.6)),
+                            borderRadius: BorderRadius.circular(6.0),
+                            side: BorderSide(
+                                color: Theme.of(context).brightness ==
+                                        Brightness.light
+                                    ? Color(0xFF0085fb)
+                                    : Colors.white70,
+                                width: 1.6),
+                          ),
                         ),
                         icon: ImageIcon(
                           AssetImage("src/icon/boost.png"),
@@ -97,7 +100,8 @@ class _BoostWidgetState extends State<BoostWidget> {
                             return;
                           }
                           widget.onBoost(
-                              widget.boostAmountList.elementAt(selectedIndex));
+                            widget.boostAmountList.elementAt(selectedIndex),
+                          );
                         },
                       ),
                     ),
@@ -111,119 +115,169 @@ class _BoostWidgetState extends State<BoostWidget> {
                             fit: StackFit.loose,
                             children: [
                               GestureDetector(
-                                  child: Container(
-                                      width: 32,
-                                      height: 64,
-                                      child: Material(
-                                        color: Colors.transparent,
-                                        borderRadius: BorderRadius.circular(32),
-                                        child: InkWell(
-                                          borderRadius:
-                                              BorderRadius.circular(32),
-                                          onTap: () {
-                                            var nextIndex = (selectedIndex == 0)
-                                                ? selectedIndex
-                                                : selectedIndex - 1;
-                                            final nextAmount = widget
-                                                .boostAmountList
-                                                .elementAt(nextIndex);
-                                            userBloc.userActionsSink.add(
-                                                SetBoostAmount(nextAmount));
-                                          },
-                                          splashColor:
-                                              Theme.of(context).splashColor,
-                                          highlightColor: Colors.transparent,
-                                          child: Icon(
-                                            Icons.remove_circle_outline,
-                                            size: 20,
-                                            color: Theme.of(context)
-                                                .appBarTheme
-                                                .actionsIconTheme
-                                                .color,
-                                          ),
-                                        ),
-                                      ))),
+                                child: Container(
+                                  width: 32,
+                                  height: 64,
+                                  child: Material(
+                                    color: Colors.transparent,
+                                    borderRadius: BorderRadius.circular(32),
+                                    child: InkWell(
+                                      borderRadius: BorderRadius.circular(32),
+                                      onTap: () {
+                                        if (widget.boostAmountList.contains(
+                                            widget.userModel
+                                                .preferredBoostValue)) {
+                                          var nextIndex = (selectedIndex == 0)
+                                              ? selectedIndex
+                                              : selectedIndex - 1;
+                                          final nextAmount = widget
+                                              .boostAmountList
+                                              .elementAt(nextIndex);
+                                          userBloc.userActionsSink.add(
+                                            SetBoostAmount(nextAmount),
+                                          );
+                                        } else {
+                                          userBloc.userActionsSink.add(
+                                            SetBoostAmount(
+                                              _getClosestBoostAmount(
+                                                  widget.userModel
+                                                      .preferredBoostValue,
+                                                  widget.boostAmountList),
+                                            ),
+                                          );
+                                        }
+                                      },
+                                      splashColor:
+                                          Theme.of(context).splashColor,
+                                      highlightColor: Colors.transparent,
+                                      child: Icon(
+                                        Icons.remove_circle_outline,
+                                        size: 20,
+                                        color: Theme.of(context)
+                                            .appBarTheme
+                                            .actionsIconTheme
+                                            .color,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
                               Positioned(
                                 left: 24,
                                 top: 16,
-                                child: SizedBox(
-                                  width: 42,
-                                  child: Column(
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.center,
-                                    children: [
-                                      Container(
-                                        width: 32,
-                                        height: 20,
-                                        child: AutoSizeText(
-                                          NumberFormat.compact().format(snapshot
-                                              .data.preferredBoostValue),
+                                child: GestureDetector(
+                                  onTap: () => showDialog(
+                                    useRootNavigator: true,
+                                    context: context,
+                                    builder: (c) => CustomAmountDialog(
+                                      widget.userModel.preferredBoostValue,
+                                      widget.boostAmountList,
+                                      (int boostAmount) {
+                                        userBloc.userActionsSink.add(
+                                          SetBoostAmount(boostAmount),
+                                        );
+                                      },
+                                    ),
+                                  ),
+                                  child: SizedBox(
+                                    width: 42,
+                                    child: Column(
+                                      mainAxisAlignment:
+                                          MainAxisAlignment.center,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.center,
+                                      children: [
+                                        Container(
+                                          width: 32,
+                                          height: 20,
+                                          child: AutoSizeText(
+                                            NumberFormat.compact().format(
+                                                snapshot
+                                                    .data.preferredBoostValue),
+                                            textAlign: TextAlign.center,
+                                            style: TextStyle(
+                                              fontSize: 14.3,
+                                              letterSpacing: 1,
+                                              fontWeight: FontWeight.w600,
+                                              height: 1.2,
+                                            ),
+                                            minFontSize: ((9) /
+                                                    MediaQuery.of(this.context)
+                                                        .textScaleFactor)
+                                                .floorToDouble(),
+                                            stepGranularity: 0.1,
+                                            maxLines: 1,
+                                          ),
+                                        ),
+                                        AutoSizeText(
+                                          "sats",
                                           textAlign: TextAlign.center,
                                           style: TextStyle(
-                                            fontSize: 14.3,
-                                            letterSpacing: 1,
-                                            fontWeight: FontWeight.w600,
-                                            height: 1.2,
-                                          ),
+                                              fontSize: 10, letterSpacing: 1),
                                           minFontSize:
                                               MinFontSize(context).minFontSize,
                                           stepGranularity: 0.1,
-                                          maxLines: 1,
-                                        ),
-                                      ),
-                                      AutoSizeText(
-                                        "sats",
-                                        textAlign: TextAlign.center,
-                                        style: TextStyle(
-                                            fontSize: 10, letterSpacing: 1),
-                                        minFontSize:
-                                            MinFontSize(context).minFontSize,
-                                        stepGranularity: 0.1,
-                                      )
-                                    ],
+                                        )
+                                      ],
+                                    ),
                                   ),
                                 ),
                               ),
                               Positioned(
                                 left: 60,
                                 child: GestureDetector(
-                                    child: Container(
-                                        width: 32,
-                                        height: 64,
-                                        child: Material(
-                                          color: Colors.transparent,
-                                          borderRadius:
-                                              BorderRadius.circular(32),
-                                          child: InkWell(
-                                            borderRadius:
-                                                BorderRadius.circular(32),
-                                            onTap: () {
-                                              var nextIndex = (selectedIndex >=
-                                                      widget.boostAmountList
-                                                              .length -
-                                                          1)
-                                                  ? selectedIndex
-                                                  : selectedIndex + 1;
-                                              final nextAmount = widget
-                                                  .boostAmountList
-                                                  .elementAt(nextIndex);
-                                              userBloc.userActionsSink.add(
-                                                  SetBoostAmount(nextAmount));
-                                            },
-                                            splashColor:
-                                                Theme.of(context).splashColor,
-                                            highlightColor: Colors.transparent,
-                                            child: Icon(
-                                              Icons.add_circle_outline,
-                                              size: 20,
-                                              color: Theme.of(context)
-                                                  .appBarTheme
-                                                  .actionsIconTheme
-                                                  .color,
-                                            ),
-                                          ),
-                                        ))),
+                                  child: Container(
+                                    width: 32,
+                                    height: 64,
+                                    child: Material(
+                                      color: Colors.transparent,
+                                      borderRadius: BorderRadius.circular(32),
+                                      child: InkWell(
+                                        borderRadius: BorderRadius.circular(32),
+                                        onTap: () {
+                                          if (widget.boostAmountList.contains(
+                                              widget.userModel
+                                                  .preferredBoostValue)) {
+                                            var nextIndex = (selectedIndex >=
+                                                    widget.boostAmountList
+                                                            .length -
+                                                        1)
+                                                ? selectedIndex
+                                                : selectedIndex + 1;
+                                            final nextAmount = widget
+                                                .boostAmountList
+                                                .elementAt(nextIndex);
+                                            userBloc.userActionsSink.add(
+                                              SetBoostAmount(nextAmount),
+                                            );
+                                          } else {
+                                            userBloc.userActionsSink.add(
+                                              SetBoostAmount(
+                                                _getClosestBoostAmount(
+                                                  widget.userModel
+                                                      .preferredBoostValue,
+                                                  widget.boostAmountList,
+                                                  bigger: true,
+                                                ),
+                                              ),
+                                            );
+                                          }
+                                        },
+                                        splashColor:
+                                            Theme.of(context).splashColor,
+                                        highlightColor: Colors.transparent,
+                                        child: Icon(
+                                          Icons.add_circle_outline,
+                                          size: 20,
+                                          color: Theme.of(context)
+                                              .appBarTheme
+                                              .actionsIconTheme
+                                              .color,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                ),
                               ),
                             ],
                           ),
@@ -234,5 +288,16 @@ class _BoostWidgetState extends State<BoostWidget> {
                 );
               });
         });
+  }
+
+  static int _getClosestBoostAmount(int customAmount, List presetAmountList,
+      {bool bigger = false}) {
+    try {
+      return presetAmountList[presetAmountList
+              .indexWhere((presetAmount) => customAmount < presetAmount) -
+          (bigger ? 0 : 1)];
+    } catch (RangeError) {
+      return presetAmountList.last;
+    }
   }
 }

--- a/lib/routes/podcast/boost.dart
+++ b/lib/routes/podcast/boost.dart
@@ -15,11 +15,9 @@ import 'custom_amount_dialog.dart';
 
 class BoostWidget extends StatefulWidget {
   final BreezUserModel userModel;
-  final List boostAmountList;
   final ValueChanged<int> onBoost;
 
-  BoostWidget({Key key, this.userModel, this.boostAmountList, this.onBoost})
-      : super(key: key);
+  BoostWidget({Key key, this.userModel, this.onBoost}) : super(key: key);
 
   @override
   _BoostWidgetState createState() => _BoostWidgetState();
@@ -30,263 +28,262 @@ class _BoostWidgetState extends State<BoostWidget> {
   Widget build(BuildContext context) {
     final userBloc = AppBlocsProvider.of<UserProfileBloc>(context);
     final accountBloc = AppBlocsProvider.of<AccountBloc>(context);
-    return StreamBuilder<BreezUserModel>(
-        stream: userBloc.userStream,
-        builder: (context, snapshot) {
-          if (snapshot.data == null) {
+
+    final selectedIndex = widget.userModel.paymentOptions.boostAmountList
+        .indexOf(widget.userModel.paymentOptions.preferredBoostValue);
+
+    return StreamBuilder<AccountModel>(
+        stream: accountBloc.accountStream,
+        builder: (context, acc) {
+          if (acc.data == null) {
             return SizedBox();
           }
-
-          final selectedIndex = widget.boostAmountList
-              .indexOf(widget.userModel.preferredBoostValue);
-
-          return StreamBuilder<AccountModel>(
-              stream: accountBloc.accountStream,
-              builder: (context, acc) {
-                if (acc.data == null) {
-                  return SizedBox();
-                }
-                return Row(
-                  mainAxisSize: MainAxisSize.max,
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Container(
-                      width: 88,
-                      child: TextButton.icon(
-                        style: TextButton.styleFrom(
-                          padding:
-                              EdgeInsets.symmetric(vertical: 8, horizontal: 8),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(6.0),
-                            side: BorderSide(
-                                color: Theme.of(context).brightness ==
-                                        Brightness.light
-                                    ? Color(0xFF0085fb)
-                                    : Colors.white70,
-                                width: 1.6),
-                          ),
-                        ),
-                        icon: ImageIcon(
-                          AssetImage("src/icon/boost.png"),
-                          size: 20,
-                          color: Theme.of(context)
-                              .appBarTheme
-                              .actionsIconTheme
-                              .color,
-                        ),
-                        label: Container(
-                          width: 44,
-                          child: AutoSizeText(
-                            "BOOST!",
-                            style: TextStyle(
-                              fontSize: 14,
-                              height: 1.2,
-                              letterSpacing: 0,
-                              fontWeight: FontWeight.w500,
-                              color: Theme.of(context).buttonColor,
-                            ),
-                            minFontSize: MinFontSize(context).minFontSize,
-                            stepGranularity: 0.1,
-                            maxLines: 1,
-                          ),
-                        ),
-                        onPressed: () {
-                          var boostAmount =
-                              widget.userModel.preferredBoostValue;
-                          if (acc.data.balance.toInt() <= boostAmount) {
-                            showFlushbar(context,
-                                message:
-                                    "You don't have enough funds to complete this payment.");
-                            return;
-                          }
-                          widget.onBoost(
-                            widget.boostAmountList.elementAt(selectedIndex),
-                          );
-                        },
-                      ),
+          return Row(
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Container(
+                width: 88,
+                child: TextButton.icon(
+                  style: TextButton.styleFrom(
+                    padding: EdgeInsets.symmetric(vertical: 8, horizontal: 8),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(6.0),
+                      side: BorderSide(
+                          color:
+                              Theme.of(context).brightness == Brightness.light
+                                  ? Color(0xFF0085fb)
+                                  : Colors.white70,
+                          width: 1.6),
                     ),
-                    Flexible(
-                      fit: FlexFit.tight,
-                      flex: 1,
-                      child: Center(
-                        child: Container(
-                          width: 92,
-                          child: Stack(
-                            fit: StackFit.loose,
-                            children: [
-                              GestureDetector(
-                                child: Container(
-                                  width: 32,
-                                  height: 64,
-                                  child: Material(
-                                    color: Colors.transparent,
-                                    borderRadius: BorderRadius.circular(32),
-                                    child: InkWell(
-                                      borderRadius: BorderRadius.circular(32),
-                                      onTap: () {
-                                        if (widget.boostAmountList.contains(
-                                            widget.userModel
-                                                .preferredBoostValue)) {
-                                          var nextIndex = (selectedIndex == 0)
-                                              ? selectedIndex
-                                              : selectedIndex - 1;
-                                          final nextAmount = widget
-                                              .boostAmountList
-                                              .elementAt(nextIndex);
-                                          userBloc.userActionsSink.add(
-                                            SetBoostAmount(nextAmount),
-                                          );
-                                        } else {
-                                          userBloc.userActionsSink.add(
-                                            SetBoostAmount(
-                                              _getClosestBoostAmount(
-                                                  widget.userModel
-                                                      .preferredBoostValue,
-                                                  widget.boostAmountList),
-                                            ),
-                                          );
-                                        }
-                                      },
-                                      splashColor:
-                                          Theme.of(context).splashColor,
-                                      highlightColor: Colors.transparent,
-                                      child: Icon(
-                                        Icons.remove_circle_outline,
-                                        size: 20,
-                                        color: Theme.of(context)
-                                            .appBarTheme
-                                            .actionsIconTheme
-                                            .color,
+                  ),
+                  icon: ImageIcon(
+                    AssetImage("src/icon/boost.png"),
+                    size: 20,
+                    color: Theme.of(context).appBarTheme.actionsIconTheme.color,
+                  ),
+                  label: Container(
+                    width: 44,
+                    child: AutoSizeText(
+                      "BOOST!",
+                      style: TextStyle(
+                        fontSize: 14,
+                        height: 1.2,
+                        letterSpacing: 0,
+                        fontWeight: FontWeight.w500,
+                        color: Theme.of(context).buttonColor,
+                      ),
+                      minFontSize: MinFontSize(context).minFontSize,
+                      stepGranularity: 0.1,
+                      maxLines: 1,
+                    ),
+                  ),
+                  onPressed: () {
+                    var boostAmount =
+                        widget.userModel.paymentOptions.preferredBoostValue;
+                    if (acc.data.balance.toInt() <= boostAmount) {
+                      showFlushbar(context,
+                          message:
+                              "You don't have enough funds to complete this payment.");
+                      return;
+                    }
+                    widget.onBoost(
+                      widget.userModel.paymentOptions.boostAmountList
+                          .elementAt(selectedIndex),
+                    );
+                  },
+                ),
+              ),
+              Flexible(
+                fit: FlexFit.tight,
+                flex: 1,
+                child: Center(
+                  child: Container(
+                    width: 92,
+                    child: Stack(
+                      fit: StackFit.loose,
+                      children: [
+                        GestureDetector(
+                          child: Container(
+                            width: 32,
+                            height: 64,
+                            child: Material(
+                              color: Colors.transparent,
+                              borderRadius: BorderRadius.circular(32),
+                              child: InkWell(
+                                borderRadius: BorderRadius.circular(32),
+                                onTap: () {
+                                  if (widget
+                                      .userModel.paymentOptions.boostAmountList
+                                      .contains(widget.userModel.paymentOptions
+                                          .preferredBoostValue)) {
+                                    var nextIndex = (selectedIndex == 0)
+                                        ? selectedIndex
+                                        : selectedIndex - 1;
+                                    final nextAmount = widget.userModel
+                                        .paymentOptions.boostAmountList
+                                        .elementAt(nextIndex);
+                                    userBloc.userActionsSink.add(
+                                      SetBoostAmount(nextAmount),
+                                    );
+                                  } else {
+                                    userBloc.userActionsSink.add(
+                                      SetBoostAmount(
+                                        _getClosestBoostAmount(
+                                            widget.userModel.paymentOptions
+                                                .preferredBoostValue,
+                                            widget.userModel.paymentOptions
+                                                .boostAmountList),
                                       ),
-                                    ),
-                                  ),
+                                    );
+                                  }
+                                },
+                                splashColor: Theme.of(context).splashColor,
+                                highlightColor: Colors.transparent,
+                                child: Icon(
+                                  Icons.remove_circle_outline,
+                                  size: 20,
+                                  color: Theme.of(context)
+                                      .appBarTheme
+                                      .actionsIconTheme
+                                      .color,
                                 ),
                               ),
-                              Positioned(
-                                left: 24,
-                                top: 16,
-                                child: GestureDetector(
-                                  onTap: () => showDialog(
-                                    useRootNavigator: true,
-                                    context: context,
-                                    builder: (c) => CustomAmountDialog(
-                                      widget.userModel.preferredBoostValue,
-                                      widget.boostAmountList,
-                                      (int boostAmount) {
-                                        userBloc.userActionsSink.add(
-                                          SetBoostAmount(boostAmount),
-                                        );
-                                      },
+                            ),
+                          ),
+                        ),
+                        Positioned(
+                          left: 24,
+                          top: 16,
+                          child: GestureDetector(
+                            onTap: () => showDialog(
+                              useRootNavigator: true,
+                              context: context,
+                              builder: (c) => CustomAmountDialog(
+                                widget
+                                    .userModel.paymentOptions.customBoostValue,
+                                widget.userModel.paymentOptions.boostAmountList,
+                                (int boostAmount) {
+                                  userBloc.userActionsSink
+                                      .add(SetCustomBoostAmount(boostAmount));
+                                  userBloc.userActionsSink.add(
+                                    SetBoostAmount(boostAmount),
+                                  );
+                                },
+                              ),
+                            ),
+                            child: SizedBox(
+                              width: 42,
+                              child: Column(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                crossAxisAlignment: CrossAxisAlignment.center,
+                                children: [
+                                  Container(
+                                    width: 32,
+                                    height: 20,
+                                    child: AutoSizeText(
+                                      NumberFormat.compact().format(widget
+                                          .userModel
+                                          .paymentOptions
+                                          .preferredBoostValue),
+                                      textAlign: TextAlign.center,
+                                      style: TextStyle(
+                                        fontSize: 14.3,
+                                        letterSpacing: 1,
+                                        fontWeight: FontWeight.w600,
+                                        height: 1.2,
+                                      ),
+                                      minFontSize: ((9) /
+                                              MediaQuery.of(this.context)
+                                                  .textScaleFactor)
+                                          .floorToDouble(),
+                                      stepGranularity: 0.1,
+                                      maxLines: 1,
                                     ),
                                   ),
-                                  child: SizedBox(
-                                    width: 42,
-                                    child: Column(
-                                      mainAxisAlignment:
-                                          MainAxisAlignment.center,
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.center,
-                                      children: [
-                                        Container(
-                                          width: 32,
-                                          height: 20,
-                                          child: AutoSizeText(
-                                            NumberFormat.compact().format(
-                                                snapshot
-                                                    .data.preferredBoostValue),
-                                            textAlign: TextAlign.center,
-                                            style: TextStyle(
-                                              fontSize: 14.3,
-                                              letterSpacing: 1,
-                                              fontWeight: FontWeight.w600,
-                                              height: 1.2,
-                                            ),
-                                            minFontSize: ((9) /
-                                                    MediaQuery.of(this.context)
-                                                        .textScaleFactor)
-                                                .floorToDouble(),
-                                            stepGranularity: 0.1,
-                                            maxLines: 1,
+                                  AutoSizeText(
+                                    "sats",
+                                    textAlign: TextAlign.center,
+                                    style: TextStyle(
+                                        fontSize: 10, letterSpacing: 1),
+                                    minFontSize:
+                                        MinFontSize(context).minFontSize,
+                                    stepGranularity: 0.1,
+                                  )
+                                ],
+                              ),
+                            ),
+                          ),
+                        ),
+                        Positioned(
+                          left: 60,
+                          child: GestureDetector(
+                            child: Container(
+                              width: 32,
+                              height: 64,
+                              child: Material(
+                                color: Colors.transparent,
+                                borderRadius: BorderRadius.circular(32),
+                                child: InkWell(
+                                  borderRadius: BorderRadius.circular(32),
+                                  onTap: () {
+                                    print("LOL");
+                                    print(widget.userModel.paymentOptions
+                                        .boostAmountList);
+                                    if (widget.userModel.paymentOptions
+                                        .boostAmountList
+                                        .contains(widget
+                                            .userModel
+                                            .paymentOptions
+                                            .preferredBoostValue)) {
+                                      var nextIndex = (selectedIndex >=
+                                              widget.userModel.paymentOptions
+                                                      .boostAmountList.length -
+                                                  1)
+                                          ? selectedIndex
+                                          : selectedIndex + 1;
+                                      final nextAmount = widget.userModel
+                                          .paymentOptions.boostAmountList
+                                          .elementAt(nextIndex);
+                                      userBloc.userActionsSink.add(
+                                        SetBoostAmount(nextAmount),
+                                      );
+                                    } else {
+                                      userBloc.userActionsSink.add(
+                                        SetBoostAmount(
+                                          _getClosestBoostAmount(
+                                            widget.userModel.paymentOptions
+                                                .preferredBoostValue,
+                                            widget.userModel.paymentOptions
+                                                .boostAmountList,
+                                            bigger: true,
                                           ),
                                         ),
-                                        AutoSizeText(
-                                          "sats",
-                                          textAlign: TextAlign.center,
-                                          style: TextStyle(
-                                              fontSize: 10, letterSpacing: 1),
-                                          minFontSize:
-                                              MinFontSize(context).minFontSize,
-                                          stepGranularity: 0.1,
-                                        )
-                                      ],
-                                    ),
+                                      );
+                                    }
+                                  },
+                                  splashColor: Theme.of(context).splashColor,
+                                  highlightColor: Colors.transparent,
+                                  child: Icon(
+                                    Icons.add_circle_outline,
+                                    size: 20,
+                                    color: Theme.of(context)
+                                        .appBarTheme
+                                        .actionsIconTheme
+                                        .color,
                                   ),
                                 ),
                               ),
-                              Positioned(
-                                left: 60,
-                                child: GestureDetector(
-                                  child: Container(
-                                    width: 32,
-                                    height: 64,
-                                    child: Material(
-                                      color: Colors.transparent,
-                                      borderRadius: BorderRadius.circular(32),
-                                      child: InkWell(
-                                        borderRadius: BorderRadius.circular(32),
-                                        onTap: () {
-                                          if (widget.boostAmountList.contains(
-                                              widget.userModel
-                                                  .preferredBoostValue)) {
-                                            var nextIndex = (selectedIndex >=
-                                                    widget.boostAmountList
-                                                            .length -
-                                                        1)
-                                                ? selectedIndex
-                                                : selectedIndex + 1;
-                                            final nextAmount = widget
-                                                .boostAmountList
-                                                .elementAt(nextIndex);
-                                            userBloc.userActionsSink.add(
-                                              SetBoostAmount(nextAmount),
-                                            );
-                                          } else {
-                                            userBloc.userActionsSink.add(
-                                              SetBoostAmount(
-                                                _getClosestBoostAmount(
-                                                  widget.userModel
-                                                      .preferredBoostValue,
-                                                  widget.boostAmountList,
-                                                  bigger: true,
-                                                ),
-                                              ),
-                                            );
-                                          }
-                                        },
-                                        splashColor:
-                                            Theme.of(context).splashColor,
-                                        highlightColor: Colors.transparent,
-                                        child: Icon(
-                                          Icons.add_circle_outline,
-                                          size: 20,
-                                          color: Theme.of(context)
-                                              .appBarTheme
-                                              .actionsIconTheme
-                                              .color,
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ],
+                            ),
                           ),
                         ),
-                      ),
+                      ],
                     ),
-                  ],
-                );
-              });
+                  ),
+                ),
+              ),
+            ],
+          );
         });
   }
 

--- a/lib/routes/podcast/custom_amount_dialog.dart
+++ b/lib/routes/podcast/custom_amount_dialog.dart
@@ -27,10 +27,7 @@ class CustomAmountDialogState extends State<CustomAmountDialog> {
     _customAmountController.addListener(() {
       setState(() {});
     });
-    _customAmountController.text =
-        !widget.presetAmountsList.contains(widget.customAmount)
-            ? widget.customAmount.toString()
-            : null;
+    _customAmountController.text = widget.customAmount?.toString();
     if (_customAmountController.text.isEmpty) _amountFocusNode.requestFocus();
   }
 

--- a/lib/routes/podcast/custom_amount_dialog.dart
+++ b/lib/routes/podcast/custom_amount_dialog.dart
@@ -27,7 +27,10 @@ class CustomAmountDialogState extends State<CustomAmountDialog> {
     _customAmountController.addListener(() {
       setState(() {});
     });
-    _customAmountController.text = widget.customAmount?.toString();
+    _customAmountController.text =
+        !widget.presetAmountsList.contains(widget.customAmount)
+            ? widget.customAmount?.toString()
+            : null;
     if (_customAmountController.text.isEmpty) _amountFocusNode.requestFocus();
   }
 

--- a/lib/routes/podcast/custom_amount_dialog.dart
+++ b/lib/routes/podcast/custom_amount_dialog.dart
@@ -1,0 +1,107 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class CustomAmountDialog extends StatefulWidget {
+  final int customAmount;
+  final List presetAmountsList;
+  final Function(int customAmount) setAmount;
+
+  CustomAmountDialog(this.customAmount, this.presetAmountsList, this.setAmount);
+
+  @override
+  State<StatefulWidget> createState() {
+    return CustomAmountDialogState();
+  }
+}
+
+class CustomAmountDialogState extends State<CustomAmountDialog> {
+  final _formKey = GlobalKey<FormState>();
+  TextEditingController _customAmountController = TextEditingController();
+  final FocusNode _amountFocusNode = FocusNode();
+
+  @override
+  void initState() {
+    super.initState();
+    _customAmountController.addListener(() {
+      setState(() {});
+    });
+    _customAmountController.text =
+        !widget.presetAmountsList.contains(widget.customAmount)
+            ? widget.customAmount.toString()
+            : null;
+    if (_customAmountController.text.isEmpty) _amountFocusNode.requestFocus();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _buildPaymentRequestDialog();
+  }
+
+  Widget _buildPaymentRequestDialog() {
+    return AlertDialog(
+      title: AutoSizeText(
+        "Enter a Custom Amount:",
+        style:
+            Theme.of(context).dialogTheme.titleTextStyle.copyWith(fontSize: 16),
+        maxLines: 1,
+      ),
+      content: _buildAmountWidget(),
+      actions: _buildActions(),
+    );
+  }
+
+  Widget _buildAmountWidget() {
+    return Form(
+      key: _formKey,
+      autovalidateMode: AutovalidateMode.disabled,
+      child: TextFormField(
+        autovalidateMode: AutovalidateMode.disabled,
+        focusNode: _amountFocusNode,
+        controller: _customAmountController,
+        keyboardType: TextInputType.number,
+        inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+        validator: (value) {
+          if (value.length == 0) {
+            return "Please enter a custom amount";
+          }
+          if (int.parse(value) < widget.presetAmountsList[0]) {
+            return "Must be at least ${widget.presetAmountsList[0]} sats.";
+          }
+          return null;
+        },
+        style: Theme.of(context)
+            .dialogTheme
+            .contentTextStyle
+            .copyWith(height: 1.0),
+      ),
+    );
+  }
+
+  List<Widget> _buildActions() {
+    List<Widget> actions = [
+      TextButton(
+        onPressed: () => Navigator.pop(context),
+        child: Text("CANCEL", style: Theme.of(context).primaryTextTheme.button),
+      ),
+    ];
+    if (_customAmountController.text.isNotEmpty) {
+      actions.add(
+        TextButton(
+          onPressed: () {
+            if (_formKey.currentState.validate()) {
+              Navigator.pop(context);
+              widget.setAmount(
+                int.parse(_customAmountController.text),
+              );
+            }
+          },
+          child:
+              Text("APPROVE", style: Theme.of(context).primaryTextTheme.button),
+        ),
+      );
+    }
+    return actions;
+  }
+}

--- a/lib/routes/podcast/payment_adjuster.dart
+++ b/lib/routes/podcast/payment_adjuster.dart
@@ -71,8 +71,8 @@ class _PaymentAdjusterState extends State<PaymentAdjuster> {
                     context: context,
                     builder: (c) => CustomAmountDialog(
                       widget.userModel.paymentOptions.customSatsPerMinValue,
-                      widget
-                          .userModel.paymentOptions.satsPerMinuteIntervalsList,
+                      widget.userModel.paymentOptions
+                          .presetSatsPerMinuteAmountsList,
                       (int satsPerMinute) {
                         userBloc.userActionsSink.add(SetPaymentOptions(
                             widget.userModel.paymentOptions.copyWith(

--- a/lib/routes/podcast/payment_adjuster.dart
+++ b/lib/routes/podcast/payment_adjuster.dart
@@ -44,31 +44,7 @@ class _PaymentAdjusterState extends State<PaymentAdjuster> {
                       child: InkWell(
                         borderRadius: BorderRadius.circular(32),
                         onTap: () {
-                          if (widget.userModel.paymentOptions
-                              .satsPerMinuteIntervalsList
-                              .contains(widget.userModel.paymentOptions
-                                  .preferredSatsPerMinValue)) {
-                            final currentAmount = widget.userModel
-                                .paymentOptions.preferredSatsPerMinValue;
-                            var index = widget.userModel.paymentOptions
-                                .satsPerMinuteIntervalsList
-                                .indexOf(currentAmount);
-                            if (index > 0) {
-                              index--;
-                            }
-                            final satAmount = widget.userModel.paymentOptions
-                                .satsPerMinuteIntervalsList
-                                .elementAt(index);
-                            widget.onChanged(satAmount);
-                          } else {
-                            widget.onChanged(
-                              _getClosestSatsPerMinAmount(
-                                  widget.userModel.paymentOptions
-                                      .preferredSatsPerMinValue,
-                                  widget.userModel.paymentOptions
-                                      .satsPerMinuteIntervalsList),
-                            );
-                          }
+                          widget.onChanged(_getPreviousAmount());
                         },
                         splashColor: Theme.of(context).splashColor,
                         highlightColor: Colors.transparent,
@@ -155,37 +131,7 @@ class _PaymentAdjusterState extends State<PaymentAdjuster> {
                       child: InkWell(
                         borderRadius: BorderRadius.circular(32),
                         onTap: () {
-                          if (widget.userModel.paymentOptions
-                              .satsPerMinuteIntervalsList
-                              .contains(widget.userModel.paymentOptions
-                                  .preferredSatsPerMinValue)) {
-                            final currentAmount = widget.userModel
-                                .paymentOptions.preferredSatsPerMinValue;
-                            var nextIndex = widget.userModel.paymentOptions
-                                    .satsPerMinuteIntervalsList
-                                    .indexOf(currentAmount) +
-                                1;
-                            if (nextIndex >=
-                                widget.userModel.paymentOptions
-                                    .satsPerMinuteIntervalsList.length) {
-                              nextIndex = widget.userModel.paymentOptions
-                                      .satsPerMinuteIntervalsList.length -
-                                  1;
-                            }
-                            final satAmount = widget.userModel.paymentOptions
-                                .satsPerMinuteIntervalsList
-                                .elementAt(nextIndex);
-                            widget.onChanged(satAmount);
-                          } else {
-                            widget.onChanged(
-                              _getClosestSatsPerMinAmount(
-                                  widget.userModel.paymentOptions
-                                      .preferredSatsPerMinValue,
-                                  widget.userModel.paymentOptions
-                                      .satsPerMinuteIntervalsList,
-                                  bigger: true),
-                            );
-                          }
+                          widget.onChanged(_getNextAmount());
                         },
                         splashColor: Theme.of(context).splashColor,
                         highlightColor: Colors.transparent,
@@ -209,15 +155,25 @@ class _PaymentAdjusterState extends State<PaymentAdjuster> {
     );
   }
 
-  static int _getClosestSatsPerMinAmount(
-      int customAmount, List presetAmountList,
-      {bool bigger = false}) {
+  int _getPreviousAmount() {
+    var currentAmount =
+        widget.userModel.paymentOptions.preferredSatsPerMinValue;
+    var amountList = widget.userModel.paymentOptions.satsPerMinuteIntervalsList;
     try {
-      return presetAmountList[presetAmountList
-              .indexWhere((presetAmount) => customAmount < presetAmount) -
-          (bigger ? 0 : 1)];
+      return amountList[amountList.indexOf(currentAmount) - 1];
     } catch (RangeError) {
-      return presetAmountList.last;
+      return amountList.first;
+    }
+  }
+
+  int _getNextAmount() {
+    var currentAmount =
+        widget.userModel.paymentOptions.preferredSatsPerMinValue;
+    var amountList = widget.userModel.paymentOptions.satsPerMinuteIntervalsList;
+    try {
+      return amountList[amountList.indexOf(currentAmount) + 1];
+    } catch (RangeError) {
+      return amountList.last;
     }
   }
 }

--- a/lib/routes/podcast/payment_adjuster.dart
+++ b/lib/routes/podcast/payment_adjuster.dart
@@ -6,6 +6,8 @@ import 'package:breez/utils/min_font_size.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+import 'custom_amount_dialog.dart';
+
 class PaymentAdjuster extends StatefulWidget {
   final BreezUserModel userModel;
   final List satsPerMinuteList;
@@ -40,117 +42,159 @@ class _PaymentAdjusterState extends State<PaymentAdjuster> {
                     Positioned(
                       left: 8,
                       child: GestureDetector(
-                          child: Container(
-                              width: 32,
-                              height: 64,
-                              child: Material(
-                                color: Colors.transparent,
-                                borderRadius: BorderRadius.circular(32),
-                                child: InkWell(
-                                  borderRadius: BorderRadius.circular(32),
-                                  onTap: () {
-                                    final currentAmount =
-                                        snapshot.data.preferredSatsPerMinValue;
-                                    var index = widget.satsPerMinuteList
-                                        .indexOf(currentAmount);
-                                    if (index > 0) {
-                                      index--;
-                                    }
-                                    final satAmount = widget.satsPerMinuteList
-                                        .elementAt(index);
-                                    widget.onChanged(satAmount);
-                                  },
-                                  splashColor: Theme.of(context).splashColor,
-                                  highlightColor: Colors.transparent,
-                                  child: Icon(
-                                    Icons.remove_circle_outline,
-                                    size: 20,
-                                    color: Theme.of(context)
-                                        .appBarTheme
-                                        .actionsIconTheme
-                                        .color,
-                                  ),
-                                ),
-                              ))),
+                        child: Container(
+                          width: 32,
+                          height: 64,
+                          child: Material(
+                            color: Colors.transparent,
+                            borderRadius: BorderRadius.circular(32),
+                            child: InkWell(
+                              borderRadius: BorderRadius.circular(32),
+                              onTap: () {
+                                if (widget.satsPerMinuteList.contains(widget
+                                    .userModel.preferredSatsPerMinValue)) {
+                                  final currentAmount =
+                                      snapshot.data.preferredSatsPerMinValue;
+                                  var index = widget.satsPerMinuteList
+                                      .indexOf(currentAmount);
+                                  if (index > 0) {
+                                    index--;
+                                  }
+                                  final satAmount =
+                                      widget.satsPerMinuteList.elementAt(index);
+                                  widget.onChanged(satAmount);
+                                } else {
+                                  widget.onChanged(
+                                    _getClosestSatsPerMinAmount(
+                                        widget
+                                            .userModel.preferredSatsPerMinValue,
+                                        widget.satsPerMinuteList),
+                                  );
+                                }
+                              },
+                              splashColor: Theme.of(context).splashColor,
+                              highlightColor: Colors.transparent,
+                              child: Icon(
+                                Icons.remove_circle_outline,
+                                size: 20,
+                                color: Theme.of(context)
+                                    .appBarTheme
+                                    .actionsIconTheme
+                                    .color,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
                     ),
                     Positioned(
                       left: 0,
                       right: 0,
                       top: 16,
-                      child: SizedBox(
-                        width: 56,
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: [
-                            Container(
-                              width: 32,
-                              height: 20,
-                              child: AutoSizeText(
-                                NumberFormat.compact().format(
-                                    snapshot.data.preferredSatsPerMinValue),
-                                textAlign: TextAlign.center,
-                                style: TextStyle(
-                                  fontSize: 14.3,
-                                  letterSpacing: 1,
-                                  fontWeight: FontWeight.w600,
-                                  height: 1.2,
+                      child: GestureDetector(
+                        onTap: () => showDialog(
+                          useRootNavigator: true,
+                          context: context,
+                          builder: (c) => CustomAmountDialog(
+                            widget.userModel.preferredSatsPerMinValue,
+                            widget.satsPerMinuteList,
+                            (int satsPerMinute) {
+                              widget.onChanged(satsPerMinute);
+                            },
+                          ),
+                        ),
+                        child: SizedBox(
+                          width: 56,
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                              Container(
+                                width: 32,
+                                height: 20,
+                                child: AutoSizeText(
+                                  NumberFormat.compact().format(
+                                      snapshot.data.preferredSatsPerMinValue),
+                                  textAlign: TextAlign.center,
+                                  style: TextStyle(
+                                    fontSize: 14.3,
+                                    letterSpacing: 1,
+                                    fontWeight: FontWeight.w600,
+                                    height: 1.2,
+                                  ),
+                                  minFontSize: ((9) /
+                                          MediaQuery.of(this.context)
+                                              .textScaleFactor)
+                                      .floorToDouble(),
+                                  stepGranularity: 0.1,
+                                  maxLines: 1,
                                 ),
+                              ),
+                              AutoSizeText(
+                                "sats/min",
+                                textAlign: TextAlign.center,
+                                style:
+                                    TextStyle(fontSize: 10, letterSpacing: 1),
                                 minFontSize: MinFontSize(context).minFontSize,
                                 stepGranularity: 0.1,
                                 maxLines: 1,
-                              ),
-                            ),
-                            AutoSizeText(
-                              "sats/min",
-                              textAlign: TextAlign.center,
-                              style: TextStyle(fontSize: 10, letterSpacing: 1),
-                              minFontSize: MinFontSize(context).minFontSize,
-                              stepGranularity: 0.1,
-                              maxLines: 1,
-                            )
-                          ],
+                              )
+                            ],
+                          ),
                         ),
                       ),
                     ),
                     Positioned(
                       right: 8,
                       child: GestureDetector(
-                          child: Container(
-                              width: 32,
-                              height: 64,
-                              child: Material(
-                                color: Colors.transparent,
-                                borderRadius: BorderRadius.circular(32),
-                                child: InkWell(
-                                  borderRadius: BorderRadius.circular(32),
-                                  onTap: () {
-                                    final currentAmount =
-                                        snapshot.data.preferredSatsPerMinValue;
-                                    var nextIndex = widget.satsPerMinuteList
-                                            .indexOf(currentAmount) +
-                                        1;
-                                    if (nextIndex >=
-                                        widget.satsPerMinuteList.length) {
-                                      nextIndex =
-                                          widget.satsPerMinuteList.length - 1;
-                                    }
-                                    final satAmount = widget.satsPerMinuteList
-                                        .elementAt(nextIndex);
-                                    widget.onChanged(satAmount);
-                                  },
-                                  splashColor: Theme.of(context).splashColor,
-                                  highlightColor: Colors.transparent,
-                                  child: Icon(
-                                    Icons.add_circle_outline,
-                                    size: 20,
-                                    color: Theme.of(context)
-                                        .appBarTheme
-                                        .actionsIconTheme
-                                        .color,
-                                  ),
-                                ),
-                              ))),
+                        child: Container(
+                          width: 32,
+                          height: 64,
+                          child: Material(
+                            color: Colors.transparent,
+                            borderRadius: BorderRadius.circular(32),
+                            child: InkWell(
+                              borderRadius: BorderRadius.circular(32),
+                              onTap: () {
+                                if (widget.satsPerMinuteList.contains(widget
+                                    .userModel.preferredSatsPerMinValue)) {
+                                  final currentAmount =
+                                      snapshot.data.preferredSatsPerMinValue;
+                                  var nextIndex = widget.satsPerMinuteList
+                                          .indexOf(currentAmount) +
+                                      1;
+                                  if (nextIndex >=
+                                      widget.satsPerMinuteList.length) {
+                                    nextIndex =
+                                        widget.satsPerMinuteList.length - 1;
+                                  }
+                                  final satAmount = widget.satsPerMinuteList
+                                      .elementAt(nextIndex);
+                                  widget.onChanged(satAmount);
+                                } else {
+                                  widget.onChanged(
+                                    _getClosestSatsPerMinAmount(
+                                        widget
+                                            .userModel.preferredSatsPerMinValue,
+                                        widget.satsPerMinuteList,
+                                        bigger: true),
+                                  );
+                                }
+                              },
+                              splashColor: Theme.of(context).splashColor,
+                              highlightColor: Colors.transparent,
+                              child: Icon(
+                                Icons.add_circle_outline,
+                                size: 20,
+                                color: Theme.of(context)
+                                    .appBarTheme
+                                    .actionsIconTheme
+                                    .color,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
                     ),
                   ],
                 ),
@@ -158,5 +202,17 @@ class _PaymentAdjusterState extends State<PaymentAdjuster> {
             ],
           );
         });
+  }
+
+  static int _getClosestSatsPerMinAmount(
+      int customAmount, List presetAmountList,
+      {bool bigger = false}) {
+    try {
+      return presetAmountList[presetAmountList
+              .indexWhere((presetAmount) => customAmount < presetAmount) -
+          (bigger ? 0 : 1)];
+    } catch (RangeError) {
+      return presetAmountList.last;
+    }
   }
 }

--- a/lib/routes/podcast/payment_adjuster.dart
+++ b/lib/routes/podcast/payment_adjuster.dart
@@ -74,9 +74,10 @@ class _PaymentAdjusterState extends State<PaymentAdjuster> {
                       widget
                           .userModel.paymentOptions.satsPerMinuteIntervalsList,
                       (int satsPerMinute) {
-                        userBloc.userActionsSink
-                            .add(SetCustomSatsPerMinAmount(satsPerMinute));
-                        widget.onChanged(satsPerMinute);
+                        userBloc.userActionsSink.add(SetPaymentOptions(
+                            widget.userModel.paymentOptions.copyWith(
+                                preferredSatsPerMinValue: satsPerMinute,
+                                customSatsPerMinValue: satsPerMinute)));
                       },
                     ),
                   ),

--- a/lib/routes/podcast/payment_adjuster.dart
+++ b/lib/routes/podcast/payment_adjuster.dart
@@ -1,6 +1,7 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez/bloc/blocs_provider.dart';
 import 'package:breez/bloc/user_profile/breez_user_model.dart';
+import 'package:breez/bloc/user_profile/user_actions.dart';
 import 'package:breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:breez/utils/min_font_size.dart';
 import 'package:flutter/material.dart';
@@ -10,12 +11,9 @@ import 'custom_amount_dialog.dart';
 
 class PaymentAdjuster extends StatefulWidget {
   final BreezUserModel userModel;
-  final List satsPerMinuteList;
   final ValueChanged<int> onChanged;
 
-  PaymentAdjuster(
-      {Key key, this.userModel, this.satsPerMinuteList, this.onChanged})
-      : super(key: key);
+  PaymentAdjuster({Key key, this.userModel, this.onChanged}) : super(key: key);
 
   @override
   _PaymentAdjusterState createState() => _PaymentAdjusterState();
@@ -25,183 +23,190 @@ class _PaymentAdjusterState extends State<PaymentAdjuster> {
   @override
   Widget build(BuildContext context) {
     final userBloc = AppBlocsProvider.of<UserProfileBloc>(context);
-    return StreamBuilder<BreezUserModel>(
-        stream: userBloc.userStream,
-        builder: (context, snapshot) {
-          if (snapshot.data == null) {
-            return SizedBox();
-          }
-          return Row(
-            mainAxisSize: MainAxisSize.max,
-            mainAxisAlignment: MainAxisAlignment.center,
+
+    return Row(
+      mainAxisSize: MainAxisSize.max,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Container(
+          width: 120,
+          child: Stack(
             children: [
-              Container(
-                width: 120,
-                child: Stack(
-                  children: [
-                    Positioned(
-                      left: 8,
-                      child: GestureDetector(
-                        child: Container(
+              Positioned(
+                left: 8,
+                child: GestureDetector(
+                  child: Container(
+                    width: 32,
+                    height: 64,
+                    child: Material(
+                      color: Colors.transparent,
+                      borderRadius: BorderRadius.circular(32),
+                      child: InkWell(
+                        borderRadius: BorderRadius.circular(32),
+                        onTap: () {
+                          if (widget.userModel.paymentOptions
+                              .satsPerMinuteIntervalsList
+                              .contains(widget.userModel.paymentOptions
+                                  .preferredSatsPerMinValue)) {
+                            final currentAmount = widget.userModel
+                                .paymentOptions.preferredSatsPerMinValue;
+                            var index = widget.userModel.paymentOptions
+                                .satsPerMinuteIntervalsList
+                                .indexOf(currentAmount);
+                            if (index > 0) {
+                              index--;
+                            }
+                            final satAmount = widget.userModel.paymentOptions
+                                .satsPerMinuteIntervalsList
+                                .elementAt(index);
+                            widget.onChanged(satAmount);
+                          } else {
+                            widget.onChanged(
+                              _getClosestSatsPerMinAmount(
+                                  widget.userModel.paymentOptions
+                                      .preferredSatsPerMinValue,
+                                  widget.userModel.paymentOptions
+                                      .satsPerMinuteIntervalsList),
+                            );
+                          }
+                        },
+                        splashColor: Theme.of(context).splashColor,
+                        highlightColor: Colors.transparent,
+                        child: Icon(
+                          Icons.remove_circle_outline,
+                          size: 20,
+                          color: Theme.of(context)
+                              .appBarTheme
+                              .actionsIconTheme
+                              .color,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              Positioned(
+                left: 0,
+                right: 0,
+                top: 16,
+                child: GestureDetector(
+                  onTap: () => showDialog(
+                    useRootNavigator: true,
+                    context: context,
+                    builder: (c) => CustomAmountDialog(
+                      widget.userModel.paymentOptions.customSatsPerMinValue,
+                      widget
+                          .userModel.paymentOptions.satsPerMinuteIntervalsList,
+                      (int satsPerMinute) {
+                        userBloc.userActionsSink
+                            .add(SetCustomSatsPerMinAmount(satsPerMinute));
+                        widget.onChanged(satsPerMinute);
+                      },
+                    ),
+                  ),
+                  child: SizedBox(
+                    width: 56,
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        Container(
                           width: 32,
-                          height: 64,
-                          child: Material(
-                            color: Colors.transparent,
-                            borderRadius: BorderRadius.circular(32),
-                            child: InkWell(
-                              borderRadius: BorderRadius.circular(32),
-                              onTap: () {
-                                if (widget.satsPerMinuteList.contains(widget
-                                    .userModel.preferredSatsPerMinValue)) {
-                                  final currentAmount =
-                                      snapshot.data.preferredSatsPerMinValue;
-                                  var index = widget.satsPerMinuteList
-                                      .indexOf(currentAmount);
-                                  if (index > 0) {
-                                    index--;
-                                  }
-                                  final satAmount =
-                                      widget.satsPerMinuteList.elementAt(index);
-                                  widget.onChanged(satAmount);
-                                } else {
-                                  widget.onChanged(
-                                    _getClosestSatsPerMinAmount(
-                                        widget
-                                            .userModel.preferredSatsPerMinValue,
-                                        widget.satsPerMinuteList),
-                                  );
-                                }
-                              },
-                              splashColor: Theme.of(context).splashColor,
-                              highlightColor: Colors.transparent,
-                              child: Icon(
-                                Icons.remove_circle_outline,
-                                size: 20,
-                                color: Theme.of(context)
-                                    .appBarTheme
-                                    .actionsIconTheme
-                                    .color,
-                              ),
+                          height: 20,
+                          child: AutoSizeText(
+                            NumberFormat.compact().format(widget.userModel
+                                .paymentOptions.preferredSatsPerMinValue),
+                            textAlign: TextAlign.center,
+                            style: TextStyle(
+                              fontSize: 14.3,
+                              letterSpacing: 1,
+                              fontWeight: FontWeight.w600,
+                              height: 1.2,
                             ),
+                            minFontSize: ((9) /
+                                    MediaQuery.of(this.context).textScaleFactor)
+                                .floorToDouble(),
+                            stepGranularity: 0.1,
+                            maxLines: 1,
                           ),
+                        ),
+                        AutoSizeText(
+                          "sats/min",
+                          textAlign: TextAlign.center,
+                          style: TextStyle(fontSize: 10, letterSpacing: 1),
+                          minFontSize: MinFontSize(context).minFontSize,
+                          stepGranularity: 0.1,
+                          maxLines: 1,
+                        )
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              Positioned(
+                right: 8,
+                child: GestureDetector(
+                  child: Container(
+                    width: 32,
+                    height: 64,
+                    child: Material(
+                      color: Colors.transparent,
+                      borderRadius: BorderRadius.circular(32),
+                      child: InkWell(
+                        borderRadius: BorderRadius.circular(32),
+                        onTap: () {
+                          if (widget.userModel.paymentOptions
+                              .satsPerMinuteIntervalsList
+                              .contains(widget.userModel.paymentOptions
+                                  .preferredSatsPerMinValue)) {
+                            final currentAmount = widget.userModel
+                                .paymentOptions.preferredSatsPerMinValue;
+                            var nextIndex = widget.userModel.paymentOptions
+                                    .satsPerMinuteIntervalsList
+                                    .indexOf(currentAmount) +
+                                1;
+                            if (nextIndex >=
+                                widget.userModel.paymentOptions
+                                    .satsPerMinuteIntervalsList.length) {
+                              nextIndex = widget.userModel.paymentOptions
+                                      .satsPerMinuteIntervalsList.length -
+                                  1;
+                            }
+                            final satAmount = widget.userModel.paymentOptions
+                                .satsPerMinuteIntervalsList
+                                .elementAt(nextIndex);
+                            widget.onChanged(satAmount);
+                          } else {
+                            widget.onChanged(
+                              _getClosestSatsPerMinAmount(
+                                  widget.userModel.paymentOptions
+                                      .preferredSatsPerMinValue,
+                                  widget.userModel.paymentOptions
+                                      .satsPerMinuteIntervalsList,
+                                  bigger: true),
+                            );
+                          }
+                        },
+                        splashColor: Theme.of(context).splashColor,
+                        highlightColor: Colors.transparent,
+                        child: Icon(
+                          Icons.add_circle_outline,
+                          size: 20,
+                          color: Theme.of(context)
+                              .appBarTheme
+                              .actionsIconTheme
+                              .color,
                         ),
                       ),
                     ),
-                    Positioned(
-                      left: 0,
-                      right: 0,
-                      top: 16,
-                      child: GestureDetector(
-                        onTap: () => showDialog(
-                          useRootNavigator: true,
-                          context: context,
-                          builder: (c) => CustomAmountDialog(
-                            widget.userModel.preferredSatsPerMinValue,
-                            widget.satsPerMinuteList,
-                            (int satsPerMinute) {
-                              widget.onChanged(satsPerMinute);
-                            },
-                          ),
-                        ),
-                        child: SizedBox(
-                          width: 56,
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            crossAxisAlignment: CrossAxisAlignment.center,
-                            children: [
-                              Container(
-                                width: 32,
-                                height: 20,
-                                child: AutoSizeText(
-                                  NumberFormat.compact().format(
-                                      snapshot.data.preferredSatsPerMinValue),
-                                  textAlign: TextAlign.center,
-                                  style: TextStyle(
-                                    fontSize: 14.3,
-                                    letterSpacing: 1,
-                                    fontWeight: FontWeight.w600,
-                                    height: 1.2,
-                                  ),
-                                  minFontSize: ((9) /
-                                          MediaQuery.of(this.context)
-                                              .textScaleFactor)
-                                      .floorToDouble(),
-                                  stepGranularity: 0.1,
-                                  maxLines: 1,
-                                ),
-                              ),
-                              AutoSizeText(
-                                "sats/min",
-                                textAlign: TextAlign.center,
-                                style:
-                                    TextStyle(fontSize: 10, letterSpacing: 1),
-                                minFontSize: MinFontSize(context).minFontSize,
-                                stepGranularity: 0.1,
-                                maxLines: 1,
-                              )
-                            ],
-                          ),
-                        ),
-                      ),
-                    ),
-                    Positioned(
-                      right: 8,
-                      child: GestureDetector(
-                        child: Container(
-                          width: 32,
-                          height: 64,
-                          child: Material(
-                            color: Colors.transparent,
-                            borderRadius: BorderRadius.circular(32),
-                            child: InkWell(
-                              borderRadius: BorderRadius.circular(32),
-                              onTap: () {
-                                if (widget.satsPerMinuteList.contains(widget
-                                    .userModel.preferredSatsPerMinValue)) {
-                                  final currentAmount =
-                                      snapshot.data.preferredSatsPerMinValue;
-                                  var nextIndex = widget.satsPerMinuteList
-                                          .indexOf(currentAmount) +
-                                      1;
-                                  if (nextIndex >=
-                                      widget.satsPerMinuteList.length) {
-                                    nextIndex =
-                                        widget.satsPerMinuteList.length - 1;
-                                  }
-                                  final satAmount = widget.satsPerMinuteList
-                                      .elementAt(nextIndex);
-                                  widget.onChanged(satAmount);
-                                } else {
-                                  widget.onChanged(
-                                    _getClosestSatsPerMinAmount(
-                                        widget
-                                            .userModel.preferredSatsPerMinValue,
-                                        widget.satsPerMinuteList,
-                                        bigger: true),
-                                  );
-                                }
-                              },
-                              splashColor: Theme.of(context).splashColor,
-                              highlightColor: Colors.transparent,
-                              child: Icon(
-                                Icons.add_circle_outline,
-                                size: 20,
-                                color: Theme.of(context)
-                                    .appBarTheme
-                                    .actionsIconTheme
-                                    .color,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
+                  ),
                 ),
               ),
             ],
-          );
-        });
+          ),
+        ),
+      ],
+    );
   }
 
   static int _getClosestSatsPerMinAmount(

--- a/lib/routes/podcast/payment_adjustment.dart
+++ b/lib/routes/podcast/payment_adjustment.dart
@@ -6,7 +6,6 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez/bloc/blocs_provider.dart';
 import 'package:breez/bloc/podcast_payments/actions.dart';
 import 'package:breez/bloc/podcast_payments/model.dart';
-import 'package:breez/bloc/podcast_payments/payment_options.dart';
 import 'package:breez/bloc/podcast_payments/podcast_payments_bloc.dart';
 import 'package:breez/bloc/user_profile/breez_user_model.dart';
 import 'package:breez/bloc/user_profile/user_actions.dart';
@@ -247,80 +246,66 @@ class PaymentAdjustmentState extends State<PaymentAdjustment> {
         tutorial?.skip();
         return Future.value(true);
       },
-      child: StreamBuilder<PaymentOptions>(
-          stream: paymentsBloc.paymentOptionsStream,
-          builder: (context, snapshot) {
-            if (!snapshot.hasData) {
-              return Center(child: Loader());
-            }
-
-            var paymentOptions = snapshot.data;
-
-            return StreamBuilder<BreezUserModel>(
-                stream: userProfileBloc.userStream,
-                builder: (context, snapshot) {
-                  if (!snapshot.hasData) {
-                    return Center(child: Loader());
-                  }
-                  var userModel = snapshot.data;
-                  return Container(
-                    height: 64,
-                    color: Theme.of(context).backgroundColor,
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: <Widget>[
-                        Flexible(
-                          flex: 5,
-                          child: Padding(
-                            padding: const EdgeInsets.only(left: 16, right: 0),
-                            child: WithConfettyPaymentEffect(
-                                type: PaymentEventType.BoostStarted,
-                                child: BoostWidget(
-                                  key: boostWidgetKey,
-                                  userModel: userModel,
-                                  boostAmountList:
-                                      paymentOptions.boostAmountList,
-                                  onBoost: (int boostAmount) {
-                                    paymentsBloc.actionsSink
-                                        .add(PayBoost(boostAmount));
-                                    userProfileBloc.userActionsSink
-                                        .add(SetBoostAmount(boostAmount));
-                                  },
-                                )),
-                          ),
-                        ),
-                        Container(
-                          height: 64,
-                          width: 1,
-                          child: VerticalDivider(
-                            thickness: 1,
-                            color: Theme.of(context).dividerColor,
-                          ),
-                        ),
-                        Flexible(
-                          flex: 3,
-                          child: Padding(
-                            padding: EdgeInsets.only(left: 0, right: 0),
-                            child: Center(
-                              child: PaymentAdjuster(
-                                  key: paymentAdjusterKey,
-                                  userModel: userModel,
-                                  satsPerMinuteList:
-                                      paymentOptions.satsPerMinuteIntervalsList,
-                                  onChanged: (int satsPerMinute) {
-                                    paymentsBloc.actionsSink
-                                        .add(AdjustAmount(satsPerMinute));
-                                    userProfileBloc.userActionsSink.add(
-                                        SetSatsPerMinAmount(satsPerMinute));
-                                  }),
-                            ),
-                          ),
-                        ),
-                      ],
+      child: StreamBuilder<BreezUserModel>(
+        stream: userProfileBloc.userStream,
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return Center(child: Loader());
+          }
+          var userModel = snapshot.data;
+          return Container(
+            height: 64,
+            color: Theme.of(context).backgroundColor,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Flexible(
+                  flex: 5,
+                  child: Padding(
+                    padding: const EdgeInsets.only(left: 16, right: 0),
+                    child: WithConfettyPaymentEffect(
+                        type: PaymentEventType.BoostStarted,
+                        child: BoostWidget(
+                          key: boostWidgetKey,
+                          userModel: userModel,
+                          onBoost: (int boostAmount) {
+                            paymentsBloc.actionsSink.add(PayBoost(boostAmount));
+                            userProfileBloc.userActionsSink
+                                .add(SetBoostAmount(boostAmount));
+                          },
+                        )),
+                  ),
+                ),
+                Container(
+                  height: 64,
+                  width: 1,
+                  child: VerticalDivider(
+                    thickness: 1,
+                    color: Theme.of(context).dividerColor,
+                  ),
+                ),
+                Flexible(
+                  flex: 3,
+                  child: Padding(
+                    padding: EdgeInsets.only(left: 0, right: 0),
+                    child: Center(
+                      child: PaymentAdjuster(
+                          key: paymentAdjusterKey,
+                          userModel: userModel,
+                          onChanged: (int satsPerMinute) {
+                            paymentsBloc.actionsSink
+                                .add(AdjustAmount(satsPerMinute));
+                            userProfileBloc.userActionsSink
+                                .add(SetSatsPerMinAmount(satsPerMinute));
+                          }),
                     ),
-                  );
-                });
-          }),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/routes/podcast/payment_adjustment.dart
+++ b/lib/routes/podcast/payment_adjustment.dart
@@ -105,6 +105,16 @@ class PaymentAdjustmentState extends State<PaymentAdjustment> {
                     "Send a one-time tip to a show's creators.",
                     style: TextStyle(color: Colors.white),
                   ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 10.0),
+                  child: Text(
+                    "Click on boost amount to set a boost value of your choosing.",
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontStyle: FontStyle.italic,
+                    ),
+                  ),
                 )
               ],
             ))
@@ -153,6 +163,16 @@ class PaymentAdjustmentState extends State<PaymentAdjustment> {
                     ),
                   );
                 }),
+                Padding(
+                  padding: const EdgeInsets.only(top: 10.0),
+                  child: Text(
+                    "Click on sats/min amount to set a sat/min value of your choosing.",
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontStyle: FontStyle.italic,
+                    ),
+                  ),
+                ),
                 Padding(
                   padding: const EdgeInsets.only(top: 10.0),
                   child: withBreezTheme(

--- a/lib/routes/podcast/payment_adjustment.dart
+++ b/lib/routes/podcast/payment_adjustment.dart
@@ -46,7 +46,7 @@ class PaymentAdjustmentState extends State<PaymentAdjustment> {
         final userBloc = AppBlocsProvider.of<UserProfileBloc>(context);
         final user = await userBloc.userStream.first;
         if (!user.seenTutorials.paymentStripTutorial) {
-          _buildTutorial();
+          _buildTutorial(user);
           tutorial.show();
           setState(() {});
         }
@@ -54,7 +54,7 @@ class PaymentAdjustmentState extends State<PaymentAdjustment> {
     });
   }
 
-  void _buildTutorial() {
+  void _buildTutorial(BreezUserModel user) {
     tutorial = TutorialCoachMark(context,
         targets: targets,
         onClickOverlay: (t) {
@@ -73,10 +73,10 @@ class PaymentAdjustmentState extends State<PaymentAdjustment> {
           final userBloc = AppBlocsProvider.of<UserProfileBloc>(context);
           userBloc.userActionsSink.add(SetSeenPaymentStripTutorial(true));
         });
-    _buildTutorialTargets();
+    _buildTutorialTargets(user);
   }
 
-  void _buildTutorialTargets() {
+  void _buildTutorialTargets(BreezUserModel user) {
     targets.add(TargetFocus(
       identify: "BoostWidget",
       keyTarget: boostWidgetKey,
@@ -190,7 +190,10 @@ class PaymentAdjustmentState extends State<PaymentAdjustment> {
                         onPressed: () {
                           AppBlocsProvider.of<UserProfileBloc>(context)
                               .userActionsSink
-                              .add(SetSatsPerMinAmount(tutorialStreamSats));
+                              .add(SetPaymentOptions(user.paymentOptions
+                                  .copyWith(
+                                      preferredSatsPerMinValue:
+                                          tutorialStreamSats)));
                           tutorial.finish();
                         },
                       )),
@@ -270,8 +273,12 @@ class PaymentAdjustmentState extends State<PaymentAdjustment> {
                           userModel: userModel,
                           onBoost: (int boostAmount) {
                             paymentsBloc.actionsSink.add(PayBoost(boostAmount));
-                            userProfileBloc.userActionsSink
-                                .add(SetBoostAmount(boostAmount));
+                          },
+                          onChanged: (int boostAmount) {
+                            userProfileBloc.userActionsSink.add(
+                                SetPaymentOptions(userModel.paymentOptions
+                                    .copyWith(
+                                        preferredBoostValue: boostAmount)));
                           },
                         )),
                   ),
@@ -295,8 +302,11 @@ class PaymentAdjustmentState extends State<PaymentAdjustment> {
                           onChanged: (int satsPerMinute) {
                             paymentsBloc.actionsSink
                                 .add(AdjustAmount(satsPerMinute));
-                            userProfileBloc.userActionsSink
-                                .add(SetSatsPerMinAmount(satsPerMinute));
+                            userProfileBloc.userActionsSink.add(
+                                SetPaymentOptions(userModel.paymentOptions
+                                    .copyWith(
+                                        preferredSatsPerMinValue:
+                                            satsPerMinute)));
                           }),
                     ),
                   ),

--- a/lib/routes/podcast/podcast_page.dart
+++ b/lib/routes/podcast/podcast_page.dart
@@ -210,7 +210,8 @@ class NowPlayingTransportState extends State<NowPlayingTransport> {
               List<Widget> widgets = [];
               widgets.add(Divider(height: 0.0, thickness: 1));
               // We'll also show add funds message if user tries to boost and has no balance
-              if (snapshot.data.balance < userModel.preferredSatsPerMinValue) {
+              if (snapshot.data.balance <
+                  userModel.paymentOptions.preferredSatsPerMinValue) {
                 widgets.add(AddFundsMessage(accountModel: snapshot.data));
                 widgets.add(Divider(height: 0.0, thickness: 1));
               }

--- a/lib/theme_data.dart
+++ b/lib/theme_data.dart
@@ -136,7 +136,7 @@ final ThemeData blueTheme = ThemeData(
     caption: TextStyle(color: BreezColors.grey[500], fontSize: 12.0),
   ),
   textSelectionTheme: TextSelectionThemeData(
-    selectionColor: Color.fromRGBO(255, 255, 255, 0.5),
+    selectionColor: Color.fromRGBO(0, 133, 251, 0.25),
     selectionHandleColor: Color(0xFF0085fb),
   ),
   primaryIconTheme: IconThemeData(color: BreezColors.grey[500]),


### PR DESCRIPTION
This PR addresses [BU-323](https://breeztech.atlassian.net/browse/BU-323)

Clicking on the boost or sats/min amounts will open a input dialog for users to enter a custom amount.

- The custom amount can’t be lower than minimum preset value (but can be higher than preset max value).
- The custom amount will be embedded into amount list.
- To remove custom amounts, users will need to enter an existing amount from preset values
- Added information text to tutorials to introduce this behavior.
- Grouped user preferences and custom amount under PaymentOptions,
- Removed unnecessary streams and related parameters on children widgets BoostWidget, PaymentAdjuster