### PR TITLE
Fix ln pizza asset on apps page

### DIFF
--- a/conf/marketplace.conf
+++ b/conf/marketplace.conf
@@ -2,7 +2,7 @@
 vendors=ln.pizza,FixedFloat,Lightnite
 [ln.pizza]
 url=https://ln.pizza/?breez_wallet
-logo=src/icon/vendors/lnpizza_logo_lg.png
+logo=src/icon/vendors/ln.pizza_logo_lg.png
 onlyShowLogo=true
 [Lightnite]
 url=https://lightnite.io/ref=breez


### PR DESCRIPTION
The logo `ln.pizza_logo_lg.png` was misstyped as `lnpizza_logo_lg.png` on `conf/marketplace.conf` file.

how it looks like before and after the fix:

|Before|After|
|---|---|
|![photo_2021-06-08 15 02 53](https://user-images.githubusercontent.com/1225438/121236266-23f1bb80-c86c-11eb-8793-23950c26689b.jpeg)|![photo_2021-06-08 15 02 51](https://user-images.githubusercontent.com/1225438/121236285-281dd900-c86c-11eb-9da3-230ee3502972.jpeg)|

