### PR TITLE
Add tests for lib/utils files

### DIFF
--- a/test/utils/currency_formatter_test.dart
+++ b/test/utils/currency_formatter_test.dart
@@ -1,0 +1,26 @@
+import 'package:breez/utils/currency_formatter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+CurrencyFormatter make() => CurrencyFormatter();
+
+void main() {
+  test('CurrencyFormatter formatter should format values properly', () {
+    final formatted = make().formatter.format(1.23);
+    expect(formatted, '1.23');
+  });
+
+  test('CurrencyFormatter formatter should format zeros properly', () {
+    final formatted = make().formatter.format(0);
+    expect(formatted, '0');
+  });
+
+  test('CurrencyFormatter formatter should format negatives properly', () {
+    final formatted = make().formatter.format(-4.56);
+    expect(formatted, '-4.56');
+  });
+
+  test('CurrencyFormatter formatter should format big numbers properly', () {
+    final formatted = make().formatter.format(12345678.90);
+    expect(formatted, '12 345 678.9');
+  });
+}


### PR DESCRIPTION
Increases the coverage from 54% to 90%

# Before

![Screenshot 2021-06-15 at 17 00 54](https://user-images.githubusercontent.com/1225438/122119582-c1fefc00-cdff-11eb-8a57-2209a354e473.png)

# After

![Screenshot 2021-06-15 at 17 30 53](https://user-images.githubusercontent.com/1225438/122119605-c88d7380-cdff-11eb-8ffc-d684bb7ce3ab.png)

# What is missing

![Screenshot 2021-06-15 at 17 31 03](https://user-images.githubusercontent.com/1225438/122119644-d2af7200-cdff-11eb-96f0-ddaef113c6db.png)

The line `FormatException` is never called because of the check `if (lowerBip21.startsWith("bitcoin:")) {` that causes `Uri.parse` to create a `_SimpleUri`, the exception is thrown on special cases when Uri.parse try to parse a `http` or `file:` uri but because of the check it never happens.

# About formation

I just get the output and set as expected on the tests but I'm not sure if `'0'` is correct instead of `'0.00'` or `'12 345 678.9'` instead of `'12,345,678.90'`