### PR TITLE
Change payment timeline date format

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:anytime/ui/podcast/now_playing.dart';
 import 'package:anytime/ui/podcast/podcast_details.dart';
 import 'package:anytime/ui/widgets/episode_tile.dart';
 import 'package:anytime/ui/widgets/placeholder_builder.dart';
+import 'package:breez/utils/date.dart';
 import 'package:provider/provider.dart';
 import 'package:anytime/services/settings/mobile_settings_service.dart';
 import 'package:breez/bloc/app_blocs.dart';
@@ -30,6 +31,7 @@ void main() async {
   SystemChrome.setPreferredOrientations(
       [DeviceOrientation.portraitUp, DeviceOrientation.portraitDown]);
   //initializeDateFormatting(Platform.localeName, null);
+  BreezDateUtils.setupLocales();
   var mobileService = await MobileSettingsService.instance();
   mobileService.autoOpenNowPlaying = true;
   mobileService.showFunding = false;

--- a/lib/routes/home/payment_item.dart
+++ b/lib/routes/home/payment_item.dart
@@ -95,7 +95,7 @@ class PaymentItem extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: <Widget>[
                         Text(
-                          BreezDateUtils.formatMonthDate(
+                          BreezDateUtils.formatTimelineRelative(
                               DateTime.fromMillisecondsSinceEpoch(
                                   _paymentInfo.creationTimestamp.toInt() *
                                       1000)),

--- a/lib/utils/date.dart
+++ b/lib/utils/date.dart
@@ -1,6 +1,7 @@
 import 'dart:io' show Platform;
 
 import "package:intl/intl.dart";
+import 'package:timeago/timeago.dart' as timeago;
 
 class BreezDateUtils {
   static final DateFormat _monthDateFormat = DateFormat.Md(Platform.localeName);
@@ -17,10 +18,23 @@ class BreezDateUtils {
       _yearMonthDayHourMinuteFormat.format(d);
   static String formatYearMonthDayHourMinuteSecond(DateTime d) =>
       _yearMonthDayHourMinuteSecondFormat.format(d);
+
+  static String formatTimelineRelative(DateTime d) {
+    if (DateTime.now().subtract(Duration(days: 4)).isBefore(d)) {
+      return timeago.format(d);
+    } else {
+      return formatYearMonthDay(d);
+    }
+  }
+
   static String formatFilterDateRange(DateTime startDate, DateTime endDate) {
     var formatter = (startDate.year == endDate.year)
         ? _monthDateFormat
         : _yearMonthDayFormat;
     return formatter.format(startDate) + "-" + formatter.format(endDate);
+  }
+
+  static void setupLocales() {
+    timeago.setLocaleMessages('en', timeago.EnMessages());
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   shared_preferences: ^2.0.6
   simple_animations: ^1.3.12
   sqflite: ^2.0.0+3
+  timeago: ^3.1.0
   tutorial_coach_mark: ^1.0.0
   uni_links: ^0.5.1
   url_launcher: ^6.0.4

--- a/test/utils/date_test.dart
+++ b/test/utils/date_test.dart
@@ -1,0 +1,144 @@
+import 'package:breez/utils/date.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+DateTime firstDay() => DateTime(2021, 1, 1, 0, 0, 0);
+
+DateTime lastDay() => DateTime(2021, 12, 31, 23, 59, 59);
+
+void main() {
+  group('formatMonthDate', () {
+    test('31 of december of 2021', () {
+      expect(
+        BreezDateUtils.formatMonthDate(lastDay()),
+        '12/31',
+      );
+    });
+
+    test('1 of january of 2021', () {
+      expect(
+        BreezDateUtils.formatMonthDate(firstDay()),
+        '1/1',
+      );
+    });
+  });
+
+  group('formatYearMonthDay', () {
+    test('31 of december of 2021', () {
+      expect(
+        BreezDateUtils.formatYearMonthDay(lastDay()),
+        '12/31/2021',
+      );
+    });
+
+    test('1 of january of 2021', () {
+      expect(
+        BreezDateUtils.formatYearMonthDay(firstDay()),
+        '1/1/2021',
+      );
+    });
+  });
+
+  group('formatYearMonthDayHourMinute', () {
+    test('31 of december of 2021', () {
+      expect(
+        BreezDateUtils.formatYearMonthDayHourMinute(lastDay()),
+        '12/31/2021 11:59 PM',
+      );
+    });
+
+    test('1 of january of 2021', () {
+      expect(
+        BreezDateUtils.formatYearMonthDayHourMinute(firstDay()),
+        '1/1/2021 12:00 AM',
+      );
+    });
+  });
+
+  group('formatYearMonthDayHourMinuteSecond', () {
+    test('31 of december of 2021', () {
+      expect(
+        BreezDateUtils.formatYearMonthDayHourMinuteSecond(lastDay()),
+        '12/31/2021 23:59:59',
+      );
+    });
+
+    test('1 of january of 2021', () {
+      expect(
+        BreezDateUtils.formatYearMonthDayHourMinuteSecond(firstDay()),
+        '1/1/2021 00:00:00',
+      );
+    });
+  });
+
+  group('formatTimelineRelative', () {
+    test('right now should return a moment ago', () {
+      expect(
+        BreezDateUtils.formatTimelineRelative(DateTime.now()),
+        'a moment ago',
+      );
+    });
+
+    test('one second ago should return a moment ago', () {
+      expect(
+        BreezDateUtils.formatTimelineRelative(
+          DateTime.now().subtract(Duration(seconds: 1)),
+        ),
+        'a moment ago',
+      );
+    });
+
+    test('one second ago should return a moment ago', () {
+      expect(
+        BreezDateUtils.formatTimelineRelative(
+          DateTime.now().subtract(Duration(seconds: 1)),
+        ),
+        'a moment ago',
+      );
+    });
+
+    test('one minute ago should return a minute ago', () {
+      expect(
+        BreezDateUtils.formatTimelineRelative(
+          DateTime.now().subtract(Duration(minutes: 1)),
+        ),
+        'a minute ago',
+      );
+    });
+
+    test('one hour ago should return about an hour ago', () {
+      expect(
+        BreezDateUtils.formatTimelineRelative(
+          DateTime.now().subtract(Duration(hours: 1)),
+        ),
+        'about an hour ago',
+      );
+    });
+
+    test('one day ago should return a day ago', () {
+      expect(
+        BreezDateUtils.formatTimelineRelative(
+          DateTime.now().subtract(Duration(days: 1)),
+        ),
+        'a day ago',
+      );
+    });
+
+    test('three days ago should return 3 days ago', () {
+      expect(
+        BreezDateUtils.formatTimelineRelative(
+          DateTime.now().subtract(Duration(days: 3)),
+        ),
+        '3 days ago',
+      );
+    });
+
+    test('more than 3 days ago should return full date', () {
+      expect(
+        BreezDateUtils.formatTimelineRelative(
+          firstDay(),
+        ),
+        '1/1/2021',
+      );
+    });
+  });
+}


### PR DESCRIPTION
@kingonly shares an idea with me about changing the time format shown on the home payments timeline.

The idea is to use relative time notation such as "1 day ago" to recent date (3 days or less) or "month/day/year" to older dates instead of just "month/day".

How those changes looks like:

# Before

https://user-images.githubusercontent.com/1225438/122615129-60889880-d05e-11eb-8b4b-645804078bd0.mp4

# After

https://user-images.githubusercontent.com/1225438/122615137-64b4b600-d05e-11eb-8f9f-c56afb96e5c3.mp4

# PS

- The library that generates those messages is: https://pub.dev/packages/timeago
- The messages are customisable but for now it is using the defaults for english
- The library supports Spanish and other languages so it is compatible with https://github.com/breez/breezmobile/pull/464