### PR TITLE
Close the drawer when back is pressed instead of showing the close dialog

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -252,7 +252,10 @@ class HomeState extends State<Home> with WidgetsBindingObserver {
     AddFundsBloc addFundsBloc = BlocProvider.of<AddFundsBloc>(context);
     LSPBloc lspBloc = AppBlocsProvider.of<LSPBloc>(context);
     return WillPopScope(
-      onWillPop: willPopCallback(context),
+      onWillPop: willPopCallback(
+        context,
+        canCancel: () => _scaffoldKey.currentState?.isDrawerOpen ?? false,
+      ),
       child: StreamBuilder<BreezUserModel>(
           stream: widget.userProfileBloc.userStream,
           builder: (context, userSnapshot) {

--- a/lib/routes/security_pin/lock_screen.dart
+++ b/lib/routes/security_pin/lock_screen.dart
@@ -33,7 +33,7 @@ class _AppLockScreenState extends State<AppLockScreen> {
     return WillPopScope(
       onWillPop: willPopCallback(
         context,
-        canCancel: Future.value(widget.canCancel),
+        canCancel: () => widget.canCancel,
       ),
       child: Scaffold(
         appBar: widget.canCancel == true

--- a/lib/widgets/close_popup.dart
+++ b/lib/widgets/close_popup.dart
@@ -7,17 +7,15 @@ WillPopCallback willPopCallback(
   BuildContext context, {
   String title: 'Exit Breez',
   String message: 'Do you really want to quit Breez?',
-  Future<bool> canCancel,
+  Function canCancel,
 }) {
-  return () {
-    return (canCancel ?? Future.value(false)).then((canCancel) {
-      if (canCancel) return true;
-      return promptAreYouSure(context, title, Text(message)).then((shouldExit) {
-        if (shouldExit) {
-          exit(0);
-        }
-        return false;
-      });
+  return () async {
+    if (canCancel != null && canCancel()) return true;
+    return promptAreYouSure(context, title, Text(message)).then((shouldExit) {
+      if (shouldExit) {
+        exit(0);
+      }
+      return false;
     });
   };
 }


### PR DESCRIPTION
The idea is to fix the issue https://github.com/breez/breezmobile/issues/461 some context https://github.com/breez/breezmobile/pull/502

When you touch the back button, if the drawer is open the app should close the drawer instead of showing the exit dialog, in another hand if the drawer is already closed it should show the close dialog.

P.S. I had to change the `canCancel` from `Future` to a `Function` to correct execute its body after the back action, it seems to not affect the lock screen.

How it looks like:

https://user-images.githubusercontent.com/1225438/122985838-072dab80-d375-11eb-9316-47b598d1a4c0.mp4

