### PR TITLE
Uses system navigator pop instead of calling exit directly

### DIFF
--- a/lib/widgets/close_popup.dart
+++ b/lib/widgets/close_popup.dart
@@ -1,6 +1,5 @@
-import 'dart:io';
-
 import 'package:breez/widgets/error_dialog.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 WillPopCallback willPopCallback(
@@ -13,7 +12,7 @@ WillPopCallback willPopCallback(
     if (canCancel != null && canCancel()) return true;
     return promptAreYouSure(context, title, Text(message)).then((shouldExit) {
       if (shouldExit) {
-        exit(0);
+        SystemNavigator.pop(animated: true);
       }
       return false;
     });

--- a/lib/widgets/close_popup.dart
+++ b/lib/widgets/close_popup.dart
@@ -1,5 +1,4 @@
 import 'package:breez/widgets/error_dialog.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 WillPopCallback willPopCallback(
@@ -10,11 +9,6 @@ WillPopCallback willPopCallback(
 }) {
   return () async {
     if (canCancel != null && canCancel()) return true;
-    return promptAreYouSure(context, title, Text(message)).then((shouldExit) {
-      if (shouldExit) {
-        SystemNavigator.pop(animated: true);
-      }
-      return false;
-    });
+    return promptAreYouSure(context, title, Text(message));
   };
 }


### PR DESCRIPTION
I was wondering the reason why the app closes abruptly instead of the smooth close that apps usually do. I find out the reason is the direct call to `exit` instead of calling `SystemNavigator.pop`.

This PR changes the close method, I could not record the animation it does now because the frame rate of the screen recorder is not enough to capture the animation, but as you run it you can notice the difference.

# The test running

https://user-images.githubusercontent.com/1225438/123309180-fa3ac480-d4fa-11eb-9966-075f0fc8a708.mp4
