### PR TITLE
LNURL-Pay.

### DIFF
--- a/lib/bloc/account/account_model.dart
+++ b/lib/bloc/account/account_model.dart
@@ -367,8 +367,8 @@ class PaymentsModel {
       [this.firstDate]);
 
   PaymentsModel.initial()
-      : this(<PaymentInfo>[], <PaymentInfo>[],
-            PaymentFilterModel.initial(), DateTime(DateTime.now().year));
+      : this(<PaymentInfo>[], <PaymentInfo>[], PaymentFilterModel.initial(),
+            DateTime(DateTime.now().year));
 
   PaymentsModel copyWith(
       {List<PaymentInfo> nonFilteredItems,
@@ -432,6 +432,7 @@ abstract class PaymentInfo {
   bool get fullPending;
   String get paymentGroup;
   String get paymentGroupName;
+  LNUrlPayInfo get lnurlPayInfo;
   PaymentInfo copyWith(AccountModel account);
 }
 
@@ -494,6 +495,8 @@ class StreamedPaymentInfo implements PaymentInfo {
   String get paymentHash => "";
   String get preimage => "";
   String get destination => "";
+
+  LNUrlPayInfo get lnurlPayInfo => null;
 }
 
 class SinglePaymentInfo implements PaymentInfo {
@@ -592,7 +595,8 @@ class SinglePaymentInfo implements PaymentInfo {
               : _paymentResponse.invoiceMemo?.description;
 
   String get imageURL {
-    if (_paymentResponse.invoiceMemo.description.startsWith("Bitrefill")) {
+    if (_paymentResponse.invoiceMemo.description.startsWith("Bitrefill")
+            || _paymentResponse.lnurlPayInfo?.host == 'api-bitrefill.com') {
       return "src/icon/vendors/bitrefill_logo.png";
     }
     if (_paymentResponse.invoiceMemo.description.startsWith("Fastbitcoins")) {
@@ -605,15 +609,39 @@ class SinglePaymentInfo implements PaymentInfo {
     String url = (type == PaymentType.SENT
         ? _paymentResponse.invoiceMemo?.payeeImageURL
         : _paymentResponse.invoiceMemo?.payerImageURL);
+
+    // Check lnurlPayInfo.metadata for the first usable image.
+    // Some services that provide an image lightning.gifts, zebedee.
+    if (url == '' && _paymentResponse.lnurlPayInfo != null) {
+        final lnurlPayInfo = _paymentResponse.lnurlPayInfo; 
+      for (var datum in lnurlPayInfo.metadata) {
+        if (datum.entry[0].startsWith('image')) {
+          url = 'data:' + datum.entry[0] + ',' + datum.entry[1];
+          break;
+        }
+      }
+    }
+
     return (url == null || url.isEmpty) ? null : url;
   }
 
   String get title {
-    if (_paymentResponse.invoiceMemo.description.startsWith("Bitrefill")) {
+    if (_paymentResponse.invoiceMemo.description.startsWith("Bitrefill") 
+            || _paymentResponse.lnurlPayInfo?.host == 'api-bitrefill.com') {
       return "Bitrefill";
     }
+
     if (_paymentResponse.invoiceMemo.description.startsWith("LN.pizza")) {
       return "ln.pizza";
+    }
+
+    if (_paymentResponse.invoiceMemo.description.startsWith('lightning.gifts') 
+            || _paymentResponse.lnurlPayInfo?.host == 'api.lightning.gifts') {
+      return 'lightning.gifts';
+    }
+
+    if (_paymentResponse.lnurlPayInfo?.host == 'api.zebedee.io') {
+      return "Zebedee";
     }
 
     if (type == PaymentType.DEPOSIT || type == PaymentType.WITHDRAWAL) {
@@ -629,8 +657,13 @@ class SinglePaymentInfo implements PaymentInfo {
     String result = (type == PaymentType.SENT
         ? _paymentResponse.invoiceMemo?.payeeName
         : _paymentResponse.invoiceMemo?.payerName);
+
     if (result == null || result.isEmpty) {
+        if (_paymentResponse.lnurlPayInfo != null && _paymentResponse.lnurlPayInfo.host != '') {
+        result = _paymentResponse.lnurlPayInfo.host;
+        } else {
       result = _paymentResponse.invoiceMemo.description;
+        }
     }
     return (result == null || result.isEmpty) ? "Unknown" : result;
   }
@@ -646,6 +679,8 @@ class SinglePaymentInfo implements PaymentInfo {
   }
 
   Currency get currency => _account.currency;
+
+  LNUrlPayInfo get lnurlPayInfo => _paymentResponse.lnurlPayInfo;
 
   SinglePaymentInfo(this._paymentResponse, this._account);
 
@@ -703,8 +738,9 @@ class CompletedPayment {
   final String paymentHash;
   final bool cancelled;
   final bool ignoreGlobalFeedback;
+  final PaymentInfo paymentItem;
 
-  CompletedPayment(this.paymentRequest, this.paymentHash,
+  CompletedPayment(this.paymentRequest, this.paymentHash, this.paymentItem,
       {this.cancelled = false, this.ignoreGlobalFeedback = false});
 }
 

--- a/lib/bloc/invoice/invoice_bloc.dart
+++ b/lib/bloc/invoice/invoice_bloc.dart
@@ -172,12 +172,13 @@ class InvoiceBloc with AsyncActionsHandler {
                 PaymentRequestModel(null, paymentRequest, null, Int64(0)));
             return null;
           } catch (e) {
-            log.info("detected not ours invoice, continue to decoding");
+            log.info("detected not our invoice, continue to decoding");
             return paymentRequest;
           }
         })
         .where((paymentRequest) => paymentRequest != null)
         .asyncMap((paymentRequest) {
+          log.info('Decoding invoice.');
           return breezLib.decodePaymentRequest(paymentRequest).then(
               (invoice) async {
             var paymentHash =

--- a/lib/bloc/lnurl/lnurl_actions.dart
+++ b/lib/bloc/lnurl/lnurl_actions.dart
@@ -28,3 +28,9 @@ class Login extends AsyncAction {
 
   Login(this.response, {this.jwt = false});
 }
+
+class FetchInvoice extends AsyncAction {
+  final PayFetchResponse response;
+
+  FetchInvoice(this.response);
+}

--- a/lib/bloc/lnurl/lnurl_bloc.dart
+++ b/lib/bloc/lnurl/lnurl_bloc.dart
@@ -26,6 +26,7 @@ class LNUrlBloc with AsyncActionsHandler {
       Withdraw: _withdraw,
       OpenChannel: _openChannel,
       Login: _login,
+      FetchInvoice: _fetchInvoice,
     });
     listenActions();
   }
@@ -53,6 +54,8 @@ class LNUrlBloc with AsyncActionsHandler {
             _lnUrlStreamController.add(ChannelFetchResponse(response.channel));
           } else if (response.hasAuth()) {
             _lnUrlStreamController.add(AuthFetchResponse(response.auth));
+          } else if (response.hasPayResponse1()) {
+            _lnUrlStreamController.add(PayFetchResponse(response.payResponse1));
           } else {
             _lnUrlStreamController.addError("Unsupported LNUrl");
           }
@@ -67,6 +70,7 @@ class LNUrlBloc with AsyncActionsHandler {
 
   Future _fetch(Fetch action) async {
     LNUrlResponse res = await _breezLib.fetchLNUrl(action.lnurl);
+
     if (res.hasWithdraw()) {
       action.resolve(WithdrawFetchResponse(res.withdraw));
       return;
@@ -79,6 +83,10 @@ class LNUrlBloc with AsyncActionsHandler {
       action.resolve(AuthFetchResponse(res.auth));
       return;
     }
+    if (res.hasPayResponse1()) {
+      action.resolve(PayFetchResponse(res.payResponse1));
+      return;
+    }
     throw "Unsupported LNUrl action";
   }
 
@@ -89,6 +97,10 @@ class LNUrlBloc with AsyncActionsHandler {
   Future _login(Login action) async {
     action.response.response.jwt = action.jwt;
     action.resolve(await _breezLib.loginLNUrl(action.response));
+  }
+
+  Future _fetchInvoice(FetchInvoice action) async {
+    action.resolve(await _breezLib.fetchLNUrlPayInvoice(action.response));
   }
 
   Future _openChannel(OpenChannel action) async {

--- a/lib/bloc/lnurl/lnurl_model.dart
+++ b/lib/bloc/lnurl/lnurl_model.dart
@@ -31,3 +31,21 @@ class AuthFetchResponse {
   String get callback => response.callback;
   String get k1 => response.k1;
 }
+
+class PayFetchResponse {
+  final LNURLPayResponse1 response;
+
+  PayFetchResponse(this.response);
+
+  String get host => response.host;
+  String get callback => response.callback;
+  Int64 get minAmount => response.minAmount;
+  Int64 get maxAmount => response.maxAmount;
+  Int64 get amount => response.amount;
+  List<LNUrlPayMetadata> get metadata => response.metadata;
+  String get tag => response.tag;
+  String get comment => response.comment;
+
+  set amount(Int64 v) => response.amount = v;
+  set comment(String s) => response.comment = s;
+}

--- a/lib/handlers/lnurl_handler.dart
+++ b/lib/handlers/lnurl_handler.dart
@@ -8,6 +8,7 @@ import 'package:breez/widgets/loader.dart';
 import 'package:breez/widgets/route.dart';
 import 'package:flutter/material.dart';
 
+import '../routes/lnurl_fetch_invoice_page.dart';
 import '../routes/create_invoice/create_invoice_page.dart';
 
 class LNURLHandler {
@@ -87,6 +88,14 @@ class LNURLHandler {
           }).whenComplete(() => Navigator.of(context).removeRoute(loaderRoute));
         }
       });
+    } else if (response is PayFetchResponse) {
+      Navigator.popUntil(context, (route) {
+        return route.settings.name == "/";
+      });
+
+      Navigator.of(context).push(FadeInRoute(
+        builder: (_) => LNURLFetchInvoicePage(response),
+      ));
     } else {
       throw "Unsupported LNURL";
     }

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -55,6 +55,7 @@ import 'handlers/podcast_url_handler.dart';
 import 'handlers/received_invoice_notification.dart';
 import 'handlers/showPinHandler.dart';
 import 'handlers/sync_ui_handler.dart';
+import 'lnurl_success_action_dialog.dart';
 import 'routes/account_required_actions.dart';
 import 'routes/connect_to_pay/connect_to_pay_page.dart';
 import 'routes/home/account_page.dart';
@@ -670,11 +671,23 @@ class HomeState extends State<Home> with WidgetsBindingObserver {
 
   void _listenPaymentResults() {
     widget.accountBloc.completedPaymentsStream.listen((fulfilledPayment) {
+      print(
+          '_listenPaymentResults processing: ${fulfilledPayment.paymentHash}');
+
       if (!fulfilledPayment.cancelled &&
           !fulfilledPayment.ignoreGlobalFeedback) {
         scrollController.animateTo(scrollController.position.minScrollExtent,
             duration: Duration(milliseconds: 10), curve: Curves.ease);
-        showFlushbar(context, message: "Payment was successfully sent!");
+
+        if (fulfilledPayment?.paymentItem?.lnurlPayInfo?.successAction?.hasTag() ==
+            true) {
+          showLNURLSuccessAction(
+              context, fulfilledPayment.paymentItem.lnurlPayInfo.successAction);
+        } else {
+          showFlushbar(context,
+              messageWidget: SingleChildScrollView(
+                  child: Text('Payment was successfully sent!')));
+        }
       }
     }, onError: (err) async {
       var error = err as PaymentError;

--- a/lib/lnurl_success_action_dialog.dart
+++ b/lib/lnurl_success_action_dialog.dart
@@ -1,0 +1,84 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:breez/services/breezlib/data/rpc.pbgrpc.dart';
+import 'package:breez/widgets/error_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+void showLNURLSuccessAction(BuildContext context, SuccessAction sa) {
+  final AutoSizeGroup _labelGroup = AutoSizeGroup();
+  promptMessage(
+      context,
+      "Purchase Information",
+      Container(
+          width: MediaQuery.of(context).size.width,
+          child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                sa.description?.isNotEmpty != true
+                    ? SizedBox(
+                        height: 0,
+                      )
+                    : Container(
+                        height: 36.0,
+                        padding: EdgeInsets.only(top: 8.0),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.max,
+                          children: <Widget>[
+                            Padding(
+                              padding: const EdgeInsets.only(right: 8.0),
+                              child: AutoSizeText(
+                                sa.description,
+                                textAlign: TextAlign.left,
+                                maxLines: 1,
+                                group: _labelGroup,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                sa.message?.isNotEmpty != true
+                    ? SizedBox(
+                        height: 0,
+                      )
+                    : Container(
+                        height: 36.0,
+                        padding: EdgeInsets.only(top: 8.0),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.max,
+                          children: <Widget>[
+                            Padding(
+                              padding: const EdgeInsets.only(right: 8.0),
+                              child: AutoSizeText(
+                                sa.message,
+                                style: Theme.of(context)
+                                    .primaryTextTheme
+                                    .headline4
+                                    .copyWith(color: Colors.black),
+                                textAlign: TextAlign.left,
+                                maxLines: 1,
+                                group: _labelGroup,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                sa.url?.isNotEmpty != true
+                    ? SizedBox(
+                        height: 0,
+                      )
+                    : Container(
+                        height: 36.0,
+                        padding: EdgeInsets.only(top: 8.0),
+                        child: GestureDetector(
+                          onTap: () {
+                            launch(sa.url);
+                          },
+                          child: Text(
+                            sa.url,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(color: Colors.blue),
+                          ),
+                        ))
+              ])));
+}

--- a/lib/routes/home/account_page.dart
+++ b/lib/routes/home/account_page.dart
@@ -75,7 +75,10 @@ class AccountPageState extends State<AccountPage>
                           snapshot.data ?? PaymentsModel.initial();
                       return Container(
                         color: theme.customData[theme.themeId].dashboardBgColor,
-                        child: _buildBalanceAndPayments(paymentsModel, account),
+                        child: _buildBalanceAndPayments(
+                          paymentsModel,
+                          account,
+                        ),
                       );
                     });
               });
@@ -83,7 +86,9 @@ class AccountPageState extends State<AccountPage>
   }
 
   Widget _buildBalanceAndPayments(
-      PaymentsModel paymentsModel, AccountModel account) {
+    PaymentsModel paymentsModel,
+    AccountModel account,
+  ) {
     LSPBloc lspBloc = AppBlocsProvider.of<LSPBloc>(context);
 
     double listHeightSpace = MediaQuery.of(context).size.height -

--- a/lib/routes/home/payments_list.dart
+++ b/lib/routes/home/payments_list.dart
@@ -42,7 +42,8 @@ class PaymentsListState extends State<PaymentsList> {
     return SliverFixedExtentList(
       itemExtent: widget._itemHeight + BOTTOM_PADDING,
       delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
-        return PaymentItem(widget._payments[index], index, 0 == index,
+        final payment = widget._payments[index];
+        return PaymentItem(payment, index, 0 == index,
             widget.firstPaymentItemKey, widget.scrollController);
       }, childCount: widget._payments.length),
     );

--- a/lib/routes/lnurl_fetch_invoice_page.dart
+++ b/lib/routes/lnurl_fetch_invoice_page.dart
@@ -1,0 +1,376 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:breez/services/breezlib/data/rpc.pb.dart';
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:breez/bloc/account/account_bloc.dart';
+import 'package:breez/bloc/account/account_model.dart';
+import 'package:breez/bloc/blocs_provider.dart';
+import 'package:breez/bloc/invoice/invoice_bloc.dart';
+import 'package:breez/bloc/lnurl/lnurl_actions.dart';
+import 'package:breez/bloc/lnurl/lnurl_bloc.dart';
+import 'package:breez/bloc/lnurl/lnurl_model.dart';
+import 'package:breez/logger.dart';
+import 'package:breez/theme_data.dart' as theme;
+import 'package:breez/utils/min_font_size.dart';
+import 'package:breez/widgets/amount_form_field.dart';
+import 'package:breez/widgets/back_button.dart' as backBtn;
+import 'package:breez/widgets/error_dialog.dart';
+import 'package:breez/widgets/keyboard_done_action.dart';
+import 'package:breez/widgets/loader.dart';
+import 'package:breez/widgets/single_button_bottom_bar.dart';
+import 'package:breez/widgets/static_loader.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class LNURLFetchInvoicePage extends StatefulWidget {
+  final PayFetchResponse payFetchResponse;
+
+  const LNURLFetchInvoicePage(this.payFetchResponse);
+
+  @override
+  LNURLFetchInvoicePageState createState() {
+    return LNURLFetchInvoicePageState();
+  }
+}
+
+class LNURLFetchInvoicePageState extends State<LNURLFetchInvoicePage> {
+  PayFetchResponse _payFetchResponse;
+
+  final _formKey = GlobalKey<FormState>();
+  var _scaffoldKey = GlobalKey<ScaffoldState>();
+
+  final TextEditingController _commentController = TextEditingController();
+  final TextEditingController _amountController = TextEditingController();
+
+  bool _isInit = false;
+  final FocusNode _amountFocusNode = FocusNode();
+  KeyboardDoneAction _doneAction;
+  ModalRoute _loaderRoute;
+  ModalRoute _currentRoute;
+
+  @override
+  void didChangeDependencies() {
+    AccountBloc accountBloc = AppBlocsProvider.of<AccountBloc>(context);
+
+    if (mounted) {
+      if (!_isInit) {
+        if (widget.payFetchResponse != null) {
+          accountBloc.accountStream.first.then((account) {
+            setState(() {
+              applyPayFetchResponse(widget.payFetchResponse, account);
+            });
+          });
+        }
+
+        Future.delayed(Duration(milliseconds: 200),
+            () => FocusScope.of(context).requestFocus(_amountFocusNode));
+      }
+
+      _isInit = true;
+      super.didChangeDependencies();
+    }
+  }
+
+  @override
+  void initState() {
+    _doneAction = KeyboardDoneAction(<FocusNode>[_amountFocusNode]);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    log.info('LNURLFetchInvoicePage disposed.');
+    _doneAction.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return showFetchInvoiceDialog();
+  }
+
+  Widget showFetchInvoiceDialog() {
+    final String _title = "Pay via Invoice";
+    AccountBloc accountBloc = AppBlocsProvider.of<AccountBloc>(context);
+    InvoiceBloc invoiceBloc = AppBlocsProvider.of<InvoiceBloc>(context);
+    LNUrlBloc lnurlBloc = AppBlocsProvider.of<LNUrlBloc>(context);
+
+    /*
+        4. `LN WALLET` displays a payment dialog where user can specify an exact sum to be sent which would be bounded by:
+
+	```
+	max can send = min(maxSendable, local estimation of how much can be sent from wallet)
+
+	min can send = max(minSendable, local minimal value allowed by wallet)
+	```
+	Additionally, a payment dialog must include:
+	- Domain name extracted from `LNURL` query string.
+	- A way to view the metadata sent of `text/plain` format.
+	- A text input where user can enter a `comment` string (max character count is equal or less than `commentAllowed` value)
+    */
+
+    return Scaffold(
+      key: _scaffoldKey,
+      bottomNavigationBar: StreamBuilder<AccountModel>(
+          stream: accountBloc.accountStream,
+          builder: (context, snapshot) {
+            if (!snapshot.hasData) {
+              return StaticLoader();
+            }
+            var account = snapshot.data;
+            return Padding(
+              padding: EdgeInsets.only(
+                  bottom: (Platform.isIOS && _amountFocusNode.hasFocus)
+                      ? 40.0
+                      : 0.0),
+              child: SingleButtonBottomBar(
+                stickToBottom: true,
+                text: "REQUEST INVOICE",
+                onPressed: () {
+                  if (_formKey.currentState.validate()) {
+                    _getInvoice(invoiceBloc, accountBloc, lnurlBloc, account);
+                  }
+                },
+              ),
+            );
+          }),
+      appBar: AppBar(
+        iconTheme: Theme.of(context).appBarTheme.iconTheme,
+        textTheme: Theme.of(context).appBarTheme.textTheme,
+        backgroundColor: Theme.of(context).canvasColor,
+        leading: backBtn.BackButton(),
+        actions: <Widget>[], // FIXME: Should we have anything here?
+        title: Text(_title,
+            style: Theme.of(context).appBarTheme.textTheme.headline6),
+        elevation: 0.0,
+      ),
+      body: StreamBuilder<AccountModel>(
+        stream: accountBloc.accountStream,
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return StaticLoader();
+          }
+          AccountModel acc = snapshot.data;
+          return Form(
+            key: _formKey,
+            child: Padding(
+              padding: EdgeInsets.only(
+                  left: 16.0, right: 16.0, bottom: 40.0, top: 24.0),
+              child: Scrollbar(
+                child: SingleChildScrollView(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.max,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      TextFormField(
+                        controller: _commentController,
+                        keyboardType: TextInputType.multiline,
+                        textInputAction: TextInputAction.done,
+                        maxLines: null,
+                        maxLength: 90,
+                        maxLengthEnforced: true,
+                        decoration: InputDecoration(
+                          labelText: "Comment (optional)",
+                        ),
+                        style: theme.FieldTextStyle.textStyle,
+                      ),
+                      AmountFormField(
+                          context: context,
+                          accountModel: acc,
+                          focusNode: _amountFocusNode,
+                          controller: _amountController,
+                          validatorFn: (amt) {
+                            final min = widget.payFetchResponse.minAmount;
+                            final max = widget.payFetchResponse.maxAmount;
+
+                            if (amt < min) {
+                              return 'Payment required is at least ${acc.currency.format(min)}.';
+                            }
+
+                            if (amt > max) {
+                              return 'Payment exceeds the limit (${acc.currency.format(max)}).';
+                            }
+
+                            return null;
+                          },
+                          style: theme.FieldTextStyle.textStyle),
+                      Text('${_payFetchResponse.host}',
+                          textAlign: TextAlign.center,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.FieldTextStyle.labelStyle),
+                      Text('${_getMetadataText(_payFetchResponse.metadata)}',
+                          textAlign: TextAlign.center,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.FieldTextStyle.labelStyle),
+                      Container(
+                        width: MediaQuery.of(context).size.width,
+                        height: 48,
+                        padding: EdgeInsets.only(top: 16.0),
+                        child: _buildPayableBTC(acc),
+                      ),
+                      StreamBuilder(
+                          stream: accountBloc.accountStream,
+                          builder: (BuildContext context,
+                              AsyncSnapshot<AccountModel> accSnapshot) {
+                            if (!accSnapshot.hasData) {
+                              return Container();
+                            }
+
+                            String message;
+                            if (accSnapshot.hasError) {
+                              message = accSnapshot.error.toString();
+                            }
+
+                            if (message != null) {
+                              // In case error doesn't have a trailing full stop
+                              if (!message.endsWith('.')) {
+                                message += '.';
+                              }
+                              return Container(
+                                  padding: EdgeInsets.only(
+                                      top: 50.0, left: 30.0, right: 30.0),
+                                  child: Column(children: <Widget>[
+                                    Text(
+                                      message,
+                                      textAlign: TextAlign.center,
+                                      style: theme.warningStyle.copyWith(
+                                          color: Theme.of(context).errorColor),
+                                    ),
+                                  ]));
+                            } else {
+                              return SizedBox();
+                            }
+                          })
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildPayableBTC(AccountModel acc) {
+    return GestureDetector(
+      child: AutoSizeText(
+        "Pay between ${acc.currency.format(widget.payFetchResponse.minAmount)} and ${acc.currency.format(widget.payFetchResponse.maxAmount)}",
+        style: theme.textStyle,
+        maxLines: 1,
+        minFontSize: MinFontSize(context).minFontSize,
+      ),
+      onTap: () => _amountController.text = acc.currency.format(
+          widget.payFetchResponse.minAmount,
+          includeDisplayName: false,
+          userInput: true),
+    );
+  }
+
+  void applyPayFetchResponse(PayFetchResponse response, AccountModel account) {
+    _payFetchResponse = response;
+    _commentController.text = response.comment;
+    _amountController.text = account.currency
+        .format(response.minAmount, includeDisplayName: false, userInput: true);
+  }
+
+  String _getMetadataText(List<LNUrlPayMetadata> metadata) {
+    /*
+
+    `metadata` json array must contain one `text/plain` entry, all other types of entries are optional:
+
+    ```
+    [
+        [
+            "text/plain", // must always be present
+            content // actual metadata content
+        ],
+        [
+            "image/png;base64", // optional 512x512px PNG thumbnail which will represent this lnurl in a list or grid
+            content // base64 string, up to 136536 characters (100Kb of image data in base-64 encoding)
+        ],
+        [
+            "image/jpeg;base64", // optional 512x512px JPG thumbnail which will represent this lnurl in a list or grid
+            content // base64 string, up to 136536 characters (100Kb of image data in base-64 encoding)
+        ],
+        ... // more objects for future types
+    ]
+    ```
+
+    and be sent as a string:
+
+    ```
+    "[[\"text/plain\", \"lorem ipsum blah blah\"]]"
+    ```
+    */
+    var result = '';
+    log.info('_getMetadataText: metadata: $metadata');
+
+    for (var datum in metadata) {
+      if (datum.entry[0] == 'text/plain') {
+        result = datum.entry[1];
+        break;
+      }
+    }
+
+    return result;
+  }
+
+  void _getInvoice(InvoiceBloc invoiceBloc, AccountBloc accountBloc,
+      LNUrlBloc lnurlBloc, AccountModel account) async {
+    log.info('_getInvoice.');
+    /*
+         5. LN WALLET makes a GET request using callback with the following query parameters:
+         amount (input) - user specified sum in MilliSatoshi
+         nonce - an optional parameter used to prevent server response caching
+         fromnodes - an optional parameter with value set to comma separated nodeIds if payer wishes a service to provide payment routes starting from specified LN nodeIds
+         comment (input) - an optional parameter to pass the LN WALLET user's comment to LN SERVICE
+
+    */
+
+    var navigator = Navigator.of(context);
+    _currentRoute = ModalRoute.of(navigator.context);
+    _loaderRoute = createLoaderRoute(context);
+    navigator.push(_loaderRoute);
+
+    _payFetchResponse.amount =
+        account.currency.parse(_amountController.text) * 1000;
+    _payFetchResponse.comment = _commentController.text;
+
+    var action = FetchInvoice(_payFetchResponse);
+    action.future.catchError((e) {
+      promptError(
+          context,
+          "LNURL-Pay Error",
+          Text(
+              "An error occurred while attempting to retreive an invoice from ${_payFetchResponse.host}!\nReason: ${e.toString()}",
+              style: Theme.of(context).dialogTheme.contentTextStyle),
+          okFunc: _removeLoader);
+    }).then((payinfo) {
+      invoiceBloc.decodeInvoiceSink.add(payinfo.invoice);
+      log.info(
+          '_getInvoice: Found LNUrlPayInfo. Beginning payment request flow.');
+      _removeLoader();
+
+      /*
+           FIXME Verify that this works when:
+           "Before popping here, I suggest to check if the user cancelled by closing the dialog (back on android).  One way to do it is to check if the current widget is disposed and continue with the invoice only if it is not." (@roeierez) 
+      */
+
+      if (!_currentRoute.isCurrent) return;
+
+      Navigator.of(context).pop();
+    });
+
+    lnurlBloc.actionsSink.add(action);
+  }
+
+  void _removeLoader() {
+    if (mounted) {
+      if (_loaderRoute != null && _loaderRoute.isCurrent) {
+        Navigator.of(context).removeRoute(_loaderRoute);
+      }
+    }
+  }
+}

--- a/lib/services/breezlib/breez_bridge.dart
+++ b/lib/services/breezlib/breez_bridge.dart
@@ -136,8 +136,10 @@ class BreezBridge {
   }
 
   Future<LNUrlResponse> fetchLNUrl(String lnurl) {
-    return _invokeMethodImmediate("fetchLnurl", {"argument": lnurl})
+    var result = _invokeMethodImmediate("fetchLnurl", {"argument": lnurl})
         .then((result) => LNUrlResponse()..mergeFromBuffer(result ?? []));
+    logger.log.info("fetchLNUrl: ${result}");
+    return result;
   }
 
   Future withdrawLNUrl(String bolt11Invoice) {
@@ -148,6 +150,12 @@ class BreezBridge {
     return _invokeMethodWhenReady(
             "finishLNURLAuth", {"argument": response.response.writeToBuffer()})
         .then((value) => value as String);
+  }
+
+  Future<LNUrlPayInfo> fetchLNUrlPayInvoice(PayFetchResponse response) {
+    return _invokeMethodWhenReady(
+            "finishLNURLPay", {"argument": response.response.writeToBuffer()})
+        .then((result) => LNUrlPayInfo()..mergeFromBuffer(result ?? []));
   }
 
   Future<String> getLogPath() {

--- a/lib/services/breezlib/data/rpc.pb.dart
+++ b/lib/services/breezlib/data/rpc.pb.dart
@@ -1,8 +1,8 @@
 ///
 //  Generated code. Do not modify.
-//  source: rpc.proto
+//  source: messages.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -40,7 +40,7 @@ class ListPaymentsRequest extends $pb.GeneratedMessage {
   static $pb.PbList<ListPaymentsRequest> createRepeated() => $pb.PbList<ListPaymentsRequest>();
   @$core.pragma('dart2js:noInline')
   static ListPaymentsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPaymentsRequest>(create);
-  static ListPaymentsRequest _defaultInstance;
+  static ListPaymentsRequest? _defaultInstance;
 }
 
 class RestartDaemonRequest extends $pb.GeneratedMessage {
@@ -69,7 +69,7 @@ class RestartDaemonRequest extends $pb.GeneratedMessage {
   static $pb.PbList<RestartDaemonRequest> createRepeated() => $pb.PbList<RestartDaemonRequest>();
   @$core.pragma('dart2js:noInline')
   static RestartDaemonRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RestartDaemonRequest>(create);
-  static RestartDaemonRequest _defaultInstance;
+  static RestartDaemonRequest? _defaultInstance;
 }
 
 class RestartDaemonReply extends $pb.GeneratedMessage {
@@ -98,7 +98,7 @@ class RestartDaemonReply extends $pb.GeneratedMessage {
   static $pb.PbList<RestartDaemonReply> createRepeated() => $pb.PbList<RestartDaemonReply>();
   @$core.pragma('dart2js:noInline')
   static RestartDaemonReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RestartDaemonReply>(create);
-  static RestartDaemonReply _defaultInstance;
+  static RestartDaemonReply? _defaultInstance;
 }
 
 class AddFundInitRequest extends $pb.GeneratedMessage {
@@ -110,8 +110,8 @@ class AddFundInitRequest extends $pb.GeneratedMessage {
 
   AddFundInitRequest._() : super();
   factory AddFundInitRequest({
-    $core.String notificationToken,
-    $core.String lspID,
+    $core.String? notificationToken,
+    $core.String? lspID,
   }) {
     final _result = create();
     if (notificationToken != null) {
@@ -141,7 +141,7 @@ class AddFundInitRequest extends $pb.GeneratedMessage {
   static $pb.PbList<AddFundInitRequest> createRepeated() => $pb.PbList<AddFundInitRequest>();
   @$core.pragma('dart2js:noInline')
   static AddFundInitRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundInitRequest>(create);
-  static AddFundInitRequest _defaultInstance;
+  static AddFundInitRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get notificationToken => $_getSZ(0);
@@ -170,7 +170,7 @@ class FundStatusRequest extends $pb.GeneratedMessage {
 
   FundStatusRequest._() : super();
   factory FundStatusRequest({
-    $core.String notificationToken,
+    $core.String? notificationToken,
   }) {
     final _result = create();
     if (notificationToken != null) {
@@ -197,7 +197,7 @@ class FundStatusRequest extends $pb.GeneratedMessage {
   static $pb.PbList<FundStatusRequest> createRepeated() => $pb.PbList<FundStatusRequest>();
   @$core.pragma('dart2js:noInline')
   static FundStatusRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<FundStatusRequest>(create);
-  static FundStatusRequest _defaultInstance;
+  static FundStatusRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get notificationToken => $_getSZ(0);
@@ -218,8 +218,8 @@ class AddInvoiceReply extends $pb.GeneratedMessage {
 
   AddInvoiceReply._() : super();
   factory AddInvoiceReply({
-    $core.String paymentRequest,
-    $fixnum.Int64 lspFee,
+    $core.String? paymentRequest,
+    $fixnum.Int64? lspFee,
   }) {
     final _result = create();
     if (paymentRequest != null) {
@@ -249,7 +249,7 @@ class AddInvoiceReply extends $pb.GeneratedMessage {
   static $pb.PbList<AddInvoiceReply> createRepeated() => $pb.PbList<AddInvoiceReply>();
   @$core.pragma('dart2js:noInline')
   static AddInvoiceReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddInvoiceReply>(create);
-  static AddInvoiceReply _defaultInstance;
+  static AddInvoiceReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get paymentRequest => $_getSZ(0);
@@ -279,8 +279,8 @@ class ChainStatus extends $pb.GeneratedMessage {
 
   ChainStatus._() : super();
   factory ChainStatus({
-    $core.int blockHeight,
-    $core.bool syncedToChain,
+    $core.int? blockHeight,
+    $core.bool? syncedToChain,
   }) {
     final _result = create();
     if (blockHeight != null) {
@@ -310,7 +310,7 @@ class ChainStatus extends $pb.GeneratedMessage {
   static $pb.PbList<ChainStatus> createRepeated() => $pb.PbList<ChainStatus>();
   @$core.pragma('dart2js:noInline')
   static ChainStatus getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChainStatus>(create);
-  static ChainStatus _defaultInstance;
+  static ChainStatus? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get blockHeight => $_getIZ(0);
@@ -354,22 +354,22 @@ class Account extends $pb.GeneratedMessage {
 
   Account._() : super();
   factory Account({
-    $core.String id,
-    $fixnum.Int64 balance,
-    $fixnum.Int64 walletBalance,
-    Account_AccountStatus status,
-    $fixnum.Int64 maxAllowedToReceive,
-    $fixnum.Int64 maxAllowedToPay,
-    $fixnum.Int64 maxPaymentAmount,
-    $fixnum.Int64 routingNodeFee,
-    $core.bool enabled,
-    $fixnum.Int64 maxChanReserve,
-    $core.String channelPoint,
-    $core.bool readyForPayments,
-    $fixnum.Int64 tipHeight,
-    $core.Iterable<$core.String> connectedPeers,
-    $fixnum.Int64 maxInboundLiquidity,
-    $core.Iterable<$core.String> unconfirmedChannels,
+    $core.String? id,
+    $fixnum.Int64? balance,
+    $fixnum.Int64? walletBalance,
+    Account_AccountStatus? status,
+    $fixnum.Int64? maxAllowedToReceive,
+    $fixnum.Int64? maxAllowedToPay,
+    $fixnum.Int64? maxPaymentAmount,
+    $fixnum.Int64? routingNodeFee,
+    $core.bool? enabled,
+    $fixnum.Int64? maxChanReserve,
+    $core.String? channelPoint,
+    $core.bool? readyForPayments,
+    $fixnum.Int64? tipHeight,
+    $core.Iterable<$core.String>? connectedPeers,
+    $fixnum.Int64? maxInboundLiquidity,
+    $core.Iterable<$core.String>? unconfirmedChannels,
   }) {
     final _result = create();
     if (id != null) {
@@ -441,7 +441,7 @@ class Account extends $pb.GeneratedMessage {
   static $pb.PbList<Account> createRepeated() => $pb.PbList<Account>();
   @$core.pragma('dart2js:noInline')
   static Account getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Account>(create);
-  static Account _defaultInstance;
+  static Account? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
@@ -599,32 +599,34 @@ class Payment extends $pb.GeneratedMessage {
     ..aOS(21, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'closedChannelSweepTxID', protoName: 'closedChannelSweepTxID')
     ..aOS(22, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'groupKey', protoName: 'groupKey')
     ..aOS(23, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'groupName', protoName: 'groupName')
+    ..aOM<LNUrlPayInfo>(24, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lnurlPayInfo', protoName: 'lnurlPayInfo', subBuilder: LNUrlPayInfo.create)
     ..hasRequiredFields = false
   ;
 
   Payment._() : super();
   factory Payment({
-    Payment_PaymentType type,
-    $fixnum.Int64 amount,
-    $fixnum.Int64 creationTimestamp,
-    InvoiceMemo invoiceMemo,
-    $core.String redeemTxID,
-    $core.String paymentHash,
-    $core.String destination,
-    $core.int pendingExpirationHeight,
-    $fixnum.Int64 pendingExpirationTimestamp,
-    $fixnum.Int64 fee,
-    $core.String preimage,
-    $core.String closedChannelPoint,
-    $core.bool isChannelPending,
-    $core.bool isChannelCloseConfimed,
-    $core.String closedChannelTxID,
-    $core.bool isKeySend,
-    $core.bool pendingFull,
-    $core.String closedChannelRemoteTxID,
-    $core.String closedChannelSweepTxID,
-    $core.String groupKey,
-    $core.String groupName,
+    Payment_PaymentType? type,
+    $fixnum.Int64? amount,
+    $fixnum.Int64? creationTimestamp,
+    InvoiceMemo? invoiceMemo,
+    $core.String? redeemTxID,
+    $core.String? paymentHash,
+    $core.String? destination,
+    $core.int? pendingExpirationHeight,
+    $fixnum.Int64? pendingExpirationTimestamp,
+    $fixnum.Int64? fee,
+    $core.String? preimage,
+    $core.String? closedChannelPoint,
+    $core.bool? isChannelPending,
+    $core.bool? isChannelCloseConfimed,
+    $core.String? closedChannelTxID,
+    $core.bool? isKeySend,
+    $core.bool? pendingFull,
+    $core.String? closedChannelRemoteTxID,
+    $core.String? closedChannelSweepTxID,
+    $core.String? groupKey,
+    $core.String? groupName,
+    LNUrlPayInfo? lnurlPayInfo,
   }) {
     final _result = create();
     if (type != null) {
@@ -690,6 +692,9 @@ class Payment extends $pb.GeneratedMessage {
     if (groupName != null) {
       _result.groupName = groupName;
     }
+    if (lnurlPayInfo != null) {
+      _result.lnurlPayInfo = lnurlPayInfo;
+    }
     return _result;
   }
   factory Payment.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
@@ -711,7 +716,7 @@ class Payment extends $pb.GeneratedMessage {
   static $pb.PbList<Payment> createRepeated() => $pb.PbList<Payment>();
   @$core.pragma('dart2js:noInline')
   static Payment getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Payment>(create);
-  static Payment _defaultInstance;
+  static Payment? _defaultInstance;
 
   @$pb.TagNumber(1)
   Payment_PaymentType get type => $_getN(0);
@@ -903,6 +908,17 @@ class Payment extends $pb.GeneratedMessage {
   $core.bool hasGroupName() => $_has(20);
   @$pb.TagNumber(23)
   void clearGroupName() => clearField(23);
+
+  @$pb.TagNumber(24)
+  LNUrlPayInfo get lnurlPayInfo => $_getN(21);
+  @$pb.TagNumber(24)
+  set lnurlPayInfo(LNUrlPayInfo v) { setField(24, v); }
+  @$pb.TagNumber(24)
+  $core.bool hasLnurlPayInfo() => $_has(21);
+  @$pb.TagNumber(24)
+  void clearLnurlPayInfo() => clearField(24);
+  @$pb.TagNumber(24)
+  LNUrlPayInfo ensureLnurlPayInfo() => $_ensure(21);
 }
 
 class PaymentsList extends $pb.GeneratedMessage {
@@ -913,7 +929,7 @@ class PaymentsList extends $pb.GeneratedMessage {
 
   PaymentsList._() : super();
   factory PaymentsList({
-    $core.Iterable<Payment> paymentsList,
+    $core.Iterable<Payment>? paymentsList,
   }) {
     final _result = create();
     if (paymentsList != null) {
@@ -940,7 +956,7 @@ class PaymentsList extends $pb.GeneratedMessage {
   static $pb.PbList<PaymentsList> createRepeated() => $pb.PbList<PaymentsList>();
   @$core.pragma('dart2js:noInline')
   static PaymentsList getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PaymentsList>(create);
-  static PaymentsList _defaultInstance;
+  static PaymentsList? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<Payment> get paymentsList => $_getList(0);
@@ -955,8 +971,8 @@ class PaymentResponse extends $pb.GeneratedMessage {
 
   PaymentResponse._() : super();
   factory PaymentResponse({
-    $core.String paymentError,
-    $core.String traceReport,
+    $core.String? paymentError,
+    $core.String? traceReport,
   }) {
     final _result = create();
     if (paymentError != null) {
@@ -986,7 +1002,7 @@ class PaymentResponse extends $pb.GeneratedMessage {
   static $pb.PbList<PaymentResponse> createRepeated() => $pb.PbList<PaymentResponse>();
   @$core.pragma('dart2js:noInline')
   static PaymentResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PaymentResponse>(create);
-  static PaymentResponse _defaultInstance;
+  static PaymentResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get paymentError => $_getSZ(0);
@@ -1016,8 +1032,8 @@ class SendWalletCoinsRequest extends $pb.GeneratedMessage {
 
   SendWalletCoinsRequest._() : super();
   factory SendWalletCoinsRequest({
-    $core.String address,
-    $fixnum.Int64 satPerByteFee,
+    $core.String? address,
+    $fixnum.Int64? satPerByteFee,
   }) {
     final _result = create();
     if (address != null) {
@@ -1047,7 +1063,7 @@ class SendWalletCoinsRequest extends $pb.GeneratedMessage {
   static $pb.PbList<SendWalletCoinsRequest> createRepeated() => $pb.PbList<SendWalletCoinsRequest>();
   @$core.pragma('dart2js:noInline')
   static SendWalletCoinsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SendWalletCoinsRequest>(create);
-  static SendWalletCoinsRequest _defaultInstance;
+  static SendWalletCoinsRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
@@ -1077,8 +1093,8 @@ class PayInvoiceRequest extends $pb.GeneratedMessage {
 
   PayInvoiceRequest._() : super();
   factory PayInvoiceRequest({
-    $fixnum.Int64 amount,
-    $core.String paymentRequest,
+    $fixnum.Int64? amount,
+    $core.String? paymentRequest,
   }) {
     final _result = create();
     if (amount != null) {
@@ -1108,7 +1124,7 @@ class PayInvoiceRequest extends $pb.GeneratedMessage {
   static $pb.PbList<PayInvoiceRequest> createRepeated() => $pb.PbList<PayInvoiceRequest>();
   @$core.pragma('dart2js:noInline')
   static PayInvoiceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PayInvoiceRequest>(create);
-  static PayInvoiceRequest _defaultInstance;
+  static PayInvoiceRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get amount => $_getI64(0);
@@ -1143,13 +1159,13 @@ class SpontaneousPaymentRequest extends $pb.GeneratedMessage {
 
   SpontaneousPaymentRequest._() : super();
   factory SpontaneousPaymentRequest({
-    $fixnum.Int64 amount,
-    $core.String destNode,
-    $core.String description,
-    $core.String groupKey,
-    $core.String groupName,
-    $fixnum.Int64 feeLimitMsat,
-    $core.Map<$fixnum.Int64, $core.String> tlv,
+    $fixnum.Int64? amount,
+    $core.String? destNode,
+    $core.String? description,
+    $core.String? groupKey,
+    $core.String? groupName,
+    $fixnum.Int64? feeLimitMsat,
+    $core.Map<$fixnum.Int64, $core.String>? tlv,
   }) {
     final _result = create();
     if (amount != null) {
@@ -1194,7 +1210,7 @@ class SpontaneousPaymentRequest extends $pb.GeneratedMessage {
   static $pb.PbList<SpontaneousPaymentRequest> createRepeated() => $pb.PbList<SpontaneousPaymentRequest>();
   @$core.pragma('dart2js:noInline')
   static SpontaneousPaymentRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SpontaneousPaymentRequest>(create);
-  static SpontaneousPaymentRequest _defaultInstance;
+  static SpontaneousPaymentRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get amount => $_getI64(0);
@@ -1270,15 +1286,15 @@ class InvoiceMemo extends $pb.GeneratedMessage {
 
   InvoiceMemo._() : super();
   factory InvoiceMemo({
-    $core.String description,
-    $fixnum.Int64 amount,
-    $core.String payeeName,
-    $core.String payeeImageURL,
-    $core.String payerName,
-    $core.String payerImageURL,
-    $core.bool transferRequest,
-    $fixnum.Int64 expiry,
-    $core.List<$core.int> preimage,
+    $core.String? description,
+    $fixnum.Int64? amount,
+    $core.String? payeeName,
+    $core.String? payeeImageURL,
+    $core.String? payerName,
+    $core.String? payerImageURL,
+    $core.bool? transferRequest,
+    $fixnum.Int64? expiry,
+    $core.List<$core.int>? preimage,
   }) {
     final _result = create();
     if (description != null) {
@@ -1329,7 +1345,7 @@ class InvoiceMemo extends $pb.GeneratedMessage {
   static $pb.PbList<InvoiceMemo> createRepeated() => $pb.PbList<InvoiceMemo>();
   @$core.pragma('dart2js:noInline')
   static InvoiceMemo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<InvoiceMemo>(create);
-  static InvoiceMemo _defaultInstance;
+  static InvoiceMemo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get description => $_getSZ(0);
@@ -1422,8 +1438,8 @@ class AddInvoiceRequest extends $pb.GeneratedMessage {
 
   AddInvoiceRequest._() : super();
   factory AddInvoiceRequest({
-    InvoiceMemo invoiceDetails,
-    LSPInformation lspInfo,
+    InvoiceMemo? invoiceDetails,
+    LSPInformation? lspInfo,
   }) {
     final _result = create();
     if (invoiceDetails != null) {
@@ -1453,7 +1469,7 @@ class AddInvoiceRequest extends $pb.GeneratedMessage {
   static $pb.PbList<AddInvoiceRequest> createRepeated() => $pb.PbList<AddInvoiceRequest>();
   @$core.pragma('dart2js:noInline')
   static AddInvoiceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddInvoiceRequest>(create);
-  static AddInvoiceRequest _defaultInstance;
+  static AddInvoiceRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   InvoiceMemo get invoiceDetails => $_getN(0);
@@ -1488,9 +1504,9 @@ class Invoice extends $pb.GeneratedMessage {
 
   Invoice._() : super();
   factory Invoice({
-    InvoiceMemo memo,
-    $core.bool settled,
-    $fixnum.Int64 amtPaid,
+    InvoiceMemo? memo,
+    $core.bool? settled,
+    $fixnum.Int64? amtPaid,
   }) {
     final _result = create();
     if (memo != null) {
@@ -1523,7 +1539,7 @@ class Invoice extends $pb.GeneratedMessage {
   static $pb.PbList<Invoice> createRepeated() => $pb.PbList<Invoice>();
   @$core.pragma('dart2js:noInline')
   static Invoice getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Invoice>(create);
-  static Invoice _defaultInstance;
+  static Invoice? _defaultInstance;
 
   @$pb.TagNumber(1)
   InvoiceMemo get memo => $_getN(0);
@@ -1563,7 +1579,7 @@ class SyncLSPChannelsRequest extends $pb.GeneratedMessage {
 
   SyncLSPChannelsRequest._() : super();
   factory SyncLSPChannelsRequest({
-    LSPInformation lspInfo,
+    LSPInformation? lspInfo,
   }) {
     final _result = create();
     if (lspInfo != null) {
@@ -1590,7 +1606,7 @@ class SyncLSPChannelsRequest extends $pb.GeneratedMessage {
   static $pb.PbList<SyncLSPChannelsRequest> createRepeated() => $pb.PbList<SyncLSPChannelsRequest>();
   @$core.pragma('dart2js:noInline')
   static SyncLSPChannelsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SyncLSPChannelsRequest>(create);
-  static SyncLSPChannelsRequest _defaultInstance;
+  static SyncLSPChannelsRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   LSPInformation get lspInfo => $_getN(0);
@@ -1612,7 +1628,7 @@ class SyncLSPChannelsResponse extends $pb.GeneratedMessage {
 
   SyncLSPChannelsResponse._() : super();
   factory SyncLSPChannelsResponse({
-    $core.bool hasMismatch,
+    $core.bool? hasMismatch,
   }) {
     final _result = create();
     if (hasMismatch != null) {
@@ -1639,7 +1655,7 @@ class SyncLSPChannelsResponse extends $pb.GeneratedMessage {
   static $pb.PbList<SyncLSPChannelsResponse> createRepeated() => $pb.PbList<SyncLSPChannelsResponse>();
   @$core.pragma('dart2js:noInline')
   static SyncLSPChannelsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SyncLSPChannelsResponse>(create);
-  static SyncLSPChannelsResponse _defaultInstance;
+  static SyncLSPChannelsResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get hasMismatch => $_getBF(0);
@@ -1659,7 +1675,7 @@ class UnconfirmedChannelsStatus extends $pb.GeneratedMessage {
 
   UnconfirmedChannelsStatus._() : super();
   factory UnconfirmedChannelsStatus({
-    $core.Iterable<UnconfirmedChannelStatus> statuses,
+    $core.Iterable<UnconfirmedChannelStatus>? statuses,
   }) {
     final _result = create();
     if (statuses != null) {
@@ -1686,7 +1702,7 @@ class UnconfirmedChannelsStatus extends $pb.GeneratedMessage {
   static $pb.PbList<UnconfirmedChannelsStatus> createRepeated() => $pb.PbList<UnconfirmedChannelsStatus>();
   @$core.pragma('dart2js:noInline')
   static UnconfirmedChannelsStatus getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UnconfirmedChannelsStatus>(create);
-  static UnconfirmedChannelsStatus _defaultInstance;
+  static UnconfirmedChannelsStatus? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<UnconfirmedChannelStatus> get statuses => $_getList(0);
@@ -1702,9 +1718,9 @@ class UnconfirmedChannelStatus extends $pb.GeneratedMessage {
 
   UnconfirmedChannelStatus._() : super();
   factory UnconfirmedChannelStatus({
-    $core.String channelPoint,
-    $fixnum.Int64 heightHint,
-    $fixnum.Int64 lspConfirmedHeight,
+    $core.String? channelPoint,
+    $fixnum.Int64? heightHint,
+    $fixnum.Int64? lspConfirmedHeight,
   }) {
     final _result = create();
     if (channelPoint != null) {
@@ -1737,7 +1753,7 @@ class UnconfirmedChannelStatus extends $pb.GeneratedMessage {
   static $pb.PbList<UnconfirmedChannelStatus> createRepeated() => $pb.PbList<UnconfirmedChannelStatus>();
   @$core.pragma('dart2js:noInline')
   static UnconfirmedChannelStatus getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UnconfirmedChannelStatus>(create);
-  static UnconfirmedChannelStatus _defaultInstance;
+  static UnconfirmedChannelStatus? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get channelPoint => $_getSZ(0);
@@ -1776,8 +1792,8 @@ class CheckLSPClosedChannelMismatchRequest extends $pb.GeneratedMessage {
 
   CheckLSPClosedChannelMismatchRequest._() : super();
   factory CheckLSPClosedChannelMismatchRequest({
-    LSPInformation lspInfo,
-    $core.String chanPoint,
+    LSPInformation? lspInfo,
+    $core.String? chanPoint,
   }) {
     final _result = create();
     if (lspInfo != null) {
@@ -1807,7 +1823,7 @@ class CheckLSPClosedChannelMismatchRequest extends $pb.GeneratedMessage {
   static $pb.PbList<CheckLSPClosedChannelMismatchRequest> createRepeated() => $pb.PbList<CheckLSPClosedChannelMismatchRequest>();
   @$core.pragma('dart2js:noInline')
   static CheckLSPClosedChannelMismatchRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CheckLSPClosedChannelMismatchRequest>(create);
-  static CheckLSPClosedChannelMismatchRequest _defaultInstance;
+  static CheckLSPClosedChannelMismatchRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   LSPInformation get lspInfo => $_getN(0);
@@ -1838,7 +1854,7 @@ class CheckLSPClosedChannelMismatchResponse extends $pb.GeneratedMessage {
 
   CheckLSPClosedChannelMismatchResponse._() : super();
   factory CheckLSPClosedChannelMismatchResponse({
-    $core.bool mismatch,
+    $core.bool? mismatch,
   }) {
     final _result = create();
     if (mismatch != null) {
@@ -1865,7 +1881,7 @@ class CheckLSPClosedChannelMismatchResponse extends $pb.GeneratedMessage {
   static $pb.PbList<CheckLSPClosedChannelMismatchResponse> createRepeated() => $pb.PbList<CheckLSPClosedChannelMismatchResponse>();
   @$core.pragma('dart2js:noInline')
   static CheckLSPClosedChannelMismatchResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CheckLSPClosedChannelMismatchResponse>(create);
-  static CheckLSPClosedChannelMismatchResponse _defaultInstance;
+  static CheckLSPClosedChannelMismatchResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get mismatch => $_getBF(0);
@@ -1886,8 +1902,8 @@ class ResetClosedChannelChainInfoRequest extends $pb.GeneratedMessage {
 
   ResetClosedChannelChainInfoRequest._() : super();
   factory ResetClosedChannelChainInfoRequest({
-    $core.String chanPoint,
-    $fixnum.Int64 blockHeight,
+    $core.String? chanPoint,
+    $fixnum.Int64? blockHeight,
   }) {
     final _result = create();
     if (chanPoint != null) {
@@ -1917,7 +1933,7 @@ class ResetClosedChannelChainInfoRequest extends $pb.GeneratedMessage {
   static $pb.PbList<ResetClosedChannelChainInfoRequest> createRepeated() => $pb.PbList<ResetClosedChannelChainInfoRequest>();
   @$core.pragma('dart2js:noInline')
   static ResetClosedChannelChainInfoRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ResetClosedChannelChainInfoRequest>(create);
-  static ResetClosedChannelChainInfoRequest _defaultInstance;
+  static ResetClosedChannelChainInfoRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get chanPoint => $_getSZ(0);
@@ -1964,7 +1980,7 @@ class ResetClosedChannelChainInfoReply extends $pb.GeneratedMessage {
   static $pb.PbList<ResetClosedChannelChainInfoReply> createRepeated() => $pb.PbList<ResetClosedChannelChainInfoReply>();
   @$core.pragma('dart2js:noInline')
   static ResetClosedChannelChainInfoReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ResetClosedChannelChainInfoReply>(create);
-  static ResetClosedChannelChainInfoReply _defaultInstance;
+  static ResetClosedChannelChainInfoReply? _defaultInstance;
 }
 
 class NotificationEvent extends $pb.GeneratedMessage {
@@ -1976,8 +1992,8 @@ class NotificationEvent extends $pb.GeneratedMessage {
 
   NotificationEvent._() : super();
   factory NotificationEvent({
-    NotificationEvent_NotificationType type,
-    $core.Iterable<$core.String> data,
+    NotificationEvent_NotificationType? type,
+    $core.Iterable<$core.String>? data,
   }) {
     final _result = create();
     if (type != null) {
@@ -2007,7 +2023,7 @@ class NotificationEvent extends $pb.GeneratedMessage {
   static $pb.PbList<NotificationEvent> createRepeated() => $pb.PbList<NotificationEvent>();
   @$core.pragma('dart2js:noInline')
   static NotificationEvent getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NotificationEvent>(create);
-  static NotificationEvent _defaultInstance;
+  static NotificationEvent? _defaultInstance;
 
   @$pb.TagNumber(1)
   NotificationEvent_NotificationType get type => $_getN(0);
@@ -2035,12 +2051,12 @@ class AddFundInitReply extends $pb.GeneratedMessage {
 
   AddFundInitReply._() : super();
   factory AddFundInitReply({
-    $core.String address,
-    $fixnum.Int64 maxAllowedDeposit,
-    $core.String errorMessage,
-    $core.String backupJson,
-    $fixnum.Int64 requiredReserve,
-    $fixnum.Int64 minAllowedDeposit,
+    $core.String? address,
+    $fixnum.Int64? maxAllowedDeposit,
+    $core.String? errorMessage,
+    $core.String? backupJson,
+    $fixnum.Int64? requiredReserve,
+    $fixnum.Int64? minAllowedDeposit,
   }) {
     final _result = create();
     if (address != null) {
@@ -2082,7 +2098,7 @@ class AddFundInitReply extends $pb.GeneratedMessage {
   static $pb.PbList<AddFundInitReply> createRepeated() => $pb.PbList<AddFundInitReply>();
   @$core.pragma('dart2js:noInline')
   static AddFundInitReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundInitReply>(create);
-  static AddFundInitReply _defaultInstance;
+  static AddFundInitReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
@@ -2147,7 +2163,7 @@ class AddFundReply extends $pb.GeneratedMessage {
 
   AddFundReply._() : super();
   factory AddFundReply({
-    $core.String errorMessage,
+    $core.String? errorMessage,
   }) {
     final _result = create();
     if (errorMessage != null) {
@@ -2174,7 +2190,7 @@ class AddFundReply extends $pb.GeneratedMessage {
   static $pb.PbList<AddFundReply> createRepeated() => $pb.PbList<AddFundReply>();
   @$core.pragma('dart2js:noInline')
   static AddFundReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundReply>(create);
-  static AddFundReply _defaultInstance;
+  static AddFundReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get errorMessage => $_getSZ(0);
@@ -2197,10 +2213,10 @@ class RefundRequest extends $pb.GeneratedMessage {
 
   RefundRequest._() : super();
   factory RefundRequest({
-    $core.String address,
-    $core.String refundAddress,
-    $core.int targetConf,
-    $fixnum.Int64 satPerByte,
+    $core.String? address,
+    $core.String? refundAddress,
+    $core.int? targetConf,
+    $fixnum.Int64? satPerByte,
   }) {
     final _result = create();
     if (address != null) {
@@ -2236,7 +2252,7 @@ class RefundRequest extends $pb.GeneratedMessage {
   static $pb.PbList<RefundRequest> createRepeated() => $pb.PbList<RefundRequest>();
   @$core.pragma('dart2js:noInline')
   static RefundRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RefundRequest>(create);
-  static RefundRequest _defaultInstance;
+  static RefundRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
@@ -2284,8 +2300,8 @@ class AddFundError extends $pb.GeneratedMessage {
 
   AddFundError._() : super();
   factory AddFundError({
-    SwapAddressInfo swapAddressInfo,
-    $core.double hoursToUnlock,
+    SwapAddressInfo? swapAddressInfo,
+    $core.double? hoursToUnlock,
   }) {
     final _result = create();
     if (swapAddressInfo != null) {
@@ -2315,7 +2331,7 @@ class AddFundError extends $pb.GeneratedMessage {
   static $pb.PbList<AddFundError> createRepeated() => $pb.PbList<AddFundError>();
   @$core.pragma('dart2js:noInline')
   static AddFundError getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundError>(create);
-  static AddFundError _defaultInstance;
+  static AddFundError? _defaultInstance;
 
   @$pb.TagNumber(1)
   SwapAddressInfo get swapAddressInfo => $_getN(0);
@@ -2348,9 +2364,9 @@ class FundStatusReply extends $pb.GeneratedMessage {
 
   FundStatusReply._() : super();
   factory FundStatusReply({
-    $core.Iterable<SwapAddressInfo> unConfirmedAddresses,
-    $core.Iterable<SwapAddressInfo> confirmedAddresses,
-    $core.Iterable<SwapAddressInfo> refundableAddresses,
+    $core.Iterable<SwapAddressInfo>? unConfirmedAddresses,
+    $core.Iterable<SwapAddressInfo>? confirmedAddresses,
+    $core.Iterable<SwapAddressInfo>? refundableAddresses,
   }) {
     final _result = create();
     if (unConfirmedAddresses != null) {
@@ -2383,7 +2399,7 @@ class FundStatusReply extends $pb.GeneratedMessage {
   static $pb.PbList<FundStatusReply> createRepeated() => $pb.PbList<FundStatusReply>();
   @$core.pragma('dart2js:noInline')
   static FundStatusReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<FundStatusReply>(create);
-  static FundStatusReply _defaultInstance;
+  static FundStatusReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<SwapAddressInfo> get unConfirmedAddresses => $_getList(0);
@@ -2404,8 +2420,8 @@ class RemoveFundRequest extends $pb.GeneratedMessage {
 
   RemoveFundRequest._() : super();
   factory RemoveFundRequest({
-    $core.String address,
-    $fixnum.Int64 amount,
+    $core.String? address,
+    $fixnum.Int64? amount,
   }) {
     final _result = create();
     if (address != null) {
@@ -2435,7 +2451,7 @@ class RemoveFundRequest extends $pb.GeneratedMessage {
   static $pb.PbList<RemoveFundRequest> createRepeated() => $pb.PbList<RemoveFundRequest>();
   @$core.pragma('dart2js:noInline')
   static RemoveFundRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFundRequest>(create);
-  static RemoveFundRequest _defaultInstance;
+  static RemoveFundRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
@@ -2465,8 +2481,8 @@ class RemoveFundReply extends $pb.GeneratedMessage {
 
   RemoveFundReply._() : super();
   factory RemoveFundReply({
-    $core.String txid,
-    $core.String errorMessage,
+    $core.String? txid,
+    $core.String? errorMessage,
   }) {
     final _result = create();
     if (txid != null) {
@@ -2496,7 +2512,7 @@ class RemoveFundReply extends $pb.GeneratedMessage {
   static $pb.PbList<RemoveFundReply> createRepeated() => $pb.PbList<RemoveFundReply>();
   @$core.pragma('dart2js:noInline')
   static RemoveFundReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFundReply>(create);
-  static RemoveFundReply _defaultInstance;
+  static RemoveFundReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
@@ -2536,18 +2552,18 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
 
   SwapAddressInfo._() : super();
   factory SwapAddressInfo({
-    $core.String address,
-    $core.String paymentHash,
-    $fixnum.Int64 confirmedAmount,
-    $core.Iterable<$core.String> confirmedTransactionIds,
-    $fixnum.Int64 paidAmount,
-    $core.int lockHeight,
-    $core.String errorMessage,
-    $core.String lastRefundTxID,
-    SwapError swapError,
-    $core.String fundingTxID,
-    $core.double hoursToUnlock,
-    $core.bool nonBlocking,
+    $core.String? address,
+    $core.String? paymentHash,
+    $fixnum.Int64? confirmedAmount,
+    $core.Iterable<$core.String>? confirmedTransactionIds,
+    $fixnum.Int64? paidAmount,
+    $core.int? lockHeight,
+    $core.String? errorMessage,
+    $core.String? lastRefundTxID,
+    SwapError? swapError,
+    $core.String? fundingTxID,
+    $core.double? hoursToUnlock,
+    $core.bool? nonBlocking,
   }) {
     final _result = create();
     if (address != null) {
@@ -2607,7 +2623,7 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   static $pb.PbList<SwapAddressInfo> createRepeated() => $pb.PbList<SwapAddressInfo>();
   @$core.pragma('dart2js:noInline')
   static SwapAddressInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SwapAddressInfo>(create);
-  static SwapAddressInfo _defaultInstance;
+  static SwapAddressInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
@@ -2720,7 +2736,7 @@ class SwapAddressList extends $pb.GeneratedMessage {
 
   SwapAddressList._() : super();
   factory SwapAddressList({
-    $core.Iterable<SwapAddressInfo> addresses,
+    $core.Iterable<SwapAddressInfo>? addresses,
   }) {
     final _result = create();
     if (addresses != null) {
@@ -2747,7 +2763,7 @@ class SwapAddressList extends $pb.GeneratedMessage {
   static $pb.PbList<SwapAddressList> createRepeated() => $pb.PbList<SwapAddressList>();
   @$core.pragma('dart2js:noInline')
   static SwapAddressList getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SwapAddressList>(create);
-  static SwapAddressList _defaultInstance;
+  static SwapAddressList? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<SwapAddressInfo> get addresses => $_getList(0);
@@ -2764,10 +2780,10 @@ class CreateRatchetSessionRequest extends $pb.GeneratedMessage {
 
   CreateRatchetSessionRequest._() : super();
   factory CreateRatchetSessionRequest({
-    $core.String secret,
-    $core.String remotePubKey,
-    $core.String sessionID,
-    $fixnum.Int64 expiry,
+    $core.String? secret,
+    $core.String? remotePubKey,
+    $core.String? sessionID,
+    $fixnum.Int64? expiry,
   }) {
     final _result = create();
     if (secret != null) {
@@ -2803,7 +2819,7 @@ class CreateRatchetSessionRequest extends $pb.GeneratedMessage {
   static $pb.PbList<CreateRatchetSessionRequest> createRepeated() => $pb.PbList<CreateRatchetSessionRequest>();
   @$core.pragma('dart2js:noInline')
   static CreateRatchetSessionRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateRatchetSessionRequest>(create);
-  static CreateRatchetSessionRequest _defaultInstance;
+  static CreateRatchetSessionRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get secret => $_getSZ(0);
@@ -2852,9 +2868,9 @@ class CreateRatchetSessionReply extends $pb.GeneratedMessage {
 
   CreateRatchetSessionReply._() : super();
   factory CreateRatchetSessionReply({
-    $core.String sessionID,
-    $core.String secret,
-    $core.String pubKey,
+    $core.String? sessionID,
+    $core.String? secret,
+    $core.String? pubKey,
   }) {
     final _result = create();
     if (sessionID != null) {
@@ -2887,7 +2903,7 @@ class CreateRatchetSessionReply extends $pb.GeneratedMessage {
   static $pb.PbList<CreateRatchetSessionReply> createRepeated() => $pb.PbList<CreateRatchetSessionReply>();
   @$core.pragma('dart2js:noInline')
   static CreateRatchetSessionReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateRatchetSessionReply>(create);
-  static CreateRatchetSessionReply _defaultInstance;
+  static CreateRatchetSessionReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sessionID => $_getSZ(0);
@@ -2927,9 +2943,9 @@ class RatchetSessionInfoReply extends $pb.GeneratedMessage {
 
   RatchetSessionInfoReply._() : super();
   factory RatchetSessionInfoReply({
-    $core.String sessionID,
-    $core.bool initiated,
-    $core.String userInfo,
+    $core.String? sessionID,
+    $core.bool? initiated,
+    $core.String? userInfo,
   }) {
     final _result = create();
     if (sessionID != null) {
@@ -2962,7 +2978,7 @@ class RatchetSessionInfoReply extends $pb.GeneratedMessage {
   static $pb.PbList<RatchetSessionInfoReply> createRepeated() => $pb.PbList<RatchetSessionInfoReply>();
   @$core.pragma('dart2js:noInline')
   static RatchetSessionInfoReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatchetSessionInfoReply>(create);
-  static RatchetSessionInfoReply _defaultInstance;
+  static RatchetSessionInfoReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sessionID => $_getSZ(0);
@@ -3001,8 +3017,8 @@ class RatchetSessionSetInfoRequest extends $pb.GeneratedMessage {
 
   RatchetSessionSetInfoRequest._() : super();
   factory RatchetSessionSetInfoRequest({
-    $core.String sessionID,
-    $core.String userInfo,
+    $core.String? sessionID,
+    $core.String? userInfo,
   }) {
     final _result = create();
     if (sessionID != null) {
@@ -3032,7 +3048,7 @@ class RatchetSessionSetInfoRequest extends $pb.GeneratedMessage {
   static $pb.PbList<RatchetSessionSetInfoRequest> createRepeated() => $pb.PbList<RatchetSessionSetInfoRequest>();
   @$core.pragma('dart2js:noInline')
   static RatchetSessionSetInfoRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatchetSessionSetInfoRequest>(create);
-  static RatchetSessionSetInfoRequest _defaultInstance;
+  static RatchetSessionSetInfoRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sessionID => $_getSZ(0);
@@ -3062,8 +3078,8 @@ class RatchetEncryptRequest extends $pb.GeneratedMessage {
 
   RatchetEncryptRequest._() : super();
   factory RatchetEncryptRequest({
-    $core.String sessionID,
-    $core.String message,
+    $core.String? sessionID,
+    $core.String? message,
   }) {
     final _result = create();
     if (sessionID != null) {
@@ -3093,7 +3109,7 @@ class RatchetEncryptRequest extends $pb.GeneratedMessage {
   static $pb.PbList<RatchetEncryptRequest> createRepeated() => $pb.PbList<RatchetEncryptRequest>();
   @$core.pragma('dart2js:noInline')
   static RatchetEncryptRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatchetEncryptRequest>(create);
-  static RatchetEncryptRequest _defaultInstance;
+  static RatchetEncryptRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sessionID => $_getSZ(0);
@@ -3123,8 +3139,8 @@ class RatchetDecryptRequest extends $pb.GeneratedMessage {
 
   RatchetDecryptRequest._() : super();
   factory RatchetDecryptRequest({
-    $core.String sessionID,
-    $core.String encryptedMessage,
+    $core.String? sessionID,
+    $core.String? encryptedMessage,
   }) {
     final _result = create();
     if (sessionID != null) {
@@ -3154,7 +3170,7 @@ class RatchetDecryptRequest extends $pb.GeneratedMessage {
   static $pb.PbList<RatchetDecryptRequest> createRepeated() => $pb.PbList<RatchetDecryptRequest>();
   @$core.pragma('dart2js:noInline')
   static RatchetDecryptRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatchetDecryptRequest>(create);
-  static RatchetDecryptRequest _defaultInstance;
+  static RatchetDecryptRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sessionID => $_getSZ(0);
@@ -3184,8 +3200,8 @@ class BootstrapFilesRequest extends $pb.GeneratedMessage {
 
   BootstrapFilesRequest._() : super();
   factory BootstrapFilesRequest({
-    $core.String workingDir,
-    $core.Iterable<$core.String> fullPaths,
+    $core.String? workingDir,
+    $core.Iterable<$core.String>? fullPaths,
   }) {
     final _result = create();
     if (workingDir != null) {
@@ -3215,7 +3231,7 @@ class BootstrapFilesRequest extends $pb.GeneratedMessage {
   static $pb.PbList<BootstrapFilesRequest> createRepeated() => $pb.PbList<BootstrapFilesRequest>();
   @$core.pragma('dart2js:noInline')
   static BootstrapFilesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BootstrapFilesRequest>(create);
-  static BootstrapFilesRequest _defaultInstance;
+  static BootstrapFilesRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get workingDir => $_getSZ(0);
@@ -3239,8 +3255,8 @@ class Peers extends $pb.GeneratedMessage {
 
   Peers._() : super();
   factory Peers({
-    $core.bool isDefault,
-    $core.Iterable<$core.String> peer,
+    $core.bool? isDefault,
+    $core.Iterable<$core.String>? peer,
   }) {
     final _result = create();
     if (isDefault != null) {
@@ -3270,7 +3286,7 @@ class Peers extends $pb.GeneratedMessage {
   static $pb.PbList<Peers> createRepeated() => $pb.PbList<Peers>();
   @$core.pragma('dart2js:noInline')
   static Peers getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Peers>(create);
-  static Peers _defaultInstance;
+  static Peers? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get isDefault => $_getBF(0);
@@ -3295,9 +3311,9 @@ class TxSpentURL extends $pb.GeneratedMessage {
 
   TxSpentURL._() : super();
   factory TxSpentURL({
-    $core.String uRL,
-    $core.bool isDefault,
-    $core.bool disabled,
+    $core.String? uRL,
+    $core.bool? isDefault,
+    $core.bool? disabled,
   }) {
     final _result = create();
     if (uRL != null) {
@@ -3330,7 +3346,7 @@ class TxSpentURL extends $pb.GeneratedMessage {
   static $pb.PbList<TxSpentURL> createRepeated() => $pb.PbList<TxSpentURL>();
   @$core.pragma('dart2js:noInline')
   static TxSpentURL getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxSpentURL>(create);
-  static TxSpentURL _defaultInstance;
+  static TxSpentURL? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get uRL => $_getSZ(0);
@@ -3369,8 +3385,8 @@ class rate extends $pb.GeneratedMessage {
 
   rate._() : super();
   factory rate({
-    $core.String coin,
-    $core.double value,
+    $core.String? coin,
+    $core.double? value,
   }) {
     final _result = create();
     if (coin != null) {
@@ -3400,7 +3416,7 @@ class rate extends $pb.GeneratedMessage {
   static $pb.PbList<rate> createRepeated() => $pb.PbList<rate>();
   @$core.pragma('dart2js:noInline')
   static rate getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<rate>(create);
-  static rate _defaultInstance;
+  static rate? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get coin => $_getSZ(0);
@@ -3429,7 +3445,7 @@ class Rates extends $pb.GeneratedMessage {
 
   Rates._() : super();
   factory Rates({
-    $core.Iterable<rate> rates,
+    $core.Iterable<rate>? rates,
   }) {
     final _result = create();
     if (rates != null) {
@@ -3456,7 +3472,7 @@ class Rates extends $pb.GeneratedMessage {
   static $pb.PbList<Rates> createRepeated() => $pb.PbList<Rates>();
   @$core.pragma('dart2js:noInline')
   static Rates getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Rates>(create);
-  static Rates _defaultInstance;
+  static Rates? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<rate> get rates => $_getList(0);
@@ -3484,21 +3500,21 @@ class LSPInformation extends $pb.GeneratedMessage {
 
   LSPInformation._() : super();
   factory LSPInformation({
-    $core.String id,
-    $core.String name,
-    $core.String widgetUrl,
-    $core.String pubkey,
-    $core.String host,
-    $fixnum.Int64 channelCapacity,
-    $core.int targetConf,
-    $fixnum.Int64 baseFeeMsat,
-    $core.double feeRate,
-    $core.int timeLockDelta,
-    $fixnum.Int64 minHtlcMsat,
-    $fixnum.Int64 channelFeePermyriad,
-    $core.List<$core.int> lspPubkey,
-    $fixnum.Int64 maxInactiveDuration,
-    $fixnum.Int64 channelMinimumFeeMsat,
+    $core.String? id,
+    $core.String? name,
+    $core.String? widgetUrl,
+    $core.String? pubkey,
+    $core.String? host,
+    $fixnum.Int64? channelCapacity,
+    $core.int? targetConf,
+    $fixnum.Int64? baseFeeMsat,
+    $core.double? feeRate,
+    $core.int? timeLockDelta,
+    $fixnum.Int64? minHtlcMsat,
+    $fixnum.Int64? channelFeePermyriad,
+    $core.List<$core.int>? lspPubkey,
+    $fixnum.Int64? maxInactiveDuration,
+    $fixnum.Int64? channelMinimumFeeMsat,
   }) {
     final _result = create();
     if (id != null) {
@@ -3567,7 +3583,7 @@ class LSPInformation extends $pb.GeneratedMessage {
   static $pb.PbList<LSPInformation> createRepeated() => $pb.PbList<LSPInformation>();
   @$core.pragma('dart2js:noInline')
   static LSPInformation getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LSPInformation>(create);
-  static LSPInformation _defaultInstance;
+  static LSPInformation? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
@@ -3731,7 +3747,7 @@ class LSPListRequest extends $pb.GeneratedMessage {
   static $pb.PbList<LSPListRequest> createRepeated() => $pb.PbList<LSPListRequest>();
   @$core.pragma('dart2js:noInline')
   static LSPListRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LSPListRequest>(create);
-  static LSPListRequest _defaultInstance;
+  static LSPListRequest? _defaultInstance;
 }
 
 class LSPList extends $pb.GeneratedMessage {
@@ -3742,7 +3758,7 @@ class LSPList extends $pb.GeneratedMessage {
 
   LSPList._() : super();
   factory LSPList({
-    $core.Map<$core.String, LSPInformation> lsps,
+    $core.Map<$core.String, LSPInformation>? lsps,
   }) {
     final _result = create();
     if (lsps != null) {
@@ -3769,7 +3785,7 @@ class LSPList extends $pb.GeneratedMessage {
   static $pb.PbList<LSPList> createRepeated() => $pb.PbList<LSPList>();
   @$core.pragma('dart2js:noInline')
   static LSPList getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LSPList>(create);
-  static LSPList _defaultInstance;
+  static LSPList? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.Map<$core.String, LSPInformation> get lsps => $_getMap(0);
@@ -3783,7 +3799,7 @@ class LSPActivity extends $pb.GeneratedMessage {
 
   LSPActivity._() : super();
   factory LSPActivity({
-    $core.Map<$core.String, $fixnum.Int64> activity,
+    $core.Map<$core.String, $fixnum.Int64>? activity,
   }) {
     final _result = create();
     if (activity != null) {
@@ -3810,7 +3826,7 @@ class LSPActivity extends $pb.GeneratedMessage {
   static $pb.PbList<LSPActivity> createRepeated() => $pb.PbList<LSPActivity>();
   @$core.pragma('dart2js:noInline')
   static LSPActivity getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LSPActivity>(create);
-  static LSPActivity _defaultInstance;
+  static LSPActivity? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.Map<$core.String, $fixnum.Int64> get activity => $_getMap(0);
@@ -3824,7 +3840,7 @@ class ConnectLSPRequest extends $pb.GeneratedMessage {
 
   ConnectLSPRequest._() : super();
   factory ConnectLSPRequest({
-    $core.String lspId,
+    $core.String? lspId,
   }) {
     final _result = create();
     if (lspId != null) {
@@ -3851,7 +3867,7 @@ class ConnectLSPRequest extends $pb.GeneratedMessage {
   static $pb.PbList<ConnectLSPRequest> createRepeated() => $pb.PbList<ConnectLSPRequest>();
   @$core.pragma('dart2js:noInline')
   static ConnectLSPRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectLSPRequest>(create);
-  static ConnectLSPRequest _defaultInstance;
+  static ConnectLSPRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get lspId => $_getSZ(0);
@@ -3889,13 +3905,14 @@ class ConnectLSPReply extends $pb.GeneratedMessage {
   static $pb.PbList<ConnectLSPReply> createRepeated() => $pb.PbList<ConnectLSPReply>();
   @$core.pragma('dart2js:noInline')
   static ConnectLSPReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectLSPReply>(create);
-  static ConnectLSPReply _defaultInstance;
+  static ConnectLSPReply? _defaultInstance;
 }
 
 enum LNUrlResponse_Action {
   withdraw, 
   channel, 
   auth, 
+  payResponse1, 
   notSet
 }
 
@@ -3904,21 +3921,24 @@ class LNUrlResponse extends $pb.GeneratedMessage {
     1 : LNUrlResponse_Action.withdraw,
     2 : LNUrlResponse_Action.channel,
     3 : LNUrlResponse_Action.auth,
+    4 : LNUrlResponse_Action.payResponse1,
     0 : LNUrlResponse_Action.notSet
   };
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNUrlResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..oo(0, [1, 2, 3])
+    ..oo(0, [1, 2, 3, 4])
     ..aOM<LNUrlWithdraw>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'withdraw', subBuilder: LNUrlWithdraw.create)
     ..aOM<LNURLChannel>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'channel', subBuilder: LNURLChannel.create)
     ..aOM<LNURLAuth>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'auth', subBuilder: LNURLAuth.create)
+    ..aOM<LNURLPayResponse1>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'payResponse1', protoName: 'payResponse1', subBuilder: LNURLPayResponse1.create)
     ..hasRequiredFields = false
   ;
 
   LNUrlResponse._() : super();
   factory LNUrlResponse({
-    LNUrlWithdraw withdraw,
-    LNURLChannel channel,
-    LNURLAuth auth,
+    LNUrlWithdraw? withdraw,
+    LNURLChannel? channel,
+    LNURLAuth? auth,
+    LNURLPayResponse1? payResponse1,
   }) {
     final _result = create();
     if (withdraw != null) {
@@ -3929,6 +3949,9 @@ class LNUrlResponse extends $pb.GeneratedMessage {
     }
     if (auth != null) {
       _result.auth = auth;
+    }
+    if (payResponse1 != null) {
+      _result.payResponse1 = payResponse1;
     }
     return _result;
   }
@@ -3951,9 +3974,9 @@ class LNUrlResponse extends $pb.GeneratedMessage {
   static $pb.PbList<LNUrlResponse> createRepeated() => $pb.PbList<LNUrlResponse>();
   @$core.pragma('dart2js:noInline')
   static LNUrlResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNUrlResponse>(create);
-  static LNUrlResponse _defaultInstance;
+  static LNUrlResponse? _defaultInstance;
 
-  LNUrlResponse_Action whichAction() => _LNUrlResponse_ActionByTag[$_whichOneof(0)];
+  LNUrlResponse_Action whichAction() => _LNUrlResponse_ActionByTag[$_whichOneof(0)]!;
   void clearAction() => clearField($_whichOneof(0));
 
   @$pb.TagNumber(1)
@@ -3988,6 +4011,17 @@ class LNUrlResponse extends $pb.GeneratedMessage {
   void clearAuth() => clearField(3);
   @$pb.TagNumber(3)
   LNURLAuth ensureAuth() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  LNURLPayResponse1 get payResponse1 => $_getN(3);
+  @$pb.TagNumber(4)
+  set payResponse1(LNURLPayResponse1 v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasPayResponse1() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearPayResponse1() => clearField(4);
+  @$pb.TagNumber(4)
+  LNURLPayResponse1 ensurePayResponse1() => $_ensure(3);
 }
 
 class LNUrlWithdraw extends $pb.GeneratedMessage {
@@ -4000,9 +4034,9 @@ class LNUrlWithdraw extends $pb.GeneratedMessage {
 
   LNUrlWithdraw._() : super();
   factory LNUrlWithdraw({
-    $fixnum.Int64 minAmount,
-    $fixnum.Int64 maxAmount,
-    $core.String defaultDescription,
+    $fixnum.Int64? minAmount,
+    $fixnum.Int64? maxAmount,
+    $core.String? defaultDescription,
   }) {
     final _result = create();
     if (minAmount != null) {
@@ -4035,7 +4069,7 @@ class LNUrlWithdraw extends $pb.GeneratedMessage {
   static $pb.PbList<LNUrlWithdraw> createRepeated() => $pb.PbList<LNUrlWithdraw>();
   @$core.pragma('dart2js:noInline')
   static LNUrlWithdraw getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNUrlWithdraw>(create);
-  static LNUrlWithdraw _defaultInstance;
+  static LNUrlWithdraw? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get minAmount => $_getI64(0);
@@ -4075,9 +4109,9 @@ class LNURLChannel extends $pb.GeneratedMessage {
 
   LNURLChannel._() : super();
   factory LNURLChannel({
-    $core.String k1,
-    $core.String callback,
-    $core.String uri,
+    $core.String? k1,
+    $core.String? callback,
+    $core.String? uri,
   }) {
     final _result = create();
     if (k1 != null) {
@@ -4110,7 +4144,7 @@ class LNURLChannel extends $pb.GeneratedMessage {
   static $pb.PbList<LNURLChannel> createRepeated() => $pb.PbList<LNURLChannel>();
   @$core.pragma('dart2js:noInline')
   static LNURLChannel getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNURLChannel>(create);
-  static LNURLChannel _defaultInstance;
+  static LNURLChannel? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get k1 => $_getSZ(0);
@@ -4152,11 +4186,11 @@ class LNURLAuth extends $pb.GeneratedMessage {
 
   LNURLAuth._() : super();
   factory LNURLAuth({
-    $core.String tag,
-    $core.String k1,
-    $core.String callback,
-    $core.String host,
-    $core.bool jwt,
+    $core.String? tag,
+    $core.String? k1,
+    $core.String? callback,
+    $core.String? host,
+    $core.bool? jwt,
   }) {
     final _result = create();
     if (tag != null) {
@@ -4195,7 +4229,7 @@ class LNURLAuth extends $pb.GeneratedMessage {
   static $pb.PbList<LNURLAuth> createRepeated() => $pb.PbList<LNURLAuth>();
   @$core.pragma('dart2js:noInline')
   static LNURLAuth getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNURLAuth>(create);
-  static LNURLAuth _defaultInstance;
+  static LNURLAuth? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get tag => $_getSZ(0);
@@ -4243,6 +4277,485 @@ class LNURLAuth extends $pb.GeneratedMessage {
   void clearJwt() => clearField(5);
 }
 
+class LNUrlPayMetadata extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNUrlPayMetadata', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+    ..pPS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'entry')
+    ..hasRequiredFields = false
+  ;
+
+  LNUrlPayMetadata._() : super();
+  factory LNUrlPayMetadata({
+    $core.Iterable<$core.String>? entry,
+  }) {
+    final _result = create();
+    if (entry != null) {
+      _result.entry.addAll(entry);
+    }
+    return _result;
+  }
+  factory LNUrlPayMetadata.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory LNUrlPayMetadata.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  LNUrlPayMetadata clone() => LNUrlPayMetadata()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  LNUrlPayMetadata copyWith(void Function(LNUrlPayMetadata) updates) => super.copyWith((message) => updates(message as LNUrlPayMetadata)) as LNUrlPayMetadata; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static LNUrlPayMetadata create() => LNUrlPayMetadata._();
+  LNUrlPayMetadata createEmptyInstance() => create();
+  static $pb.PbList<LNUrlPayMetadata> createRepeated() => $pb.PbList<LNUrlPayMetadata>();
+  @$core.pragma('dart2js:noInline')
+  static LNUrlPayMetadata getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNUrlPayMetadata>(create);
+  static LNUrlPayMetadata? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$core.String> get entry => $_getList(0);
+}
+
+class LNURLPayResponse1 extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNURLPayResponse1', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'callback')
+    ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'minAmount')
+    ..aInt64(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxAmount')
+    ..pc<LNUrlPayMetadata>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'metadata', $pb.PbFieldType.PM, subBuilder: LNUrlPayMetadata.create)
+    ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'tag')
+    ..a<$fixnum.Int64>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'amount', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'fromNodes')
+    ..aOS(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'comment')
+    ..aOS(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'host')
+    ..hasRequiredFields = false
+  ;
+
+  LNURLPayResponse1._() : super();
+  factory LNURLPayResponse1({
+    $core.String? callback,
+    $fixnum.Int64? minAmount,
+    $fixnum.Int64? maxAmount,
+    $core.Iterable<LNUrlPayMetadata>? metadata,
+    $core.String? tag,
+    $fixnum.Int64? amount,
+    $core.String? fromNodes,
+    $core.String? comment,
+    $core.String? host,
+  }) {
+    final _result = create();
+    if (callback != null) {
+      _result.callback = callback;
+    }
+    if (minAmount != null) {
+      _result.minAmount = minAmount;
+    }
+    if (maxAmount != null) {
+      _result.maxAmount = maxAmount;
+    }
+    if (metadata != null) {
+      _result.metadata.addAll(metadata);
+    }
+    if (tag != null) {
+      _result.tag = tag;
+    }
+    if (amount != null) {
+      _result.amount = amount;
+    }
+    if (fromNodes != null) {
+      _result.fromNodes = fromNodes;
+    }
+    if (comment != null) {
+      _result.comment = comment;
+    }
+    if (host != null) {
+      _result.host = host;
+    }
+    return _result;
+  }
+  factory LNURLPayResponse1.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory LNURLPayResponse1.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  LNURLPayResponse1 clone() => LNURLPayResponse1()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  LNURLPayResponse1 copyWith(void Function(LNURLPayResponse1) updates) => super.copyWith((message) => updates(message as LNURLPayResponse1)) as LNURLPayResponse1; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static LNURLPayResponse1 create() => LNURLPayResponse1._();
+  LNURLPayResponse1 createEmptyInstance() => create();
+  static $pb.PbList<LNURLPayResponse1> createRepeated() => $pb.PbList<LNURLPayResponse1>();
+  @$core.pragma('dart2js:noInline')
+  static LNURLPayResponse1 getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNURLPayResponse1>(create);
+  static LNURLPayResponse1? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get callback => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set callback($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasCallback() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearCallback() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get minAmount => $_getI64(1);
+  @$pb.TagNumber(2)
+  set minAmount($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMinAmount() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMinAmount() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get maxAmount => $_getI64(2);
+  @$pb.TagNumber(3)
+  set maxAmount($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasMaxAmount() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearMaxAmount() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<LNUrlPayMetadata> get metadata => $_getList(3);
+
+  @$pb.TagNumber(5)
+  $core.String get tag => $_getSZ(4);
+  @$pb.TagNumber(5)
+  set tag($core.String v) { $_setString(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasTag() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearTag() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $fixnum.Int64 get amount => $_getI64(5);
+  @$pb.TagNumber(6)
+  set amount($fixnum.Int64 v) { $_setInt64(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasAmount() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearAmount() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.String get fromNodes => $_getSZ(6);
+  @$pb.TagNumber(7)
+  set fromNodes($core.String v) { $_setString(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasFromNodes() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearFromNodes() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.String get comment => $_getSZ(7);
+  @$pb.TagNumber(8)
+  set comment($core.String v) { $_setString(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasComment() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearComment() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.String get host => $_getSZ(8);
+  @$pb.TagNumber(9)
+  set host($core.String v) { $_setString(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasHost() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearHost() => clearField(9);
+}
+
+class SuccessAction extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SuccessAction', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'tag')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'description')
+    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'url')
+    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'message')
+    ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'ciphertext')
+    ..aOS(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'iv')
+    ..hasRequiredFields = false
+  ;
+
+  SuccessAction._() : super();
+  factory SuccessAction({
+    $core.String? tag,
+    $core.String? description,
+    $core.String? url,
+    $core.String? message,
+    $core.String? ciphertext,
+    $core.String? iv,
+  }) {
+    final _result = create();
+    if (tag != null) {
+      _result.tag = tag;
+    }
+    if (description != null) {
+      _result.description = description;
+    }
+    if (url != null) {
+      _result.url = url;
+    }
+    if (message != null) {
+      _result.message = message;
+    }
+    if (ciphertext != null) {
+      _result.ciphertext = ciphertext;
+    }
+    if (iv != null) {
+      _result.iv = iv;
+    }
+    return _result;
+  }
+  factory SuccessAction.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SuccessAction.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SuccessAction clone() => SuccessAction()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SuccessAction copyWith(void Function(SuccessAction) updates) => super.copyWith((message) => updates(message as SuccessAction)) as SuccessAction; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static SuccessAction create() => SuccessAction._();
+  SuccessAction createEmptyInstance() => create();
+  static $pb.PbList<SuccessAction> createRepeated() => $pb.PbList<SuccessAction>();
+  @$core.pragma('dart2js:noInline')
+  static SuccessAction getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SuccessAction>(create);
+  static SuccessAction? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get tag => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set tag($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTag() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTag() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get description => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set description($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasDescription() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearDescription() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get url => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set url($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasUrl() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearUrl() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get message => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set message($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasMessage() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearMessage() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.String get ciphertext => $_getSZ(4);
+  @$pb.TagNumber(5)
+  set ciphertext($core.String v) { $_setString(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasCiphertext() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearCiphertext() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.String get iv => $_getSZ(5);
+  @$pb.TagNumber(6)
+  set iv($core.String v) { $_setString(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasIv() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearIv() => clearField(6);
+}
+
+class LNUrlPayInfo extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNUrlPayInfo', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentHash', protoName: 'paymentHash')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'invoice')
+    ..aOM<SuccessAction>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'successAction', subBuilder: SuccessAction.create)
+    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'comment')
+    ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'invoiceDescription')
+    ..pc<LNUrlPayMetadata>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'metadata', $pb.PbFieldType.PM, subBuilder: LNUrlPayMetadata.create)
+    ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'host')
+    ..hasRequiredFields = false
+  ;
+
+  LNUrlPayInfo._() : super();
+  factory LNUrlPayInfo({
+    $core.String? paymentHash,
+    $core.String? invoice,
+    SuccessAction? successAction,
+    $core.String? comment,
+    $core.String? invoiceDescription,
+    $core.Iterable<LNUrlPayMetadata>? metadata,
+    $core.String? host,
+  }) {
+    final _result = create();
+    if (paymentHash != null) {
+      _result.paymentHash = paymentHash;
+    }
+    if (invoice != null) {
+      _result.invoice = invoice;
+    }
+    if (successAction != null) {
+      _result.successAction = successAction;
+    }
+    if (comment != null) {
+      _result.comment = comment;
+    }
+    if (invoiceDescription != null) {
+      _result.invoiceDescription = invoiceDescription;
+    }
+    if (metadata != null) {
+      _result.metadata.addAll(metadata);
+    }
+    if (host != null) {
+      _result.host = host;
+    }
+    return _result;
+  }
+  factory LNUrlPayInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory LNUrlPayInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  LNUrlPayInfo clone() => LNUrlPayInfo()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  LNUrlPayInfo copyWith(void Function(LNUrlPayInfo) updates) => super.copyWith((message) => updates(message as LNUrlPayInfo)) as LNUrlPayInfo; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static LNUrlPayInfo create() => LNUrlPayInfo._();
+  LNUrlPayInfo createEmptyInstance() => create();
+  static $pb.PbList<LNUrlPayInfo> createRepeated() => $pb.PbList<LNUrlPayInfo>();
+  @$core.pragma('dart2js:noInline')
+  static LNUrlPayInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNUrlPayInfo>(create);
+  static LNUrlPayInfo? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get paymentHash => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set paymentHash($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPaymentHash() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPaymentHash() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get invoice => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set invoice($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasInvoice() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearInvoice() => clearField(2);
+
+  @$pb.TagNumber(3)
+  SuccessAction get successAction => $_getN(2);
+  @$pb.TagNumber(3)
+  set successAction(SuccessAction v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSuccessAction() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSuccessAction() => clearField(3);
+  @$pb.TagNumber(3)
+  SuccessAction ensureSuccessAction() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  $core.String get comment => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set comment($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasComment() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearComment() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.String get invoiceDescription => $_getSZ(4);
+  @$pb.TagNumber(5)
+  set invoiceDescription($core.String v) { $_setString(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasInvoiceDescription() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearInvoiceDescription() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.List<LNUrlPayMetadata> get metadata => $_getList(5);
+
+  @$pb.TagNumber(7)
+  $core.String get host => $_getSZ(6);
+  @$pb.TagNumber(7)
+  set host($core.String v) { $_setString(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasHost() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearHost() => clearField(7);
+}
+
+class LNUrlPayInfoList extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNUrlPayInfoList', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+    ..pc<LNUrlPayInfo>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'infoList', $pb.PbFieldType.PM, protoName: 'infoList', subBuilder: LNUrlPayInfo.create)
+    ..hasRequiredFields = false
+  ;
+
+  LNUrlPayInfoList._() : super();
+  factory LNUrlPayInfoList({
+    $core.Iterable<LNUrlPayInfo>? infoList,
+  }) {
+    final _result = create();
+    if (infoList != null) {
+      _result.infoList.addAll(infoList);
+    }
+    return _result;
+  }
+  factory LNUrlPayInfoList.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory LNUrlPayInfoList.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  LNUrlPayInfoList clone() => LNUrlPayInfoList()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  LNUrlPayInfoList copyWith(void Function(LNUrlPayInfoList) updates) => super.copyWith((message) => updates(message as LNUrlPayInfoList)) as LNUrlPayInfoList; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static LNUrlPayInfoList create() => LNUrlPayInfoList._();
+  LNUrlPayInfoList createEmptyInstance() => create();
+  static $pb.PbList<LNUrlPayInfoList> createRepeated() => $pb.PbList<LNUrlPayInfoList>();
+  @$core.pragma('dart2js:noInline')
+  static LNUrlPayInfoList getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNUrlPayInfoList>(create);
+  static LNUrlPayInfoList? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<LNUrlPayInfo> get infoList => $_getList(0);
+}
+
 class ReverseSwapRequest extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReverseSwapRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'address')
@@ -4253,9 +4766,9 @@ class ReverseSwapRequest extends $pb.GeneratedMessage {
 
   ReverseSwapRequest._() : super();
   factory ReverseSwapRequest({
-    $core.String address,
-    $fixnum.Int64 amount,
-    $core.String feesHash,
+    $core.String? address,
+    $fixnum.Int64? amount,
+    $core.String? feesHash,
   }) {
     final _result = create();
     if (address != null) {
@@ -4288,7 +4801,7 @@ class ReverseSwapRequest extends $pb.GeneratedMessage {
   static $pb.PbList<ReverseSwapRequest> createRepeated() => $pb.PbList<ReverseSwapRequest>();
   @$core.pragma('dart2js:noInline')
   static ReverseSwapRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapRequest>(create);
-  static ReverseSwapRequest _defaultInstance;
+  static ReverseSwapRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
@@ -4338,19 +4851,19 @@ class ReverseSwap extends $pb.GeneratedMessage {
 
   ReverseSwap._() : super();
   factory ReverseSwap({
-    $core.String id,
-    $core.String invoice,
-    $core.String script,
-    $core.String lockupAddress,
-    $core.String preimage,
-    $core.String key,
-    $core.String claimAddress,
-    $fixnum.Int64 lnAmount,
-    $fixnum.Int64 onchainAmount,
-    $fixnum.Int64 timeoutBlockHeight,
-    $fixnum.Int64 startBlockHeight,
-    $fixnum.Int64 claimFee,
-    $core.String claimTxid,
+    $core.String? id,
+    $core.String? invoice,
+    $core.String? script,
+    $core.String? lockupAddress,
+    $core.String? preimage,
+    $core.String? key,
+    $core.String? claimAddress,
+    $fixnum.Int64? lnAmount,
+    $fixnum.Int64? onchainAmount,
+    $fixnum.Int64? timeoutBlockHeight,
+    $fixnum.Int64? startBlockHeight,
+    $fixnum.Int64? claimFee,
+    $core.String? claimTxid,
   }) {
     final _result = create();
     if (id != null) {
@@ -4413,7 +4926,7 @@ class ReverseSwap extends $pb.GeneratedMessage {
   static $pb.PbList<ReverseSwap> createRepeated() => $pb.PbList<ReverseSwap>();
   @$core.pragma('dart2js:noInline')
   static ReverseSwap getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwap>(create);
-  static ReverseSwap _defaultInstance;
+  static ReverseSwap? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
@@ -4543,9 +5056,9 @@ class ReverseSwapFees extends $pb.GeneratedMessage {
 
   ReverseSwapFees._() : super();
   factory ReverseSwapFees({
-    $core.double percentage,
-    $fixnum.Int64 lockup,
-    $fixnum.Int64 claim,
+    $core.double? percentage,
+    $fixnum.Int64? lockup,
+    $fixnum.Int64? claim,
   }) {
     final _result = create();
     if (percentage != null) {
@@ -4578,7 +5091,7 @@ class ReverseSwapFees extends $pb.GeneratedMessage {
   static $pb.PbList<ReverseSwapFees> createRepeated() => $pb.PbList<ReverseSwapFees>();
   @$core.pragma('dart2js:noInline')
   static ReverseSwapFees getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapFees>(create);
-  static ReverseSwapFees _defaultInstance;
+  static ReverseSwapFees? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.double get percentage => $_getN(0);
@@ -4619,10 +5132,10 @@ class ReverseSwapInfo extends $pb.GeneratedMessage {
 
   ReverseSwapInfo._() : super();
   factory ReverseSwapInfo({
-    $fixnum.Int64 min,
-    $fixnum.Int64 max,
-    ReverseSwapFees fees,
-    $core.String feesHash,
+    $fixnum.Int64? min,
+    $fixnum.Int64? max,
+    ReverseSwapFees? fees,
+    $core.String? feesHash,
   }) {
     final _result = create();
     if (min != null) {
@@ -4658,7 +5171,7 @@ class ReverseSwapInfo extends $pb.GeneratedMessage {
   static $pb.PbList<ReverseSwapInfo> createRepeated() => $pb.PbList<ReverseSwapInfo>();
   @$core.pragma('dart2js:noInline')
   static ReverseSwapInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapInfo>(create);
-  static ReverseSwapInfo _defaultInstance;
+  static ReverseSwapInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get min => $_getI64(0);
@@ -4708,8 +5221,8 @@ class ReverseSwapPaymentRequest extends $pb.GeneratedMessage {
 
   ReverseSwapPaymentRequest._() : super();
   factory ReverseSwapPaymentRequest({
-    $core.String hash,
-    PushNotificationDetails pushNotificationDetails,
+    $core.String? hash,
+    PushNotificationDetails? pushNotificationDetails,
   }) {
     final _result = create();
     if (hash != null) {
@@ -4739,7 +5252,7 @@ class ReverseSwapPaymentRequest extends $pb.GeneratedMessage {
   static $pb.PbList<ReverseSwapPaymentRequest> createRepeated() => $pb.PbList<ReverseSwapPaymentRequest>();
   @$core.pragma('dart2js:noInline')
   static ReverseSwapPaymentRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapPaymentRequest>(create);
-  static ReverseSwapPaymentRequest _defaultInstance;
+  static ReverseSwapPaymentRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
@@ -4772,9 +5285,9 @@ class PushNotificationDetails extends $pb.GeneratedMessage {
 
   PushNotificationDetails._() : super();
   factory PushNotificationDetails({
-    $core.String deviceId,
-    $core.String title,
-    $core.String body,
+    $core.String? deviceId,
+    $core.String? title,
+    $core.String? body,
   }) {
     final _result = create();
     if (deviceId != null) {
@@ -4807,7 +5320,7 @@ class PushNotificationDetails extends $pb.GeneratedMessage {
   static $pb.PbList<PushNotificationDetails> createRepeated() => $pb.PbList<PushNotificationDetails>();
   @$core.pragma('dart2js:noInline')
   static PushNotificationDetails getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PushNotificationDetails>(create);
-  static PushNotificationDetails _defaultInstance;
+  static PushNotificationDetails? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get deviceId => $_getSZ(0);
@@ -4846,8 +5359,8 @@ class ReverseSwapPaymentStatus extends $pb.GeneratedMessage {
 
   ReverseSwapPaymentStatus._() : super();
   factory ReverseSwapPaymentStatus({
-    $core.String hash,
-    $core.int eta,
+    $core.String? hash,
+    $core.int? eta,
   }) {
     final _result = create();
     if (hash != null) {
@@ -4877,7 +5390,7 @@ class ReverseSwapPaymentStatus extends $pb.GeneratedMessage {
   static $pb.PbList<ReverseSwapPaymentStatus> createRepeated() => $pb.PbList<ReverseSwapPaymentStatus>();
   @$core.pragma('dart2js:noInline')
   static ReverseSwapPaymentStatus getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapPaymentStatus>(create);
-  static ReverseSwapPaymentStatus _defaultInstance;
+  static ReverseSwapPaymentStatus? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
@@ -4906,7 +5419,7 @@ class ReverseSwapPaymentStatuses extends $pb.GeneratedMessage {
 
   ReverseSwapPaymentStatuses._() : super();
   factory ReverseSwapPaymentStatuses({
-    $core.Iterable<ReverseSwapPaymentStatus> paymentsStatus,
+    $core.Iterable<ReverseSwapPaymentStatus>? paymentsStatus,
   }) {
     final _result = create();
     if (paymentsStatus != null) {
@@ -4933,7 +5446,7 @@ class ReverseSwapPaymentStatuses extends $pb.GeneratedMessage {
   static $pb.PbList<ReverseSwapPaymentStatuses> createRepeated() => $pb.PbList<ReverseSwapPaymentStatuses>();
   @$core.pragma('dart2js:noInline')
   static ReverseSwapPaymentStatuses getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapPaymentStatuses>(create);
-  static ReverseSwapPaymentStatuses _defaultInstance;
+  static ReverseSwapPaymentStatuses? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<ReverseSwapPaymentStatus> get paymentsStatus => $_getList(0);
@@ -4948,8 +5461,8 @@ class ReverseSwapClaimFee extends $pb.GeneratedMessage {
 
   ReverseSwapClaimFee._() : super();
   factory ReverseSwapClaimFee({
-    $core.String hash,
-    $fixnum.Int64 fee,
+    $core.String? hash,
+    $fixnum.Int64? fee,
   }) {
     final _result = create();
     if (hash != null) {
@@ -4979,7 +5492,7 @@ class ReverseSwapClaimFee extends $pb.GeneratedMessage {
   static $pb.PbList<ReverseSwapClaimFee> createRepeated() => $pb.PbList<ReverseSwapClaimFee>();
   @$core.pragma('dart2js:noInline')
   static ReverseSwapClaimFee getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapClaimFee>(create);
-  static ReverseSwapClaimFee _defaultInstance;
+  static ReverseSwapClaimFee? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
@@ -5008,7 +5521,7 @@ class ClaimFeeEstimates extends $pb.GeneratedMessage {
 
   ClaimFeeEstimates._() : super();
   factory ClaimFeeEstimates({
-    $core.Map<$core.int, $fixnum.Int64> fees,
+    $core.Map<$core.int, $fixnum.Int64>? fees,
   }) {
     final _result = create();
     if (fees != null) {
@@ -5035,7 +5548,7 @@ class ClaimFeeEstimates extends $pb.GeneratedMessage {
   static $pb.PbList<ClaimFeeEstimates> createRepeated() => $pb.PbList<ClaimFeeEstimates>();
   @$core.pragma('dart2js:noInline')
   static ClaimFeeEstimates getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ClaimFeeEstimates>(create);
-  static ClaimFeeEstimates _defaultInstance;
+  static ClaimFeeEstimates? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.Map<$core.int, $fixnum.Int64> get fees => $_getMap(0);
@@ -5051,9 +5564,9 @@ class UnspendLockupInformation extends $pb.GeneratedMessage {
 
   UnspendLockupInformation._() : super();
   factory UnspendLockupInformation({
-    $core.int heightHint,
-    $core.List<$core.int> lockupScript,
-    $core.List<$core.int> claimTxHash,
+    $core.int? heightHint,
+    $core.List<$core.int>? lockupScript,
+    $core.List<$core.int>? claimTxHash,
   }) {
     final _result = create();
     if (heightHint != null) {
@@ -5086,7 +5599,7 @@ class UnspendLockupInformation extends $pb.GeneratedMessage {
   static $pb.PbList<UnspendLockupInformation> createRepeated() => $pb.PbList<UnspendLockupInformation>();
   @$core.pragma('dart2js:noInline')
   static UnspendLockupInformation getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UnspendLockupInformation>(create);
-  static UnspendLockupInformation _defaultInstance;
+  static UnspendLockupInformation? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get heightHint => $_getIZ(0);
@@ -5126,9 +5639,9 @@ class TransactionDetails extends $pb.GeneratedMessage {
 
   TransactionDetails._() : super();
   factory TransactionDetails({
-    $core.List<$core.int> tx,
-    $core.String txHash,
-    $fixnum.Int64 fees,
+    $core.List<$core.int>? tx,
+    $core.String? txHash,
+    $fixnum.Int64? fees,
   }) {
     final _result = create();
     if (tx != null) {
@@ -5161,7 +5674,7 @@ class TransactionDetails extends $pb.GeneratedMessage {
   static $pb.PbList<TransactionDetails> createRepeated() => $pb.PbList<TransactionDetails>();
   @$core.pragma('dart2js:noInline')
   static TransactionDetails getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransactionDetails>(create);
-  static TransactionDetails _defaultInstance;
+  static TransactionDetails? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get tx => $_getN(0);
@@ -5200,8 +5713,8 @@ class SweepAllCoinsTransactions extends $pb.GeneratedMessage {
 
   SweepAllCoinsTransactions._() : super();
   factory SweepAllCoinsTransactions({
-    $fixnum.Int64 amt,
-    $core.Map<$core.int, TransactionDetails> transactions,
+    $fixnum.Int64? amt,
+    $core.Map<$core.int, TransactionDetails>? transactions,
   }) {
     final _result = create();
     if (amt != null) {
@@ -5231,7 +5744,7 @@ class SweepAllCoinsTransactions extends $pb.GeneratedMessage {
   static $pb.PbList<SweepAllCoinsTransactions> createRepeated() => $pb.PbList<SweepAllCoinsTransactions>();
   @$core.pragma('dart2js:noInline')
   static SweepAllCoinsTransactions getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SweepAllCoinsTransactions>(create);
-  static SweepAllCoinsTransactions _defaultInstance;
+  static SweepAllCoinsTransactions? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get amt => $_getI64(0);
@@ -5254,7 +5767,7 @@ class DownloadBackupResponse extends $pb.GeneratedMessage {
 
   DownloadBackupResponse._() : super();
   factory DownloadBackupResponse({
-    $core.Iterable<$core.String> files,
+    $core.Iterable<$core.String>? files,
   }) {
     final _result = create();
     if (files != null) {
@@ -5281,7 +5794,7 @@ class DownloadBackupResponse extends $pb.GeneratedMessage {
   static $pb.PbList<DownloadBackupResponse> createRepeated() => $pb.PbList<DownloadBackupResponse>();
   @$core.pragma('dart2js:noInline')
   static DownloadBackupResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DownloadBackupResponse>(create);
-  static DownloadBackupResponse _defaultInstance;
+  static DownloadBackupResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.String> get files => $_getList(0);

--- a/lib/services/breezlib/data/rpc.pbenum.dart
+++ b/lib/services/breezlib/data/rpc.pbenum.dart
@@ -1,8 +1,8 @@
 ///
 //  Generated code. Do not modify.
-//  source: rpc.proto
+//  source: messages.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 // ignore_for_file: UNDEFINED_SHOWN_NAME
@@ -25,7 +25,7 @@ class SwapError extends $pb.ProtobufEnum {
   ];
 
   static final $core.Map<$core.int, SwapError> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static SwapError valueOf($core.int value) => _byValue[value];
+  static SwapError? valueOf($core.int value) => _byValue[value];
 
   const SwapError._($core.int v, $core.String n) : super(v, n);
 }
@@ -44,7 +44,7 @@ class Account_AccountStatus extends $pb.ProtobufEnum {
   ];
 
   static final $core.Map<$core.int, Account_AccountStatus> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static Account_AccountStatus valueOf($core.int value) => _byValue[value];
+  static Account_AccountStatus? valueOf($core.int value) => _byValue[value];
 
   const Account_AccountStatus._($core.int v, $core.String n) : super(v, n);
 }
@@ -65,7 +65,7 @@ class Payment_PaymentType extends $pb.ProtobufEnum {
   ];
 
   static final $core.Map<$core.int, Payment_PaymentType> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static Payment_PaymentType valueOf($core.int value) => _byValue[value];
+  static Payment_PaymentType? valueOf($core.int value) => _byValue[value];
 
   const Payment_PaymentType._($core.int v, $core.String n) : super(v, n);
 }
@@ -116,7 +116,7 @@ class NotificationEvent_NotificationType extends $pb.ProtobufEnum {
   ];
 
   static final $core.Map<$core.int, NotificationEvent_NotificationType> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static NotificationEvent_NotificationType valueOf($core.int value) => _byValue[value];
+  static NotificationEvent_NotificationType? valueOf($core.int value) => _byValue[value];
 
   const NotificationEvent_NotificationType._($core.int v, $core.String n) : super(v, n);
 }

--- a/lib/services/breezlib/data/rpc.pbgrpc.dart
+++ b/lib/services/breezlib/data/rpc.pbgrpc.dart
@@ -1,8 +1,8 @@
 ///
 //  Generated code. Do not modify.
-//  source: rpc.proto
+//  source: messages.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:async' as $async;
@@ -61,54 +61,54 @@ class BreezAPIClient extends $grpc.Client {
           ($core.List<$core.int> value) => $0.PaymentsList.fromBuffer(value));
 
   BreezAPIClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions options,
-      $core.Iterable<$grpc.ClientInterceptor> interceptors})
+      {$grpc.CallOptions? options,
+      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
   $grpc.ResponseFuture<$0.LSPList> getLSPList($0.LSPListRequest request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$getLSPList, request, options: options);
   }
 
   $grpc.ResponseFuture<$0.ConnectLSPReply> connectToLSP(
       $0.ConnectLSPRequest request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$connectToLSP, request, options: options);
   }
 
   $grpc.ResponseFuture<$0.AddFundInitReply> addFundInit(
       $0.AddFundInitRequest request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$addFundInit, request, options: options);
   }
 
   $grpc.ResponseFuture<$0.FundStatusReply> getFundStatus(
       $0.FundStatusRequest request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$getFundStatus, request, options: options);
   }
 
   $grpc.ResponseFuture<$0.AddInvoiceReply> addInvoice(
       $0.AddInvoiceRequest request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$addInvoice, request, options: options);
   }
 
   $grpc.ResponseFuture<$0.PaymentResponse> payInvoice(
       $0.PayInvoiceRequest request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$payInvoice, request, options: options);
   }
 
   $grpc.ResponseFuture<$0.RestartDaemonReply> restartDaemon(
       $0.RestartDaemonRequest request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$restartDaemon, request, options: options);
   }
 
   $grpc.ResponseFuture<$0.PaymentsList> listPayments(
       $0.ListPaymentsRequest request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$listPayments, request, options: options);
   }
 }

--- a/lib/services/breezlib/data/rpc.pbjson.dart
+++ b/lib/services/breezlib/data/rpc.pbjson.dart
@@ -1,8 +1,8 @@
 ///
 //  Generated code. Do not modify.
-//  source: rpc.proto
+//  source: messages.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
 
 import 'dart:core' as $core;
@@ -148,6 +148,7 @@ const Payment$json = const {
     const {'1': 'closedChannelSweepTxID', '3': 21, '4': 1, '5': 9, '10': 'closedChannelSweepTxID'},
     const {'1': 'groupKey', '3': 22, '4': 1, '5': 9, '10': 'groupKey'},
     const {'1': 'groupName', '3': 23, '4': 1, '5': 9, '10': 'groupName'},
+    const {'1': 'lnurlPayInfo', '3': 24, '4': 1, '5': 11, '6': '.data.LNUrlPayInfo', '10': 'lnurlPayInfo'},
   ],
   '4': const [Payment_PaymentType$json],
 };
@@ -165,7 +166,7 @@ const Payment_PaymentType$json = const {
 };
 
 /// Descriptor for `Payment`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List paymentDescriptor = $convert.base64Decode('CgdQYXltZW50Ei0KBHR5cGUYASABKA4yGS5kYXRhLlBheW1lbnQuUGF5bWVudFR5cGVSBHR5cGUSFgoGYW1vdW50GAMgASgDUgZhbW91bnQSLAoRY3JlYXRpb25UaW1lc3RhbXAYBCABKANSEWNyZWF0aW9uVGltZXN0YW1wEjMKC2ludm9pY2VNZW1vGAYgASgLMhEuZGF0YS5JbnZvaWNlTWVtb1ILaW52b2ljZU1lbW8SHgoKcmVkZWVtVHhJRBgHIAEoCVIKcmVkZWVtVHhJRBIgCgtwYXltZW50SGFzaBgIIAEoCVILcGF5bWVudEhhc2gSIAoLZGVzdGluYXRpb24YCSABKAlSC2Rlc3RpbmF0aW9uEjgKF1BlbmRpbmdFeHBpcmF0aW9uSGVpZ2h0GAogASgNUhdQZW5kaW5nRXhwaXJhdGlvbkhlaWdodBI+ChpQZW5kaW5nRXhwaXJhdGlvblRpbWVzdGFtcBgLIAEoA1IaUGVuZGluZ0V4cGlyYXRpb25UaW1lc3RhbXASEAoDZmVlGAwgASgDUgNmZWUSGgoIcHJlaW1hZ2UYDSABKAlSCHByZWltYWdlEi4KEmNsb3NlZENoYW5uZWxQb2ludBgOIAEoCVISY2xvc2VkQ2hhbm5lbFBvaW50EioKEGlzQ2hhbm5lbFBlbmRpbmcYDyABKAhSEGlzQ2hhbm5lbFBlbmRpbmcSNgoWaXNDaGFubmVsQ2xvc2VDb25maW1lZBgQIAEoCFIWaXNDaGFubmVsQ2xvc2VDb25maW1lZBIsChFjbG9zZWRDaGFubmVsVHhJRBgRIAEoCVIRY2xvc2VkQ2hhbm5lbFR4SUQSHAoJaXNLZXlTZW5kGBIgASgIUglpc0tleVNlbmQSIAoLUGVuZGluZ0Z1bGwYEyABKAhSC1BlbmRpbmdGdWxsEjgKF2Nsb3NlZENoYW5uZWxSZW1vdGVUeElEGBQgASgJUhdjbG9zZWRDaGFubmVsUmVtb3RlVHhJRBI2ChZjbG9zZWRDaGFubmVsU3dlZXBUeElEGBUgASgJUhZjbG9zZWRDaGFubmVsU3dlZXBUeElEEhoKCGdyb3VwS2V5GBYgASgJUghncm91cEtleRIcCglncm91cE5hbWUYFyABKAlSCWdyb3VwTmFtZSJWCgtQYXltZW50VHlwZRILCgdERVBPU0lUEAASDgoKV0lUSERSQVdBTBABEggKBFNFTlQQAhIMCghSRUNFSVZFRBADEhIKDkNMT1NFRF9DSEFOTkVMEAQ=');
+final $typed_data.Uint8List paymentDescriptor = $convert.base64Decode('CgdQYXltZW50Ei0KBHR5cGUYASABKA4yGS5kYXRhLlBheW1lbnQuUGF5bWVudFR5cGVSBHR5cGUSFgoGYW1vdW50GAMgASgDUgZhbW91bnQSLAoRY3JlYXRpb25UaW1lc3RhbXAYBCABKANSEWNyZWF0aW9uVGltZXN0YW1wEjMKC2ludm9pY2VNZW1vGAYgASgLMhEuZGF0YS5JbnZvaWNlTWVtb1ILaW52b2ljZU1lbW8SHgoKcmVkZWVtVHhJRBgHIAEoCVIKcmVkZWVtVHhJRBIgCgtwYXltZW50SGFzaBgIIAEoCVILcGF5bWVudEhhc2gSIAoLZGVzdGluYXRpb24YCSABKAlSC2Rlc3RpbmF0aW9uEjgKF1BlbmRpbmdFeHBpcmF0aW9uSGVpZ2h0GAogASgNUhdQZW5kaW5nRXhwaXJhdGlvbkhlaWdodBI+ChpQZW5kaW5nRXhwaXJhdGlvblRpbWVzdGFtcBgLIAEoA1IaUGVuZGluZ0V4cGlyYXRpb25UaW1lc3RhbXASEAoDZmVlGAwgASgDUgNmZWUSGgoIcHJlaW1hZ2UYDSABKAlSCHByZWltYWdlEi4KEmNsb3NlZENoYW5uZWxQb2ludBgOIAEoCVISY2xvc2VkQ2hhbm5lbFBvaW50EioKEGlzQ2hhbm5lbFBlbmRpbmcYDyABKAhSEGlzQ2hhbm5lbFBlbmRpbmcSNgoWaXNDaGFubmVsQ2xvc2VDb25maW1lZBgQIAEoCFIWaXNDaGFubmVsQ2xvc2VDb25maW1lZBIsChFjbG9zZWRDaGFubmVsVHhJRBgRIAEoCVIRY2xvc2VkQ2hhbm5lbFR4SUQSHAoJaXNLZXlTZW5kGBIgASgIUglpc0tleVNlbmQSIAoLUGVuZGluZ0Z1bGwYEyABKAhSC1BlbmRpbmdGdWxsEjgKF2Nsb3NlZENoYW5uZWxSZW1vdGVUeElEGBQgASgJUhdjbG9zZWRDaGFubmVsUmVtb3RlVHhJRBI2ChZjbG9zZWRDaGFubmVsU3dlZXBUeElEGBUgASgJUhZjbG9zZWRDaGFubmVsU3dlZXBUeElEEhoKCGdyb3VwS2V5GBYgASgJUghncm91cEtleRIcCglncm91cE5hbWUYFyABKAlSCWdyb3VwTmFtZRI2CgxsbnVybFBheUluZm8YGCABKAsyEi5kYXRhLkxOVXJsUGF5SW5mb1IMbG51cmxQYXlJbmZvIlYKC1BheW1lbnRUeXBlEgsKB0RFUE9TSVQQABIOCgpXSVRIRFJBV0FMEAESCAoEU0VOVBACEgwKCFJFQ0VJVkVEEAMSEgoOQ0xPU0VEX0NIQU5ORUwQBA==');
 @$core.Deprecated('Use paymentsListDescriptor instead')
 const PaymentsList$json = const {
   '1': 'PaymentsList',
@@ -733,6 +734,7 @@ const LNUrlResponse$json = const {
     const {'1': 'withdraw', '3': 1, '4': 1, '5': 11, '6': '.data.LNUrlWithdraw', '9': 0, '10': 'withdraw'},
     const {'1': 'channel', '3': 2, '4': 1, '5': 11, '6': '.data.LNURLChannel', '9': 0, '10': 'channel'},
     const {'1': 'auth', '3': 3, '4': 1, '5': 11, '6': '.data.LNURLAuth', '9': 0, '10': 'auth'},
+    const {'1': 'payResponse1', '3': 4, '4': 1, '5': 11, '6': '.data.LNURLPayResponse1', '9': 0, '10': 'payResponse1'},
   ],
   '8': const [
     const {'1': 'action'},
@@ -740,7 +742,7 @@ const LNUrlResponse$json = const {
 };
 
 /// Descriptor for `LNUrlResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List lNUrlResponseDescriptor = $convert.base64Decode('Cg1MTlVybFJlc3BvbnNlEjEKCHdpdGhkcmF3GAEgASgLMhMuZGF0YS5MTlVybFdpdGhkcmF3SABSCHdpdGhkcmF3Ei4KB2NoYW5uZWwYAiABKAsyEi5kYXRhLkxOVVJMQ2hhbm5lbEgAUgdjaGFubmVsEiUKBGF1dGgYAyABKAsyDy5kYXRhLkxOVVJMQXV0aEgAUgRhdXRoQggKBmFjdGlvbg==');
+final $typed_data.Uint8List lNUrlResponseDescriptor = $convert.base64Decode('Cg1MTlVybFJlc3BvbnNlEjEKCHdpdGhkcmF3GAEgASgLMhMuZGF0YS5MTlVybFdpdGhkcmF3SABSCHdpdGhkcmF3Ei4KB2NoYW5uZWwYAiABKAsyEi5kYXRhLkxOVVJMQ2hhbm5lbEgAUgdjaGFubmVsEiUKBGF1dGgYAyABKAsyDy5kYXRhLkxOVVJMQXV0aEgAUgRhdXRoEj0KDHBheVJlc3BvbnNlMRgEIAEoCzIXLmRhdGEuTE5VUkxQYXlSZXNwb25zZTFIAFIMcGF5UmVzcG9uc2UxQggKBmFjdGlvbg==');
 @$core.Deprecated('Use lNUrlWithdrawDescriptor instead')
 const LNUrlWithdraw$json = const {
   '1': 'LNUrlWithdraw',
@@ -779,6 +781,75 @@ const LNURLAuth$json = const {
 
 /// Descriptor for `LNURLAuth`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List lNURLAuthDescriptor = $convert.base64Decode('CglMTlVSTEF1dGgSEAoDdGFnGAEgASgJUgN0YWcSDgoCazEYAiABKAlSAmsxEhoKCGNhbGxiYWNrGAMgASgJUghjYWxsYmFjaxISCgRob3N0GAQgASgJUgRob3N0EhAKA2p3dBgFIAEoCFIDand0');
+@$core.Deprecated('Use lNUrlPayMetadataDescriptor instead')
+const LNUrlPayMetadata$json = const {
+  '1': 'LNUrlPayMetadata',
+  '2': const [
+    const {'1': 'entry', '3': 1, '4': 3, '5': 9, '10': 'entry'},
+  ],
+};
+
+/// Descriptor for `LNUrlPayMetadata`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List lNUrlPayMetadataDescriptor = $convert.base64Decode('ChBMTlVybFBheU1ldGFkYXRhEhQKBWVudHJ5GAEgAygJUgVlbnRyeQ==');
+@$core.Deprecated('Use lNURLPayResponse1Descriptor instead')
+const LNURLPayResponse1$json = const {
+  '1': 'LNURLPayResponse1',
+  '2': const [
+    const {'1': 'callback', '3': 1, '4': 1, '5': 9, '10': 'callback'},
+    const {'1': 'min_amount', '3': 2, '4': 1, '5': 3, '10': 'minAmount'},
+    const {'1': 'max_amount', '3': 3, '4': 1, '5': 3, '10': 'maxAmount'},
+    const {'1': 'metadata', '3': 4, '4': 3, '5': 11, '6': '.data.LNUrlPayMetadata', '10': 'metadata'},
+    const {'1': 'tag', '3': 5, '4': 1, '5': 9, '10': 'tag'},
+    const {'1': 'amount', '3': 6, '4': 1, '5': 4, '10': 'amount'},
+    const {'1': 'from_nodes', '3': 7, '4': 1, '5': 9, '10': 'fromNodes'},
+    const {'1': 'comment', '3': 8, '4': 1, '5': 9, '10': 'comment'},
+    const {'1': 'host', '3': 9, '4': 1, '5': 9, '10': 'host'},
+  ],
+};
+
+/// Descriptor for `LNURLPayResponse1`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List lNURLPayResponse1Descriptor = $convert.base64Decode('ChFMTlVSTFBheVJlc3BvbnNlMRIaCghjYWxsYmFjaxgBIAEoCVIIY2FsbGJhY2sSHQoKbWluX2Ftb3VudBgCIAEoA1IJbWluQW1vdW50Eh0KCm1heF9hbW91bnQYAyABKANSCW1heEFtb3VudBIyCghtZXRhZGF0YRgEIAMoCzIWLmRhdGEuTE5VcmxQYXlNZXRhZGF0YVIIbWV0YWRhdGESEAoDdGFnGAUgASgJUgN0YWcSFgoGYW1vdW50GAYgASgEUgZhbW91bnQSHQoKZnJvbV9ub2RlcxgHIAEoCVIJZnJvbU5vZGVzEhgKB2NvbW1lbnQYCCABKAlSB2NvbW1lbnQSEgoEaG9zdBgJIAEoCVIEaG9zdA==');
+@$core.Deprecated('Use successActionDescriptor instead')
+const SuccessAction$json = const {
+  '1': 'SuccessAction',
+  '2': const [
+    const {'1': 'tag', '3': 1, '4': 1, '5': 9, '10': 'tag'},
+    const {'1': 'description', '3': 2, '4': 1, '5': 9, '10': 'description'},
+    const {'1': 'url', '3': 3, '4': 1, '5': 9, '10': 'url'},
+    const {'1': 'message', '3': 4, '4': 1, '5': 9, '10': 'message'},
+    const {'1': 'ciphertext', '3': 5, '4': 1, '5': 9, '10': 'ciphertext'},
+    const {'1': 'iv', '3': 6, '4': 1, '5': 9, '10': 'iv'},
+  ],
+};
+
+/// Descriptor for `SuccessAction`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List successActionDescriptor = $convert.base64Decode('Cg1TdWNjZXNzQWN0aW9uEhAKA3RhZxgBIAEoCVIDdGFnEiAKC2Rlc2NyaXB0aW9uGAIgASgJUgtkZXNjcmlwdGlvbhIQCgN1cmwYAyABKAlSA3VybBIYCgdtZXNzYWdlGAQgASgJUgdtZXNzYWdlEh4KCmNpcGhlcnRleHQYBSABKAlSCmNpcGhlcnRleHQSDgoCaXYYBiABKAlSAml2');
+@$core.Deprecated('Use lNUrlPayInfoDescriptor instead')
+const LNUrlPayInfo$json = const {
+  '1': 'LNUrlPayInfo',
+  '2': const [
+    const {'1': 'paymentHash', '3': 1, '4': 1, '5': 9, '10': 'paymentHash'},
+    const {'1': 'invoice', '3': 2, '4': 1, '5': 9, '10': 'invoice'},
+    const {'1': 'success_action', '3': 3, '4': 1, '5': 11, '6': '.data.SuccessAction', '10': 'successAction'},
+    const {'1': 'comment', '3': 4, '4': 1, '5': 9, '10': 'comment'},
+    const {'1': 'invoice_description', '3': 5, '4': 1, '5': 9, '10': 'invoiceDescription'},
+    const {'1': 'metadata', '3': 6, '4': 3, '5': 11, '6': '.data.LNUrlPayMetadata', '10': 'metadata'},
+    const {'1': 'host', '3': 7, '4': 1, '5': 9, '10': 'host'},
+  ],
+};
+
+/// Descriptor for `LNUrlPayInfo`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List lNUrlPayInfoDescriptor = $convert.base64Decode('CgxMTlVybFBheUluZm8SIAoLcGF5bWVudEhhc2gYASABKAlSC3BheW1lbnRIYXNoEhgKB2ludm9pY2UYAiABKAlSB2ludm9pY2USOgoOc3VjY2Vzc19hY3Rpb24YAyABKAsyEy5kYXRhLlN1Y2Nlc3NBY3Rpb25SDXN1Y2Nlc3NBY3Rpb24SGAoHY29tbWVudBgEIAEoCVIHY29tbWVudBIvChNpbnZvaWNlX2Rlc2NyaXB0aW9uGAUgASgJUhJpbnZvaWNlRGVzY3JpcHRpb24SMgoIbWV0YWRhdGEYBiADKAsyFi5kYXRhLkxOVXJsUGF5TWV0YWRhdGFSCG1ldGFkYXRhEhIKBGhvc3QYByABKAlSBGhvc3Q=');
+@$core.Deprecated('Use lNUrlPayInfoListDescriptor instead')
+const LNUrlPayInfoList$json = const {
+  '1': 'LNUrlPayInfoList',
+  '2': const [
+    const {'1': 'infoList', '3': 1, '4': 3, '5': 11, '6': '.data.LNUrlPayInfo', '10': 'infoList'},
+  ],
+};
+
+/// Descriptor for `LNUrlPayInfoList`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List lNUrlPayInfoListDescriptor = $convert.base64Decode('ChBMTlVybFBheUluZm9MaXN0Ei4KCGluZm9MaXN0GAEgAygLMhIuZGF0YS5MTlVybFBheUluZm9SCGluZm9MaXN0');
 @$core.Deprecated('Use reverseSwapRequestDescriptor instead')
 const ReverseSwapRequest$json = const {
   '1': 'ReverseSwapRequest',

--- a/lib/widgets/breez_avatar.dart
+++ b/lib/widgets/breez_avatar.dart
@@ -62,6 +62,10 @@ class BreezAvatar extends StatelessWidget {
         return _NetworkImageAvatar(avatarURL, radius);
       }
 
+      if (Uri.tryParse(avatarURL)?.scheme?.startsWith("data") ?? false) {
+        return _DataImageAvatar(avatarURL, radius);
+      }
+
       return _FileImageAvatar(radius, avatarURL);
     }
 
@@ -149,6 +153,26 @@ class _NetworkImageAvatar extends StatelessWidget {
       child: ClipRRect(
         borderRadius: BorderRadius.circular(radius),
         child: ExtendedImage.network(avatarURL),
+      ),
+    );
+  }
+}
+
+class _DataImageAvatar extends StatelessWidget {
+  final double radius;
+  final String avatarURL;
+
+  _DataImageAvatar(this.avatarURL, this.radius);
+
+  @override
+  Widget build(BuildContext context) {
+      final uri = UriData.parse(this.avatarURL);
+      final _bytes = uri.contentAsBytes();
+    return CircleAvatar(
+        backgroundColor: theme.sessionAvatarBackgroundColor,
+      radius: radius,
+      child: ClipOval(
+        child: Image.memory(_bytes) ,
       ),
     );
   }

--- a/lib/widgets/error_dialog.dart
+++ b/lib/widgets/error_dialog.dart
@@ -112,3 +112,40 @@ Future<bool> promptAreYouSure(BuildContext context, String title, Widget body,
         );
       });
 }
+
+Future<bool> promptMessage(BuildContext context, String title, Widget body,
+    {contentPadding = const EdgeInsets.only(top: 32.0, left: 32.0, right: 32.0),
+    bool wideTitle = false,
+    String closeText = "CLOSE",
+    TextStyle textStyle = const TextStyle(color: Colors.white)}) {
+  Widget titleWidget = title == null
+      ? null
+      : Text(title, style: Theme.of(context).dialogTheme.titleTextStyle);
+  if (titleWidget != null && wideTitle) {
+    titleWidget = Container(
+      child: titleWidget,
+      width: MediaQuery.of(context).size.width,
+    );
+  }
+  return showDialog<bool>(
+      useRootNavigator: false,
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          contentPadding: contentPadding,
+          title: titleWidget,
+          content: SingleChildScrollView(
+            child: body,
+          ),
+          actions: <Widget>[
+            TextButton(
+              child: Text(closeText,
+                  style: Theme.of(context).primaryTextTheme.button),
+              onPressed: () {
+                Navigator.of(context).pop(false);
+              },
+            ),
+          ],
+        );
+      });
+}

--- a/lib/widgets/payment_details_dialog.dart
+++ b/lib/widgets/payment_details_dialog.dart
@@ -84,7 +84,8 @@ Future<Null> showPaymentDetailsDialog(
       ),
     ]),
     contentPadding: EdgeInsets.fromLTRB(8.0, 16.0, 8.0, 16.0),
-    content: Container(
+    content: SingleChildScrollView(
+        child: Container(
       width: MediaQuery.of(context).size.width,
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -245,10 +246,16 @@ Future<Null> showPaymentDetailsDialog(
                     ],
                   ),
                 ),
+          if (paymentInfo.lnurlPayInfo != null && paymentInfo.lnurlPayInfo.comment != '') 
+      ShareablePaymentRow(title: "Comment", sharedValue: paymentInfo.lnurlPayInfo.comment),
+          if (paymentInfo.type == PaymentType.SENT 
+              && paymentInfo.lnurlPayInfo != null) 
+            ..._getLNUrlSuccessActionForPayment(
+                context, paymentInfo.lnurlPayInfo?.successAction),
           ..._getPaymentInfoDetails(paymentInfo),
         ],
       ),
-    ),
+    )),
     shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(
             bottom: Radius.circular(12.0), top: Radius.circular(13.0))),
@@ -275,6 +282,18 @@ List<Widget> _getStreamedPaymentInfoDetails(StreamedPaymentInfo paymentInfo) {
         Int64(0), (previousValue, element) => element.amount + previousValue);
     return _Destination(title, amount, ent.value[0].currency);
   }).toList();
+}
+
+List<Widget> _getLNUrlSuccessActionForPayment(
+    BuildContext context, SuccessAction sa) {
+  return <Widget>[
+    if (sa.tag == 'url') ...[
+      ShareablePaymentRow(title: "Description", sharedValue: sa.description),
+      ShareablePaymentRow(title: "URL", sharedValue: sa.url), // TODO Hyperlink.
+    ],
+    if (sa.tag == 'message' || sa.tag == 'aes')
+      ShareablePaymentRow(title: 'Message', sharedValue: sa.message),
+  ];
 }
 
 List<Widget> _getSinglePaymentInfoDetails(PaymentInfo paymentInfo) {


### PR DESCRIPTION
This PR depends on [PR #135](https://github.com/breez/breez/pull/135).

This PR is ready for testing. Bugs and missing functionality are listed below.

## TODO

- [ ] Test 
    - [x] <http://bitrefill.com> wallet deposit.
    - [x]  <http://coinos.io> wallet deposit.
    - [x] Bug: <http://zebedee.io> lnurl-pay QR codes aren't handled.
        - Fix: BreezMobile uses qr_code_tools. Upstream [qr_code_tools needs to upgrade its zxing dependency](https://github.com/AifeiI/qr_code_tools/pull/9).
    - [x] lnurl-toolbox.
    - [x] <https://lightning.gifts>
- [x] Handle `SuccessAction`.
   - [x] Handle `SuccessAction` "aes" tag.
       - [ ] We need a way to test decryption of lnurl-Pay messages. I'll configure `LNBits` for this.
- [x] Save `description` from `service`. (description hash is already saved in the invoice `h` tag.)
- [x] Save user's `comment`.
- [ ] Display user's `comment` with transaction details.
    - [ ] Feature; Should users be able to label/comment any transaction (as we do in Bitcon wallets, for coin control?). 
- [x] Code cleanup.
    - [x]  Make sure any new files don't have extraneous dependencies.
    - [x] Remove unnecessary comments. 
- [x] Bug: Errors from rpc server are not being received in pay_invoice_page.dart. Why have errors stopped working?
- [ ] Bug: lnurls in the clipboard should be detected and optionally trigger lnurl-pay flow.
