### PR TITLE
Protect Security & Backup page with Manager Password

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -468,9 +468,14 @@ class HomeState extends State<Home> with WidgetsBindingObserver {
                                                                   "Network",
                                                                   "src/icon/network.png"),
                                                               DrawerItemConfig(
-                                                                  "/security",
+                                                                  "",
                                                                   "Security & Backup",
-                                                                  "src/icon/security.png"),
+                                                                  "src/icon/security.png",
+                                                                  onItemSelected: (_) =>
+                                                                      protectAdminRoute(
+                                                                          context,
+                                                                          user,
+                                                                          "/security")),
                                                               ...advancedFlavorItems,
                                                             ]),
                                                             groupTitle:


### PR DESCRIPTION
Solves #528

Security & Backup page is now protected by Manager password.

User will be prompted manager password followed by PIN code if available before entering Security & Backup page _on POS mode_. 
 - This behavior is exclusive to POS mode as switching to other modes requires the user to enter the Manager password beforehand.