### PR TITLE
Fix custom amount dialog

### DIFF
--- a/lib/routes/podcast/custom_amount_dialog.dart
+++ b/lib/routes/podcast/custom_amount_dialog.dart
@@ -1,4 +1,3 @@
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -41,7 +40,7 @@ class CustomAmountDialogState extends State<CustomAmountDialog> {
 
   Widget _buildPaymentRequestDialog() {
     return AlertDialog(
-      title: AutoSizeText(
+      title: Text(
         "Enter a Custom Amount:",
         style:
             Theme.of(context).dialogTheme.titleTextStyle.copyWith(fontSize: 16),


### PR DESCRIPTION
On my device the dialog was not being shown, as you see on the following video:

https://user-images.githubusercontent.com/1225438/126834508-fb5886a3-38d6-4454-8a46-ea19dad64b85.mp4

It seems to be a issue with `AutoSizeText` as title to `AlertDialog`, because the text is always `"Enter a Custom Amount:"` I guess just changing it to `Text` is enough as you can see on the following video:

https://user-images.githubusercontent.com/1225438/126834662-7bdbb554-32e6-42a7-87df-65ad13dee022.mp4

If I'm missing something and it is necessary to use the `AutoSizeText` let me know so I can check the library code and try to solve that issue there.