### PR TITLE
Bug fixes and small changes to lightning-address functionality.

### DIFF
--- a/lib/bloc/account/account_model.dart
+++ b/lib/bloc/account/account_model.dart
@@ -665,6 +665,13 @@ class SinglePaymentInfo implements PaymentInfo {
     if (this.keySend && description.isNotEmpty) {
       return description;
     }
+
+    if (_paymentResponse.hasLnurlPayInfo()) {
+      if (_paymentResponse.lnurlPayInfo.lightningAddress.isNotEmpty) {
+        return _paymentResponse.lnurlPayInfo.lightningAddress;
+      }
+    }
+
     return title;
   }
 

--- a/lib/bloc/invoice/invoice_bloc.dart
+++ b/lib/bloc/invoice/invoice_bloc.dart
@@ -12,6 +12,7 @@ import 'package:breez/services/nfc.dart';
 import 'package:breez/services/notifications.dart';
 import 'package:breez/utils/bip21.dart';
 import 'package:breez/utils/node_id.dart';
+import 'package:breez/utils/lnurl.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -78,9 +79,15 @@ class InvoiceBloc with AsyncActionsHandler {
         if (normalized.startsWith("lightning:")) {
           normalized = normalized.substring(10);
         }
+
         if (normalized.startsWith("lnurl")) {
           return DecodedClipboardData(clipboardData, "lnurl");
         }
+
+        if (isLightningAddress(normalized)) {
+          return DecodedClipboardData(clipboardData, "lightning-address");
+        }
+
         if (normalized.startsWith("ln")) {
           try {
             await _breezLib.getRelatedInvoice(clipboardData);

--- a/lib/bloc/lnurl/lnurl_bloc.dart
+++ b/lib/bloc/lnurl/lnurl_bloc.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:breez/logger.dart';
 import 'package:breez/services/breezlib/breez_bridge.dart';
 import 'package:breez/services/breezlib/data/rpc.pbserver.dart';
 import 'package:breez/services/injector.dart';
@@ -37,6 +38,7 @@ class LNUrlBloc with AsyncActionsHandler {
   }
 
   listenLNUrl() {
+    log.info('listenLNUrl');
     if (_lnUrlStreamController == null) {
       _lnUrlStreamController = StreamController.broadcast();
       final injector = ServiceInjector();
@@ -44,7 +46,11 @@ class LNUrlBloc with AsyncActionsHandler {
         injector.nfc.receivedLnLinks(),
         injector.lightningLinks.linksNotifications,
         _lnurlInputController.stream,
-        injector.device.distinctClipboardStream,
+
+        // Process lightning-addresses in the clipboard only when the user manually 
+        // pastes them in and they show up in _lnurlInputController.stream.
+        injector.device.distinctClipboardStream
+            .where((l) => !isLightningAddress(l)),
       ])
           .where((l) => l != null)
           .map((l) => l.toLowerCase())

--- a/lib/routes/home/bottom_actions_bar.dart
+++ b/lib/routes/home/bottom_actions_bar.dart
@@ -88,7 +88,8 @@ class BottomActionsBar extends StatelessWidget {
                         DecodedClipboardData clipboardData =
                             await snapshot.data;
                         if (clipboardData != null) {
-                          if (clipboardData.type == "lnurl") {
+                          if (clipboardData.type == "lnurl" ||
+                              clipboardData.type == "lightning-address") {
                             lnurlBloc.lnurlInputSink.add(clipboardData.data);
                           } else if (clipboardData.type == "invoice") {
                             invoiceBloc.decodeInvoiceSink
@@ -104,8 +105,8 @@ class BottomActionsBar extends StatelessWidget {
                               useRootNavigator: false,
                               context: context,
                               barrierDismissible: false,
-                              builder: (_) => EnterPaymentInfoDialog(
-                                  context, invoiceBloc, firstPaymentItemKey));
+                              builder: (_) => EnterPaymentInfoDialog(context,
+                                  invoiceBloc, lnurlBloc, firstPaymentItemKey));
                         }
                       },
                     ),

--- a/lib/routes/home/bottom_actions_bar.dart
+++ b/lib/routes/home/bottom_actions_bar.dart
@@ -80,7 +80,7 @@ class BottomActionsBar extends StatelessWidget {
                           iconAssetPath: "src/icon/paste.png",
                           enabled: account.connected),
                       title: Text(
-                        "Paste Invoice or Node ID",
+                        "Paste Invoice or ID",
                         style: theme.bottomSheetTextStyle,
                       ),
                       onTap: () async {

--- a/lib/routes/lnurl_fetch_invoice_page.dart
+++ b/lib/routes/lnurl_fetch_invoice_page.dart
@@ -202,10 +202,12 @@ class LNURLFetchInvoicePageState extends State<LNURLFetchInvoicePage> {
                             return null;
                           },
                           style: theme.FieldTextStyle.textStyle),
-                      Text(
-                          "Enter an amount between ${acc.currency.format(widget.payFetchResponse.minAmount)} and ${acc.currency.format(widget.payFetchResponse.maxAmount)}",
-                          textAlign: TextAlign.left,
-                          style: theme.FieldTextStyle.labelStyle),
+                      Padding(
+                              padding: EdgeInsets.only(top: 8),
+                              child: Text(
+                                      "Enter an amount between ${acc.currency.format(widget.payFetchResponse.minAmount)} and ${acc.currency.format(widget.payFetchResponse.maxAmount)}",
+                                      textAlign: TextAlign.left,
+                                      style: theme.FieldTextStyle.labelStyle)),
                       Container(
                         width: MediaQuery.of(context).size.width,
                         height: 48,

--- a/lib/widgets/enter_payment_info_dialog.dart
+++ b/lib/widgets/enter_payment_info_dialog.dart
@@ -1,7 +1,9 @@
 import 'package:breez/bloc/invoice/invoice_bloc.dart';
+import 'package:breez/bloc/lnurl/lnurl_bloc.dart';
 import 'package:breez/routes/spontaneous_payment/spontaneous_payment_page.dart';
 import 'package:breez/theme_data.dart' as theme;
 import 'package:breez/utils/node_id.dart';
+import 'package:breez/utils/lnurl.dart';
 import 'package:breez/widgets/route.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -11,10 +13,11 @@ import 'flushbar.dart';
 class EnterPaymentInfoDialog extends StatefulWidget {
   final BuildContext context;
   final InvoiceBloc invoiceBloc;
+  final LNUrlBloc lnurlBloc;
   final GlobalKey firstPaymentItemKey;
 
   EnterPaymentInfoDialog(
-      this.context, this.invoiceBloc, this.firstPaymentItemKey);
+      this.context, this.invoiceBloc, this.lnurlBloc, this.firstPaymentItemKey);
 
   @override
   State<StatefulWidget> createState() {
@@ -93,7 +96,8 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
                             Theme.of(context).primaryTextTheme.headline4.color),
                     validator: (value) {
                       if (parseNodeId(value) == null &&
-                          decodeInvoice(value) == null) {
+                          decodeInvoice(value) == null &&
+                          !isLightningAddress(value)) {
                         return "Invalid invoice or ID";
                       }
                       return null;
@@ -137,6 +141,9 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
             if (decodeInvoice(_paymentInfoController.text) != null) {
               widget.invoiceBloc.decodeInvoiceSink
                   .add(_paymentInfoController.text);
+            }
+            if (isLightningAddress(_paymentInfoController.text)) {
+              widget.lnurlBloc.lnurlInputSink.add(_paymentInfoController.text);
             }
           }
         }),

--- a/lib/widgets/enter_payment_info_dialog.dart
+++ b/lib/widgets/enter_payment_info_dialog.dart
@@ -71,7 +71,7 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
                 children: <Widget>[
                   TextFormField(
                     decoration: InputDecoration(
-                      labelText: "Invoice or Node ID",
+                      labelText: "Invoice or ID",
                       suffixIcon: IconButton(
                         padding: EdgeInsets.only(top: 21.0),
                         alignment: Alignment.bottomRight,
@@ -94,7 +94,7 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
                     validator: (value) {
                       if (parseNodeId(value) == null &&
                           decodeInvoice(value) == null) {
-                        return "Invalid invoice or node ID";
+                        return "Invalid invoice or ID";
                       }
                       return null;
                     },

--- a/lib/widgets/payment_details_dialog.dart
+++ b/lib/widgets/payment_details_dialog.dart
@@ -306,10 +306,6 @@ List<Widget> _getSinglePaymentInfoDetails(PaymentInfo paymentInfo) {
         ? Container()
         : ShareablePaymentRow(
             title: "Node ID", sharedValue: paymentInfo.destination),
-    paymentInfo.paymentHash == null || paymentInfo.paymentHash.isEmpty
-        ? Container()
-        : ShareablePaymentRow(
-            title: "Transaction Hash", sharedValue: paymentInfo.paymentHash),
     paymentInfo.redeemTxID == null || paymentInfo.redeemTxID.isEmpty
         ? Container()
         : ShareablePaymentRow(


### PR DESCRIPTION
This PR depends on https://github.com/breez/breez/pull/141.
- [x] Simplify 'Send' input labels and help-text because we can paste other   types of ids that are supported e.g. Lightning-Addresses.
- [x] Small improvement to widget layout.
- [x] Show Lightning-Address in payment details dialog.
- ~Silent fail if we've set an LNUrlResponseError.~
    - This will be improved because Breez should present the user with an error if 
        - they manually paste a non-lightning-address. -
        - they paste a lightning-address but the host server generates an error.
- [x] Allow user to manually paste a lightning-address.

---

- [x] Improve error handling for lightning-addresses.
    - [x] Do not automatically process lightning-addresses from the clipboard. Require the user to manually paste.
    - [x] Show user an error if they manually paste a lightning-address and the host server generates an error.
        - [x] Handle when the server generates an lnurl json error.
        - [x] Handle when the server fails in a non-standard way e.g.
            - [x] [coinos.io](coinos.io) responds with the following on 20210904:
            ```
            $ curl -LR https://coinos.io/.well-known/lnurlp/chiron
            LNURL payments temporarily disabled due to a server issue. Sep. 2, 2021. Join our Telegram channel https://t.me/coinoswallet for updates
            ```
            - [x] [lntxbot.com](lntxbot.com)  responds with nothing on 20210904.
    - [x] Show user an error if they manually paste an non-lightning-address.
