### PR TITLE
Add custom amount to boostagram

### DIFF
--- a/lib/bloc/podcast_payments/payment_options.dart
+++ b/lib/bloc/podcast_payments/payment_options.dart
@@ -43,7 +43,8 @@ class PaymentOptions {
         'customSatsPerMinValue': customSatsPerMinValue,
       };
 
-  List get presetBoostAmountsList => [100, 500, 1000, 5000, 10000, 50000];
+  List<int> get presetBoostAmountsList =>
+      [50, 100, 500, 1000, 5000, 10000, 50000];
 
   List get boostAmountList {
     List boostAmountList = presetBoostAmountsList;
@@ -55,7 +56,7 @@ class PaymentOptions {
     ];
   }
 
-  List get presetSatsPerMinuteAmountsList =>
+  List<int> get presetSatsPerMinuteAmountsList =>
       [0, 10, 25, 50, 100, 250, 500, 1000];
 
   List get satsPerMinuteIntervalsList {

--- a/lib/bloc/user_profile/currency.dart
+++ b/lib/bloc/user_profile/currency.dart
@@ -32,6 +32,19 @@ class Currency extends Object {
 
   Int64 parse(String amountStr) => _CurrencyFormatter().parse(amountStr, this);
 
+  int parseToInt(
+    String amountStr, {
+    int def: 0,
+  }) {
+    int value;
+    try {
+      value = parse(amountStr).toInt() ?? def;
+    } catch (e) {
+      return def;
+    }
+    return value;
+  }
+
   Int64 toSats(double amount) => _CurrencyFormatter().toSats(amount, this);
 
   String get displayName =>

--- a/lib/routes/podcast/boost_message_dialog.dart
+++ b/lib/routes/podcast/boost_message_dialog.dart
@@ -1,11 +1,19 @@
+import 'package:breez/bloc/user_profile/currency.dart';
+import 'package:breez/routes/podcast/custom_amount_form.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 class BoostMessageDialog extends StatefulWidget {
-  final Function(String boostMessage) setMessage;
+  final int customAmount;
+  final List<int> preset;
+  final Function(int customAmount, String boostMessage) setBoost;
 
-  BoostMessageDialog(this.setMessage);
+  BoostMessageDialog(
+    this.customAmount,
+    this.preset,
+    this.setBoost,
+  );
 
   @override
   State<StatefulWidget> createState() {
@@ -14,17 +22,23 @@ class BoostMessageDialog extends StatefulWidget {
 }
 
 class BoostMessageDialogState extends State<BoostMessageDialog> {
-  final _formKey = GlobalKey<FormState>();
-  TextEditingController _boostMessageController = TextEditingController();
+  final _messageKey = GlobalKey<FormState>();
+  final _amountKey = GlobalKey<FormState>();
+  final TextEditingController _messageController = TextEditingController();
+  CustomAmountTextEditingController _amountController;
   final FocusNode _messageFocusNode = FocusNode();
+  final FocusNode _amountFocusNode = FocusNode();
 
   @override
   void initState() {
     super.initState();
-    _boostMessageController.addListener(() {
+    _amountController = CustomAmountTextEditingController(widget.customAmount);
+    _messageController.addListener(() {
       setState(() {});
     });
-    if (_boostMessageController.text.isEmpty) _messageFocusNode.requestFocus();
+    _amountController.addListener(() {
+      setState(() {});
+    });
   }
 
   @override
@@ -33,11 +47,12 @@ class BoostMessageDialogState extends State<BoostMessageDialog> {
   }
 
   Widget _buildBoostMessageDialog() {
+    var theme = Theme.of(context);
     return AlertDialog(
+      scrollable: true,
       title: Text(
         "Send a Boostagram",
-        style:
-            Theme.of(context).dialogTheme.titleTextStyle.copyWith(fontSize: 16),
+        style: theme.dialogTheme.titleTextStyle.copyWith(fontSize: 16),
         maxLines: 1,
       ),
       content: _buildMessageWidget(),
@@ -46,50 +61,71 @@ class BoostMessageDialogState extends State<BoostMessageDialog> {
   }
 
   Widget _buildMessageWidget() {
-    return Form(
-      key: _formKey,
-      autovalidateMode: AutovalidateMode.disabled,
-      child: TextFormField(
-        autovalidateMode: AutovalidateMode.disabled,
-        focusNode: _messageFocusNode,
-        controller: _boostMessageController,
-        keyboardType: TextInputType.multiline,
-        textInputAction: TextInputAction.done,
-        maxLines: null,
-        maxLength: 90,
-        maxLengthEnforcement: MaxLengthEnforcement.enforced,
-        validator: (raw) {
-          if (raw.length == 0) {
-            return "Please enter a message";
-          }
-          return null;
-        },
-        style: Theme.of(context)
-            .dialogTheme
-            .contentTextStyle
-            .copyWith(height: 1.0),
-      ),
+    final theme = Theme.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Form(
+          key: _messageKey,
+          autovalidateMode: AutovalidateMode.disabled,
+          child: TextFormField(
+            autovalidateMode: AutovalidateMode.disabled,
+            focusNode: _messageFocusNode,
+            controller: _messageController,
+            keyboardType: TextInputType.multiline,
+            textInputAction: TextInputAction.next,
+            maxLines: null,
+            maxLength: 90,
+            maxLengthEnforcement: MaxLengthEnforcement.enforced,
+            style: theme.dialogTheme.contentTextStyle.copyWith(height: 1.0),
+            decoration: InputDecoration(
+              labelText: "Boostagram (optional)",
+            ),
+          ),
+        ),
+        Form(
+          key: _amountKey,
+          autovalidateMode: AutovalidateMode.disabled,
+          child: CustomAmountFormField(
+            focusNode: _amountFocusNode,
+            controller: _amountController,
+            preset: widget.preset,
+            decoration: InputDecoration(
+              labelText: "Boost Amount",
+            ),
+            style: theme.dialogTheme.contentTextStyle.copyWith(height: 1.0),
+          ),
+        )
+      ],
     );
   }
 
   List<Widget> _buildActions() {
+    final theme = Theme.of(context);
     List<Widget> actions = [
       TextButton(
         onPressed: () => Navigator.pop(context),
-        child: Text("CANCEL", style: Theme.of(context).primaryTextTheme.button),
+        child: Text("CANCEL", style: theme.primaryTextTheme.button),
       ),
     ];
-    if (_boostMessageController.text.isNotEmpty) {
+    if (_amountKey.currentState?.validate() ??
+        _amountController.text.isNotEmpty) {
       actions.add(
         TextButton(
           onPressed: () {
-            if (_formKey.currentState.validate()) {
+            if (_amountKey.currentState?.validate() ?? false) {
               Navigator.pop(context);
-              widget.setMessage(_boostMessageController.text);
+              widget.setBoost(
+                Currency.SAT.parseToInt(_amountController.text),
+                _messageController.text,
+              );
             }
           },
-          child:
-              Text("BOOST!", style: Theme.of(context).primaryTextTheme.button),
+          child: Text(
+            "BOOST!",
+            style: theme.primaryTextTheme.button,
+          ),
         ),
       );
     }

--- a/lib/routes/podcast/custom_amount_dialog.dart
+++ b/lib/routes/podcast/custom_amount_dialog.dart
@@ -1,13 +1,11 @@
 import 'package:breez/bloc/user_profile/currency.dart';
-import 'package:breez/widgets/sat_amount_form_field_formatter.dart';
-import 'package:fixnum/fixnum.dart';
+import 'package:breez/routes/podcast/custom_amount_form.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 class CustomAmountDialog extends StatefulWidget {
   final int customAmount;
-  final List presetAmountsList;
+  final List<int> presetAmountsList;
   final Function(int customAmount) setAmount;
 
   CustomAmountDialog(this.customAmount, this.presetAmountsList, this.setAmount);
@@ -20,32 +18,19 @@ class CustomAmountDialog extends StatefulWidget {
 
 class CustomAmountDialogState extends State<CustomAmountDialog> {
   final _formKey = GlobalKey<FormState>();
-  TextEditingController _customAmountController = TextEditingController();
+  CustomAmountTextEditingController _amountController;
   final FocusNode _amountFocusNode = FocusNode();
 
   @override
   void initState() {
     super.initState();
-    _customAmountController.addListener(() {
+    _amountController = CustomAmountTextEditingController(widget.customAmount);
+    _amountController.addListener(() {
       setState(() {});
     });
-    _customAmountController.text = _initialCustomAmount();
-    if (_customAmountController.text.isEmpty) _amountFocusNode.requestFocus();
-  }
-
-  String _initialCustomAmount() {
-    final initial = widget.customAmount;
-    if (initial == null) {
-      return null;
+    if (_amountController.text.isEmpty) {
+      _amountFocusNode.requestFocus();
     }
-    if (widget.presetAmountsList.contains(initial)) {
-      return null;
-    }
-    return Currency.SAT.format(
-      Int64(initial),
-      includeDisplayName: false,
-      includeCurrencySymbol: false,
-    );
   }
 
   @override
@@ -54,42 +39,27 @@ class CustomAmountDialogState extends State<CustomAmountDialog> {
   }
 
   Widget _buildPaymentRequestDialog() {
+    final theme = Theme.of(context);
     return AlertDialog(
       title: Text(
         "Enter a Custom Amount:",
-        style:
-            Theme.of(context).dialogTheme.titleTextStyle.copyWith(fontSize: 16),
+        style: theme.dialogTheme.titleTextStyle.copyWith(fontSize: 16),
         maxLines: 1,
       ),
-      content: _buildAmountWidget(),
+      content: _buildAmountWidget(theme),
       actions: _buildActions(),
     );
   }
 
-  Widget _buildAmountWidget() {
+  Widget _buildAmountWidget(ThemeData theme) {
     return Form(
       key: _formKey,
       autovalidateMode: AutovalidateMode.disabled,
-      child: TextFormField(
-        autovalidateMode: AutovalidateMode.disabled,
+      child: CustomAmountFormField(
         focusNode: _amountFocusNode,
-        controller: _customAmountController,
-        keyboardType: TextInputType.number,
-        inputFormatters: [SatAmountFormFieldFormatter()],
-        validator: (raw) {
-          if (raw.length == 0) {
-            return "Please enter a custom amount";
-          }
-          int value = _satsValue(raw);
-          if (value < widget.presetAmountsList[0]) {
-            return "Please enter at least ${widget.presetAmountsList[0]} sats.";
-          }
-          return null;
-        },
-        style: Theme.of(context)
-            .dialogTheme
-            .contentTextStyle
-            .copyWith(height: 1.0),
+        controller: _amountController,
+        preset: widget.presetAmountsList,
+        style: theme.dialogTheme.contentTextStyle.copyWith(height: 1.0),
       ),
     );
   }
@@ -101,14 +71,14 @@ class CustomAmountDialogState extends State<CustomAmountDialog> {
         child: Text("CANCEL", style: Theme.of(context).primaryTextTheme.button),
       ),
     ];
-    if (_customAmountController.text.isNotEmpty) {
+    if (_amountController.text.isNotEmpty) {
       actions.add(
         TextButton(
           onPressed: () {
             if (_formKey.currentState.validate()) {
               Navigator.pop(context);
               widget.setAmount(
-                _satsValue(_customAmountController.text),
+                Currency.SAT.parseToInt(_amountController.text),
               );
             }
           },
@@ -118,15 +88,5 @@ class CustomAmountDialogState extends State<CustomAmountDialog> {
       );
     }
     return actions;
-  }
-
-  int _satsValue(String raw) {
-    int value;
-    try {
-      value = Currency.SAT.parse(raw).toInt();
-    } catch (e) {
-      return 0;
-    }
-    return value;
   }
 }

--- a/lib/routes/podcast/custom_amount_form.dart
+++ b/lib/routes/podcast/custom_amount_form.dart
@@ -1,0 +1,63 @@
+import 'package:breez/bloc/user_profile/currency.dart';
+import 'package:breez/widgets/sat_amount_form_field_formatter.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+class CustomAmountFormField extends TextFormField {
+  final List<int> preset;
+
+  CustomAmountFormField({
+    Key key,
+    FocusNode focusNode,
+    TextEditingController controller,
+    InputDecoration decoration,
+    TextStyle style,
+    this.preset,
+  }) : super(
+          key: key,
+          autovalidateMode: AutovalidateMode.disabled,
+          focusNode: focusNode,
+          controller: controller,
+          keyboardType: TextInputType.number,
+          decoration: decoration,
+          style: style,
+          inputFormatters: [
+            SatAmountFormFieldFormatter(),
+          ],
+        );
+
+  @override
+  FormFieldValidator<String> get validator {
+    return (value) {
+      if (value.isEmpty) {
+        return "Please enter a custom amount";
+      }
+      int valueInt = Currency.SAT.parseToInt(value);
+      if (valueInt < preset[0]) {
+        return "Please enter at least ${preset[0]} sats.";
+      }
+      return null;
+    };
+  }
+}
+
+class CustomAmountTextEditingController extends TextEditingController {
+  CustomAmountTextEditingController(
+    int customAmount,
+  ) : super() {
+    this.text = _initialCustomAmount(customAmount);
+  }
+
+  String _initialCustomAmount(int customAmount) {
+    final initial = customAmount;
+    if (initial == null) {
+      return null;
+    }
+    return Currency.SAT.format(
+      Int64(initial),
+      includeDisplayName: false,
+      includeCurrencySymbol: false,
+    );
+  }
+}


### PR DESCRIPTION
The main change of the PR is to add on boostagram dialog a form to set a custom amount.

The amount field is the same being used on other amount dialogs, to do so I had to extract the form to its own widget `CustomAmountFormField`.

Those changes also swap the tap and long-press behaviors, so now the tap opens the boostagram dialog and long-press applies the boostagram with the current value.

https://user-images.githubusercontent.com/1225438/133261138-b7ce6dbd-8d3d-46c3-b6c9-218c7b7e5056.mp4



