### PR TITLE
Add last selected currency on item addition

### DIFF
--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:developer';
 import 'dart:io';
 
 import 'package:breez/bloc/account/account_actions.dart';
@@ -10,8 +9,8 @@ import 'package:breez/bloc/async_action.dart';
 import 'package:breez/bloc/csv_exporter.dart';
 import 'package:breez/bloc/user_profile/breez_user_model.dart';
 import 'package:breez/logger.dart';
-import 'package:breez/services/breez_server/server.dart';
 import 'package:breez/services/background_task.dart';
+import 'package:breez/services/breez_server/server.dart';
 import 'package:breez/services/breezlib/breez_bridge.dart';
 import 'package:breez/services/breezlib/data/rpc.pb.dart';
 import 'package:breez/services/currency_data.dart';

--- a/lib/bloc/pos_catalog/actions.dart
+++ b/lib/bloc/pos_catalog/actions.dart
@@ -60,3 +60,9 @@ class ImportItems extends AsyncAction {
 
   ImportItems(this.importFile);
 }
+
+class UpdatePosItemAdditionCurrency extends AsyncAction {
+  final String currency;
+
+  UpdatePosItemAdditionCurrency(this.currency);
+}

--- a/lib/bloc/pos_catalog/bloc.dart
+++ b/lib/bloc/pos_catalog/bloc.dart
@@ -38,6 +38,10 @@ class PosCatalogBloc with AsyncActionsHandler {
   Stream<List<ProductIcon>> get productIconsStream =>
       _productIconsController.stream;
 
+  final BehaviorSubject<String> _selectedCurrency = BehaviorSubject();
+
+  Stream<String> get selectedCurrencyStream => _selectedCurrency.stream;
+
   PosCatalogBloc(Stream<AccountModel> accountStream) {
     _repository = SqliteRepository();
     _loadItems();
@@ -52,12 +56,14 @@ class PosCatalogBloc with AsyncActionsHandler {
       FilterItems: _filterItems,
       ExportItems: _exportItems,
       ImportItems: _importItems,
+      UpdatePosItemAdditionCurrency: _updatePosItemAdditionCurrency,
     });
     listenActions();
     _currentSaleController.add(Sale(saleLines: []));
     _trackCurrentSaleRates(accountStream);
     _trackSalePayments();
     _loadIcons();
+    _loadSelectedCurrency();
   }
 
   Future _loadIcons() async {
@@ -66,6 +72,17 @@ class PosCatalogBloc with AsyncActionsHandler {
     List<dynamic> decoded = json.decode(iconsJson);
     _productIconsController
         .add(decoded.map((e) => ProductIcon.fromJson(e)).toList());
+  }
+
+  void _loadSelectedCurrency() async {
+    final prefs = await ServiceInjector().sharedPreferences;
+    String currency;
+    if (prefs.containsKey("ITEM_ADDITION_CURRENCY")) {
+      currency = prefs.getString("ITEM_ADDITION_CURRENCY");
+    } else {
+      currency = "SAT";
+    }
+    _selectedCurrency.add(currency);
   }
 
   void _trackSalePayments() {
@@ -173,6 +190,14 @@ class PosCatalogBloc with AsyncActionsHandler {
   Future _setCurrentSale(SetCurrentSale action) async {
     _currentSaleController.add(action.currentSale);
     action.resolve(action.currentSale);
+  }
+
+  Future _updatePosItemAdditionCurrency(
+    UpdatePosItemAdditionCurrency action,
+  ) async {
+    final prefs = await ServiceInjector().sharedPreferences;
+    prefs.setString("ITEM_ADDITION_CURRENCY", action.currency);
+    _selectedCurrency.add(action.currency);
   }
 
   Future resetDB() async {

--- a/lib/routes/charge/items/item_page.dart
+++ b/lib/routes/charge/items/item_page.dart
@@ -53,8 +53,8 @@ class ItemPageState extends State<ItemPage> {
       _accountBloc = AppBlocsProvider.of<AccountBloc>(context);
       FetchRates fetchRatesAction = FetchRates();
       _accountBloc.userActionsSink.add(fetchRatesAction);
-      if (widget.item != null) {
-        _accountBloc.accountStream.first.then((accountModel) {
+      _accountBloc.accountStream.first.then((accountModel) {
+        if (widget.item != null) {
           setState(() {
             _title = "Edit Item";
             _itemImage = widget.item.imageURL;
@@ -64,8 +64,15 @@ class ItemPageState extends State<ItemPage> {
                 widget.item.currency, accountModel);
             _priceController.text = _formattedPrice(widget.item.price);
           });
-        });
-      }
+        } else {
+          widget._posCatalogBloc.selectedCurrencyStream.listen((currency) {
+            setState(() {
+              _selectedCurrency =
+                  CurrencyWrapper.fromShortName(currency, accountModel);
+            });
+          });
+        }
+      });
 
       fetchRatesAction.future.catchError((err) {
         if (this.mounted) {
@@ -300,6 +307,7 @@ class ItemPageState extends State<ItemPage> {
             _formattedPrice(double.parse(_priceController.text));
       }
     });
+    widget._posCatalogBloc.actionsSink.add(UpdatePosItemAdditionCurrency(value));
   }
 
   String _formattedPrice(double price) {


### PR DESCRIPTION
When you are adding items to the POS, each time you enter the add item screen you have to select the currency, this PR saves the last currency used and use that next time the user enters that screen.

# Before

https://user-images.githubusercontent.com/1225438/136356652-24f12c11-7e95-4db7-82b8-5e6873309bd6.mp4

# After

https://user-images.githubusercontent.com/1225438/136356640-b5bd99d3-175a-4df8-9441-317e73291375.mp4

 