### PR TITLE
Add an extra space on pos items list

### DIFF
--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -611,32 +611,64 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
             child: ListView(
               primary: false,
               shrinkWrap: true,
-              children: <Widget>[
-                catalogItems?.length == 0
-                    ? Padding(
-                        padding: const EdgeInsets.only(
-                            top: 180.0, left: 40.0, right: 40.0),
-                        child: AutoSizeText(
-                          _itemFilterController.text.isNotEmpty
-                              ? "No matching items found."
-                              : "No items to display.\nAdd items to this view using the '+' button.",
-                          textAlign: TextAlign.center,
-                          minFontSize: MinFontSize(context).minFontSize,
-                          stepGranularity: 0.1,
-                        ),
-                      )
-                    : ItemsList(
-                        accountModel,
-                        posCatalogBloc,
-                        catalogItems,
-                        (item, avatarKey) => _addItem(posCatalogBloc,
-                            currentSale, accountModel, item, avatarKey))
-              ],
+              children: catalogItems?.length == 0
+                  ? _emptyCatalog()
+                  : _filledCatalog(
+                      accountModel,
+                      posCatalogBloc,
+                      catalogItems,
+                      currentSale,
+                    ),
             ),
           ),
         ),
       ],
     );
+  }
+
+  List<Widget> _emptyCatalog() {
+    return [
+      Padding(
+        padding: const EdgeInsets.only(
+          top: 180.0,
+          left: 40.0,
+          right: 40.0,
+        ),
+        child: AutoSizeText(
+          _itemFilterController.text.isNotEmpty
+              ? "No matching items found."
+              : "No items to display.\nAdd items to this view using the '+' button.",
+          textAlign: TextAlign.center,
+          minFontSize: MinFontSize(context).minFontSize,
+          stepGranularity: 0.1,
+        ),
+      ),
+    ];
+  }
+
+  List<Widget> _filledCatalog(
+    AccountModel accountModel,
+    PosCatalogBloc posCatalogBloc,
+    List<Item> catalogItems,
+    Sale currentSale,
+  ) {
+    return [
+      ItemsList(
+        accountModel,
+        posCatalogBloc,
+        catalogItems,
+        (item, avatarKey) => _addItem(
+          posCatalogBloc,
+          currentSale,
+          accountModel,
+          item,
+          avatarKey,
+        ),
+      ),
+      Container(
+        height: 80.0,
+      )
+    ];
   }
 
   onInvoiceSubmitted(Sale currentSale, InvoiceBloc invoiceBloc,


### PR DESCRIPTION
The last item of pos item has its value hide by the fab button, the PR adds an extra space to the user scroll the list and be able to read the value.

# Before

https://user-images.githubusercontent.com/1225438/136365945-37fe7d72-feaf-455c-8fb8-4b1ccee077b8.mp4

# After

https://user-images.githubusercontent.com/1225438/136365929-1551b8ca-46b6-4034-b677-3aa7b24dbb2e.mp4
