### PR TITLE
Fix pdf print on some edge cases

### DIFF
--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -811,7 +811,6 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
               PaymentInfo paymentInfo = await _findPayment(payReq.paymentHash);
               PrintParameters printParameters = PrintParameters(
                 currentUser: user,
-                currentCurrency: currentCurrency,
                 account: account,
                 submittedSale: submittedSale,
                 paymentInfo: paymentInfo,

--- a/lib/routes/charge/sale_view.dart
+++ b/lib/routes/charge/sale_view.dart
@@ -129,7 +129,7 @@ class SaleViewState extends State<SaleView> {
               leading: backBtn.BackButton(),
               title: Text(title),
               actions: widget.readOnly
-                  ? _buildPrintIcon(accModel, saleCurrency)
+                  ? _buildPrintIcon(accModel)
                   : <Widget>[
                       IconButton(
                         icon: Icon(
@@ -242,7 +242,7 @@ class SaleViewState extends State<SaleView> {
         });
   }
 
-  _buildPrintIcon(AccountModel account, CurrencyWrapper saleCurrency) {
+  _buildPrintIcon(AccountModel account) {
     UserProfileBloc userBloc = AppBlocsProvider.of<UserProfileBloc>(context);
     return <Widget>[
       StreamBuilder<BreezUserModel>(
@@ -268,7 +268,6 @@ class SaleViewState extends State<SaleView> {
                 ),
                 onPressed: () => PrintService(PrintParameters(
                         currentUser: user,
-                        currentCurrency: saleCurrency,
                         account: account,
                         submittedSale: widget.readOnlySale,
                         paymentInfo: widget.salePayment))

--- a/lib/widgets/print_parameters.dart
+++ b/lib/widgets/print_parameters.dart
@@ -1,19 +1,17 @@
 import 'package:breez/bloc/account/account_model.dart';
 import 'package:breez/bloc/pos_catalog/model.dart';
 import 'package:breez/bloc/user_profile/breez_user_model.dart';
-import 'package:breez/routes/charge/currency_wrapper.dart';
 
 class PrintParameters {
   final BreezUserModel currentUser;
-  final CurrencyWrapper currentCurrency;
   final AccountModel account;
   final Sale submittedSale;
   final PaymentInfo paymentInfo;
 
-  PrintParameters(
-      {this.currentUser,
-      this.currentCurrency,
-      this.account,
-      this.submittedSale,
-      this.paymentInfo});
+  PrintParameters({
+    this.currentUser,
+    this.account,
+    this.submittedSale,
+    this.paymentInfo,
+  });
 }


### PR DESCRIPTION
Fix the printing on some edge cases.

# The print logic now is:

- If there is just one currency and it is not sat:
  - for each line prints: `Currency value formatted by currency` + `space` + `open parenthesis` + `Satoshi value formatted` + `close parenthesis`
  - for total prints: `Satoshi value` + `space` + `SAT` + `space` + `open parenthesis` + `Currency value formatted by currency` + `close parenthesis`

- If there is just one currency and it is sat:
  - for each line prints: `Satoshi value formatted`
  - for total prints: `Satoshi value` + `space` + `SAT`

- If there is two or more currency on items, do:
  - for each line prints: `Currency value formatted by currency` + `space` + `open parenthesis` + `Satoshi value formatted` + `close parenthesis`
  - for total prints: `Satoshi value` + `space` + `SAT`

# How it looks like on pos invoice (Transaction history)

[pos invoice brl.pdf](https://github.com/breez/breezmobile/files/7365522/pos.invoice.brl.pdf)
[pos invoice euro.pdf](https://github.com/breez/breezmobile/files/7365523/pos.invoice.euro.pdf)
[pos invoice multi currency.pdf](https://github.com/breez/breezmobile/files/7365524/pos.invoice.multi.currency.pdf)
[pos invoice sat.pdf](https://github.com/breez/breezmobile/files/7365525/pos.invoice.sat.pdf)

# How it looks like on sale view (Sale success popup)

[sale view brl.pdf](https://github.com/breez/breezmobile/files/7365526/sale.view.brl.pdf)
[sale view euro.pdf](https://github.com/breez/breezmobile/files/7365527/sale.view.euro.pdf)
[sale view multi currency.pdf](https://github.com/breez/breezmobile/files/7365528/sale.view.multi.currency.pdf)
[sale view sat.pdf](https://github.com/breez/breezmobile/files/7365529/sale.view.sat.pdf)
