### PR TITLE
Use uppercase characters when generating QR codes for more compact QR codes.

### DIFF
--- a/lib/bloc/account/add_funds_bloc.dart
+++ b/lib/bloc/account/add_funds_bloc.dart
@@ -14,7 +14,6 @@ import "package:ini/ini.dart";
 import 'package:rxdart/rxdart.dart';
 
 import '../blocs_provider.dart';
-import 'account_model.dart';
 import 'add_fund_vendor_model.dart';
 import 'add_funds_model.dart';
 import 'moonpay_order.dart';

--- a/lib/widgets/compact_qr_image.dart
+++ b/lib/widgets/compact_qr_image.dart
@@ -55,7 +55,13 @@ class CompactQRImage extends StatelessWidget {
     return QrImage(
       backgroundColor: Colors.white,
       version: _calculateVersion(),
-      data: data,
+      /*
+         Bech32 addresses consisting of uppercase and digits results in more compact QR codes.
+         NB. If we ever generate BIP21 URI's that have query parameters, this will have to be fixed so that
+         we will not change the case of the parameters because BIP21 parameters are case sensitive.
+         Ref. https://bitcoinops.org/en/bech32-sending-support/#creating-more-efficient-qr-codes-with-bech32-addresses
+      */
+      data: data?.toUpperCase(),
       size: this.size,
     );
   }


### PR DESCRIPTION
Fixes #595.
