### PR TITLE
Add Portuguese support on timeago messages

### DIFF
--- a/lib/utils/date.dart
+++ b/lib/utils/date.dart
@@ -21,7 +21,7 @@ class BreezDateUtils {
 
   static String formatTimelineRelative(DateTime d) {
     if (DateTime.now().subtract(Duration(days: 4)).isBefore(d)) {
-      return timeago.format(d);
+      return timeago.format(d, locale: Platform.localeName);
     } else {
       return formatYearMonthDay(d);
     }
@@ -36,5 +36,8 @@ class BreezDateUtils {
 
   static void setupLocales() {
     timeago.setLocaleMessages('en', timeago.EnMessages());
+    timeago.setLocaleMessages('en_short', timeago.EnShortMessages());
+    timeago.setLocaleMessages('pt_BR', timeago.PtBrMessages());
+    timeago.setLocaleMessages('pt_BR_short', timeago.PtBrShortMessages());
   }
 }


### PR DESCRIPTION
|Portuguese|English|Englis US|
|---|---|---|
|![portuguese](https://user-images.githubusercontent.com/1225438/139256875-8bf1242b-0b8e-4d68-9167-272df51b984e.png)|![english](https://user-images.githubusercontent.com/1225438/139256878-9351afb1-a10a-4684-af93-eb491fffa172.png)|![english_us](https://user-images.githubusercontent.com/1225438/139256883-87b9c022-02fe-4ea7-85d5-3edb40edb000.png)|

I'm adding Brazilian Portuguese only because it is the only Portuguese variant supported by the timeago

![Screenshot 2021-10-28 at 09 14 18](https://user-images.githubusercontent.com/1225438/139257165-65ff00c0-d527-493d-949c-93d9493023de.png)

