### PR TITLE
Add locale support for currency format

### DIFF
--- a/lib/bloc/account/fiat_conversion.dart
+++ b/lib/bloc/account/fiat_conversion.dart
@@ -49,14 +49,15 @@ class FiatConversion {
     bool removeTrailingZeros = false,
     bool allowBelowMin = false,
   }) {
-    int fractionSize = this.currencyData.fractionSize;
+    final currencyData = this.currencyData.localeAware();
+    int fractionSize = currencyData.fractionSize;
     double minimumAmount = 1 / (pow(10, fractionSize));
 
     String formattedAmount = "";
-    String spacing = " " * this.currencyData.spacing;
-    String symbol = (this.currencyData.position == 1)
-        ? spacing + '${this.currencyData.symbol}'
-        : '${this.currencyData.symbol}' + spacing;
+    String spacing = " " * currencyData.spacing;
+    String symbol = (currencyData.position == 1)
+        ? spacing + '${currencyData.symbol}'
+        : '${currencyData.symbol}' + spacing;
     // if conversion result is less than the minimum it doesn't make sense to display
     // it.
     if (!allowBelowMin && fiatAmount < minimumAmount) {
@@ -69,11 +70,11 @@ class FiatConversion {
       formattedAmount = formatter.format(fiatAmount);
     }
     if (addCurrencySymbol) {
-      formattedAmount = (this.currencyData.position == 1)
+      formattedAmount = (currencyData.position == 1)
           ? formattedAmount + symbol
           : symbol + formattedAmount;
     } else if (includeDisplayName) {
-      formattedAmount += this.currencyData.shortName;
+      formattedAmount += currencyData.shortName;
     }
     if (removeTrailingZeros) {
       RegExp removeTrailingZeros = RegExp(r"([.]0*)(?!.*\d)");

--- a/lib/l10n/locales.dart
+++ b/lib/l10n/locales.dart
@@ -16,7 +16,6 @@ Iterable<LocalizationsDelegate<dynamic>> localizationsDelegates() {
 Iterable<Locale> supportedLocales() {
   return [
     const Locale('en', ''),
-    const Locale('de', ''),
     const Locale('pt', ''),
   ];
 }

--- a/lib/services/currency_data.dart
+++ b/lib/services/currency_data.dart
@@ -1,8 +1,21 @@
 import 'dart:convert';
 
+import 'package:breez/utils/locale.dart';
+
 Map<String, CurrencyData> currencyDataFromJson(String str) =>
     Map.from(json.decode(str)).map((k, v) =>
         MapEntry<String, CurrencyData>(k, CurrencyData.fromJson(k, v)));
+
+Map<String, CurrencyDataOverride> currencyDataOverrideFromJson(
+  CurrencyData base,
+  Map<String, dynamic> src,
+) {
+  if (src == null || src.isEmpty) return {};
+  return src.map((locale, json) => MapEntry<String, CurrencyDataOverride>(
+        locale,
+        CurrencyDataOverride.fromJson(base, json),
+      ));
+}
 
 class CurrencyData {
   String name;
@@ -12,24 +25,72 @@ class CurrencyData {
   bool rtl;
   int position;
   int spacing;
+  Map<String, CurrencyDataOverride> localeOverrides = {};
 
-  CurrencyData(
-      {this.name,
-      this.shortName,
-      this.fractionSize,
-      this.symbol,
-      this.rtl,
-      this.position,
-      this.spacing});
+  CurrencyData({
+    this.name,
+    this.shortName,
+    this.fractionSize,
+    this.symbol,
+    this.rtl,
+    this.position,
+    this.spacing,
+  });
 
-  factory CurrencyData.fromJson(String shortName, Map<String, dynamic> json) =>
-      CurrencyData(
-        name: json["name"],
-        shortName: shortName,
-        fractionSize: json["fractionSize"] ?? 0,
-        symbol: json["symbol"] != null ? json["symbol"]["grapheme"] : shortName,
-        rtl: json["symbol"] != null ? json["symbol"]["rtl"] : false,
-        position: json["symbol"] != null ? json["symbol"]["position"] ?? 0 : 0,
-        spacing: json["spacing"] ?? 1,
-      );
+  CurrencyData localeAware() {
+    if (localeOverrides.isEmpty) return this;
+    final locale = getSystemLocale();
+    if (localeOverrides.containsKey(locale.toLanguageTag())) {
+      return localeOverrides[locale.toLanguageTag()];
+    }
+    if (localeOverrides.containsKey(locale.languageCode)) {
+      return localeOverrides[locale.languageCode];
+    }
+    return this;
+  }
+
+  factory CurrencyData.fromJson(String shortName, Map<String, dynamic> json) {
+    final currencyData = CurrencyData(
+      name: json["name"],
+      shortName: shortName,
+      fractionSize: json["fractionSize"] ?? 0,
+      symbol: json["symbol"] != null ? json["symbol"]["grapheme"] : shortName,
+      rtl: json["symbol"] != null ? json["symbol"]["rtl"] : false,
+      position: json["symbol"] != null ? json["symbol"]["position"] ?? 0 : 0,
+      spacing: json["spacing"] ?? 1,
+    );
+    final localeOverrides = currencyDataOverrideFromJson(
+      currencyData,
+      json["localeOverrides"],
+    );
+    currencyData.localeOverrides = localeOverrides;
+    return currencyData;
+  }
+}
+
+class CurrencyDataOverride extends CurrencyData {
+  CurrencyDataOverride({
+    CurrencyData base,
+    int position,
+    int spacing,
+  }) : super(
+          name: base.name,
+          shortName: base.shortName,
+          fractionSize: base.fractionSize,
+          symbol: base.symbol,
+          rtl: base.rtl,
+          position: position ?? base.position,
+          spacing: spacing ?? base.spacing,
+        );
+
+  factory CurrencyDataOverride.fromJson(
+    CurrencyData base,
+    Map<String, dynamic> json,
+  ) {
+    return CurrencyDataOverride(
+      base: base,
+      position: json["symbol"] != null ? json["symbol"]["position"] : null,
+      spacing: json["spacing"],
+    );
+  }
 }

--- a/lib/utils/locale.dart
+++ b/lib/utils/locale.dart
@@ -1,0 +1,12 @@
+import 'dart:io';
+import 'dart:ui';
+
+Locale getSystemLocale() {
+  final localeName = Platform.localeName;
+  if (localeName.contains("_")) {
+    final pieces = localeName.split("_");
+    return Locale(pieces[0], pieces[1]);
+  } else {
+    return Locale(localeName);
+  }
+}

--- a/src/json/currencies.json
+++ b/src/json/currencies.json
@@ -539,16 +539,45 @@
   "EUR": {
     "name": "Euro",
     "fractionSize": 2,
-    "spacing": 0,
+    "spacing": 1,
     "symbol": {
       "grapheme": "€",
-      "template": "$1",
+      "position": 1,
       "rtl": false
     },
     "uniqSymbol": {
       "grapheme": "€",
-      "template": "$1",
       "rtl": false
+    },
+    "localeOverrides": {
+      "de-AT": {
+        "symbol": {
+          "position": 0
+        }
+      },
+      "el-CY": {
+        "spacing": 0,
+        "symbol": {
+          "position": 0
+        }
+      },
+      "en": {
+        "spacing": 0,
+        "symbol": {
+          "position": 0
+        }
+      },
+      "nl": {
+        "symbol": {
+          "position": 0
+        }
+      },
+      "tr": {
+        "spacing": 0,
+        "symbol": {
+          "position": 0
+        }
+      }
     }
   },
   "FJD": {


### PR DESCRIPTION
|Default `x,xx €`|English `€x,xx`|Dutch `€ x,xx`|Turkish `€x,xx`|
|---|---|---|---|
|![pt](https://user-images.githubusercontent.com/1225438/139481694-6e1fe69d-f606-4c58-980a-a7f410094967.png)|![en](https://user-images.githubusercontent.com/1225438/139481688-612096f4-f8e6-4da3-a786-9d15004f8b65.png)|![nl](https://user-images.githubusercontent.com/1225438/139481678-f7e1dc63-909c-41ed-a0a4-7bc9309b8ff3.png)|![tr](https://user-images.githubusercontent.com/1225438/139481692-d331b1b6-3fe5-46f8-abc5-5801a1eead66.png)|

|Greek `x,xx €`| Cyprus's Greek `€x,xx`|German `x,xx €`|Austria's German `€ x,xx`|
|---|---|---|---|
|![el](https://user-images.githubusercontent.com/1225438/139481685-dc260dab-24b5-4f11-8fed-01e5d5ff3cba.png)|![el-cy](https://user-images.githubusercontent.com/1225438/139481690-9e1f8d89-1e6e-4301-b91b-b22354132124.png)|![de](https://user-images.githubusercontent.com/1225438/139481698-cc010fcd-710d-47fa-a594-7d1931807ced.png)|![de-AT](https://user-images.githubusercontent.com/1225438/139481696-230c203b-5573-47ba-adc9-b099de7b35d3.png)|


I'm using this table as reference: https://en.wikipedia.org/wiki/Language_and_the_euro#Written_conventions_for_the_euro_in_the_languages_of_EU_member_states

Fixes https://github.com/breez/breezmobile/issues/598

P.S. I did not add `Irish` and `Maltese` overrides because the support on my device is incomplete so I could not test it, in theory copying the English overrides with the proper tag, `ga` and `mt` should work.