### PR TITLE
Handle lightning-address URIs.

### DIFF
--- a/lib/bloc/invoice/invoice_bloc.dart
+++ b/lib/bloc/invoice/invoice_bloc.dart
@@ -156,6 +156,9 @@ class InvoiceBloc with AsyncActionsHandler {
         .map((s) {
           String lower = s.toLowerCase();
           if (lower.startsWith("lightning:")) {
+            if (isLightningAddress(lower)) {
+              return null;
+            }
             return s.substring(10);
           }
 

--- a/lib/bloc/invoice/invoice_bloc.dart
+++ b/lib/bloc/invoice/invoice_bloc.dart
@@ -85,7 +85,7 @@ class InvoiceBloc with AsyncActionsHandler {
         }
 
         if (isLightningAddress(normalized)) {
-          return DecodedClipboardData(clipboardData, "lightning-address");
+          return DecodedClipboardData(normalized, "lightning-address");
         }
 
         if (normalized.startsWith("ln")) {

--- a/lib/bloc/invoice/invoice_bloc.dart
+++ b/lib/bloc/invoice/invoice_bloc.dart
@@ -154,11 +154,12 @@ class InvoiceBloc with AsyncActionsHandler {
           s.toLowerCase().startsWith("lightning:"))
     ])
         .map((s) {
+          if (isLightningAddress(s)) {
+            return null;
+          }
+
           String lower = s.toLowerCase();
           if (lower.startsWith("lightning:")) {
-            if (isLightningAddress(lower)) {
-              return null;
-            }
             return s.substring(10);
           }
 

--- a/lib/routes/home/qr_action_button.dart
+++ b/lib/routes/home/qr_action_button.dart
@@ -56,12 +56,10 @@ class QrActionButton extends StatelessWidget {
               }
 
               // lightning address
-              if (isLightningAddress(lower)) {
-                if (lower.startsWith('lightning:')) {
-                  var v = lower.substring('lightning:'.length);
-                  lnurlBloc.lnurlInputSink.add(v);
-                  return;
-                }
+              final v = parseLightningAddress(scannedString);
+              if (v != null) {
+                lnurlBloc.lnurlInputSink.add(v);
+                return;
               }
 
               // bip 121

--- a/lib/routes/home/qr_action_button.dart
+++ b/lib/routes/home/qr_action_button.dart
@@ -55,6 +55,15 @@ class QrActionButton extends StatelessWidget {
                 return;
               }
 
+              // lightning address
+              if (isLightningAddress(lower)) {
+                if (lower.startsWith('lightning:')) {
+                  var v = lower.substring('lightning:'.length);
+                  lnurlBloc.lnurlInputSink.add(v);
+                  return;
+                }
+              }
+
               // bip 121
               String lnInvoice = extractBolt11FromBip21(lower);
               if (lnInvoice != null) {

--- a/lib/utils/lnurl.dart
+++ b/lib/utils/lnurl.dart
@@ -20,6 +20,7 @@ bool isLNURL(String url) {
   return false;
 }
 
+// FIXME(nochiel) Maybe this should parse 'lightning:' uris and return the address instead of a boolean?
 bool isLightningAddress(String uri) {
   // Ref. https://github.com/andrerfneves/lightning-address/blob/master/DIY.md
 
@@ -31,7 +32,7 @@ bool isLightningAddress(String uri) {
     }
 
   var result = EmailValidator.validate(email);
-  print('isLightningAddress: $email: $result');
+  print('isLightningAddress: $uri: $result');
   return result;
 
 }

--- a/lib/utils/lnurl.dart
+++ b/lib/utils/lnurl.dart
@@ -1,12 +1,12 @@
 import 'package:email_validator/email_validator.dart';
 
 RegExp _lnurlPrefix = new RegExp(",*?((lnurl)([0-9]{1,}[a-z0-9]+){1})");
-String _lightningProtoclPrefix = "lightning:";
+String _lightningProtocolPrefix = "lightning:";
 
 bool isLNURL(String url) {
   var lower = url.toLowerCase();
-  if (lower.startsWith(_lightningProtoclPrefix)) {
-    lower = lower.substring(_lightningProtoclPrefix.length);
+  if (lower.startsWith(_lightningProtocolPrefix)) {
+    lower = lower.substring(_lightningProtocolPrefix.length);
   }
   var firstMatch = _lnurlPrefix.firstMatch(lower);
   if (firstMatch != null && firstMatch.start == 0) {
@@ -20,19 +20,38 @@ bool isLNURL(String url) {
   return false;
 }
 
-// FIXME(nochiel) Maybe this should parse 'lightning:' uris and return the address instead of a boolean?
 bool isLightningAddress(String uri) {
+  var result = false;
+  var v = parseLightningAddress(uri);
+  result = v != null && v.isNotEmpty;
+  return result;
+}
+
+bool isLightningAddressURI(String uri) {
+  var result = false;
+
+  if (uri != null) {
+    result = uri.toLowerCase().startsWith(_lightningProtocolPrefix) &&
+        isLightningAddress(uri);
+  }
+  return result;
+}
+
+parseLightningAddress(String uri) {
   // Ref. https://github.com/andrerfneves/lightning-address/blob/master/DIY.md
 
-    if(uri == null || uri.isEmpty) { return false; }
-
-    var email = uri.toLowerCase();
-    if (email.startsWith("lightning:")) {
-      email = email.substring("lightning:".length);
+  String result;
+  if (uri != null && uri.isNotEmpty) {
+    var l = uri.toLowerCase();
+    if (l.startsWith(_lightningProtocolPrefix)) {
+      result = uri.substring(_lightningProtocolPrefix.length);
     }
 
-  var result = EmailValidator.validate(email);
-  print('isLightningAddress: $uri: $result');
+    result ??= uri;
+    if (!EmailValidator.validate(result)) {
+      result = null;
+    }
+    print('parseLightningAddress: $uri: $result');
+  }
   return result;
-
 }

--- a/lib/utils/lnurl.dart
+++ b/lib/utils/lnurl.dart
@@ -20,11 +20,18 @@ bool isLNURL(String url) {
   return false;
 }
 
-bool isLightningAddress(String email) {
-  // This is just a normal e-mail address.
+bool isLightningAddress(String uri) {
   // Ref. https://github.com/andrerfneves/lightning-address/blob/master/DIY.md
 
+    if(uri == null || uri.isEmpty) { return false; }
+
+    var email = uri.toLowerCase();
+    if (email.startsWith("lightning:")) {
+      email = email.substring("lightning:".length);
+    }
+
   var result = EmailValidator.validate(email);
-  print('isLightningAddress: $result');
+  print('isLightningAddress: $email: $result');
   return result;
+
 }

--- a/lib/utils/lnurl.dart
+++ b/lib/utils/lnurl.dart
@@ -39,9 +39,11 @@ bool isLightningAddressURI(String uri) {
 
 parseLightningAddress(String uri) {
   // Ref. https://github.com/andrerfneves/lightning-address/blob/master/DIY.md
+  print('parseLightningAddress: given "$uri"');
 
   String result;
   if (uri != null && uri.isNotEmpty) {
+    uri = uri.trim();
     var l = uri.toLowerCase();
     if (l.startsWith(_lightningProtocolPrefix)) {
       result = uri.substring(_lightningProtocolPrefix.length);
@@ -51,7 +53,7 @@ parseLightningAddress(String uri) {
     if (!EmailValidator.validate(result)) {
       result = null;
     }
-    print('parseLightningAddress: $uri: $result');
+    print('parseLightningAddress: got "$result"');
   }
   return result;
 }

--- a/lib/widgets/enter_payment_info_dialog.dart
+++ b/lib/widgets/enter_payment_info_dialog.dart
@@ -138,12 +138,17 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
               ));
               return;
             }
-            if (decodeInvoice(_paymentInfoController.text) != null) {
+
+            var decoded = decodeInvoice(_paymentInfoController.text);
+            decoded ??= _paymentInfoController.text;
+            if (isLightningAddress(decoded)) {
+              widget.lnurlBloc.lnurlInputSink.add(decoded);
+              return;
+            }
+
+            if (decoded != null) {
               widget.invoiceBloc.decodeInvoiceSink
                   .add(_paymentInfoController.text);
-            }
-            if (isLightningAddress(_paymentInfoController.text)) {
-              widget.lnurlBloc.lnurlInputSink.add(_paymentInfoController.text);
             }
           }
         }),
@@ -177,6 +182,10 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
     }
     if (normalized.startsWith("lightning:")) {
       normalized = normalized.substring(10);
+
+      if (isLightningAddress(normalized)) {
+        return normalized;
+      }
     }
     if (normalized.startsWith("ln") && !normalized.startsWith("lnurl")) {
       return invoiceString;

--- a/lib/widgets/enter_payment_info_dialog.dart
+++ b/lib/widgets/enter_payment_info_dialog.dart
@@ -139,10 +139,10 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
               return;
             }
 
-            var decoded = decodeInvoice(_paymentInfoController.text);
-            decoded ??= _paymentInfoController.text;
-            if (isLightningAddress(decoded)) {
-              widget.lnurlBloc.lnurlInputSink.add(decoded);
+            final decoded = decodeInvoice(_paymentInfoController.text);
+            final lightningAddress = parseLightningAddress(decoded);
+            if (lightningAddress != null) {
+              widget.lnurlBloc.lnurlInputSink.add(lightningAddress);
               return;
             }
 
@@ -182,10 +182,6 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
     }
     if (normalized.startsWith("lightning:")) {
       normalized = normalized.substring(10);
-
-      if (isLightningAddress(normalized)) {
-        return normalized;
-      }
     }
     if (normalized.startsWith("ln") && !normalized.startsWith("lnurl")) {
       return invoiceString;

--- a/lib/widgets/enter_payment_info_dialog.dart
+++ b/lib/widgets/enter_payment_info_dialog.dart
@@ -139,14 +139,14 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
               return;
             }
 
-            final decoded = decodeInvoice(_paymentInfoController.text);
-            final lightningAddress = parseLightningAddress(decoded);
+            final lightningAddress =
+                parseLightningAddress(_paymentInfoController.text);
             if (lightningAddress != null) {
               widget.lnurlBloc.lnurlInputSink.add(lightningAddress);
               return;
             }
 
-            if (decoded != null) {
+            if (decodeInvoice(_paymentInfoController.text) != null) {
               widget.invoiceBloc.decodeInvoiceSink
                   .add(_paymentInfoController.text);
             }


### PR DESCRIPTION
Fixes: breez/breezmobile/issues/616.

- [x] Handle `lightning:name@domain.com` uris correctly.
    - [x] Autodetect lightning-address URIs in the clipboard.
    - [x] Handle `lightning:name@domain.com` QR codes correctly.
    - [x] Handle pasting lightning-address URIs using the bottom_actions_bar widget.
    - [x] Handle pasting lightning-address URI into payee information dialog.
    - [x] Handle intent when the user clicks on a lightning-address link and Breez opens.
- [x] Test to make sure that all the usual paths for processing invoices and lnurls have not broken.
    - [x] Test pasting plain lightning-addresses.
    - [x] Test autodetection of lnurls in clipboard.
- [ ] Code review.
- [ ] Send PR upstream to [lighting-address spec](github.com/andrerfneves/lightning-address) to mention `lighting:` prefix for lightning-address URIs.
