### PR TITLE
Update android dependencies

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -29,14 +29,12 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.breez.client"
         minSdkVersion 24
         targetSdkVersion 30
         multiDexEnabled true
         versionCode 1
         versionName "0.12-beta"
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     signingConfigs {
@@ -88,31 +86,28 @@ configurations {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
-    implementation(name:'breez', ext:'aar')
-    implementation 'com.theartofdev.edmodo:android-image-cropper:2.5.+'
-    implementation 'androidx.exifinterface:exifinterface:1.0.0-beta01'
-    implementation 'com.google.android.material:material:1.0.0-beta01'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0-beta01'
-    implementation 'androidx.appcompat:appcompat:1.0.0-beta01'    
-    implementation 'com.google.android.gms:play-services-drive:16.0.0'
-    implementation('com.google.api-client:google-api-client-android:1.26.0') {
-        exclude group: 'org.apache.httpcomponents'        
+    implementation(name: 'breez', ext: 'aar')
+
+    implementation('com.google.api-client:google-api-client-android:1.32.2') {
+        exclude group: 'org.apache.httpcomponents'
     }
     implementation('com.google.apis:google-api-services-drive:v3-rev136-1.25.0') {
-        exclude group: 'org.apache.httpcomponents'        
+        exclude group: 'org.apache.httpcomponents'
     }
-    implementation 'com.felipecsl:gifimageview:2.1.0'
-    implementation ('commons-io:commons-io:2.4') {
+    implementation('commons-io:commons-io:2.4') {
         exclude group: 'com.google.guava', module: 'listenablefuture'
     }
-    implementation 'androidx.work:work-runtime:2.3.4'
-    implementation 'androidx.lifecycle:lifecycle-process:2.2.0'
-    implementation 'com.google.android.gms:play-services-auth:16.0.1'
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.3.20'
-    testImplementation 'org.jetbrains.kotlin:kotlin-test-junit:1.3.20'
-    implementation "androidx.biometric:biometric:1.0.0"
+
+    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.biometric:biometric:1.1.0'
+    implementation 'androidx.exifinterface:exifinterface:1.3.3'
+    implementation 'androidx.lifecycle:lifecycle-process:2.3.0'
+    implementation 'androidx.work:work-runtime:2.6.0'
+    implementation 'com.felipecsl:gifimageview:2.1.0'
+    implementation 'com.google.android.gms:play-services-auth:19.2.0'
+    implementation 'com.google.android.gms:play-services-drive:17.0.0'
+    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'com.theartofdev.edmodo:android-image-cropper:2.8.0'
 }
+
 apply plugin: 'com.google.gms.google-services'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.1'
+        classpath 'com.android.tools.build:gradle:7.0.3'
         classpath 'com.google.gms:google-services:4.3.10'
     }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 android.enableJetifier=true
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4G
 android.enableR8=true
 android.enableR8.fullMode=true


### PR DESCRIPTION
# Removed because is not used

- junit / junit-kotlin
- test-runner
- espresso

# Removed for other reasons

- kotlin-stdlib: Starting from Kotlin 1.4.0, the stdlib dependency is added automatically, so no need to declare it
- legacy-support-v4: There is no need to support sdk 4 as the minimum sdk is 24

# Partially Update

- work-runtime: `2.3.4` -> `2.6.0`: There is a version `2.7.0` but it depends of compile sdk 31
- lifecycle-process: `2.2.0` -> `2.3.0`: There is a version `2.4.0` but it depends of compile sdk 31
- gifimageview: There is a version `2.2.0` but it is not working with the Jetifier

# Fully updated (libs previously on beta or alpha)

- appcompat: `1.0.0-beta01` -> `1.3.1`
- exifinterface: `1.0.0-beta01` -> `1.3.3`
- material: `1.0.0-beta01` -> `1.4.0`

# Fully updated

- biometric: `1.0.0` -> `1.1.0`
- play-services-auth: `16.0.1` -> `19.2.0`
- play-services-drive: `16.0.0` -> `17.0.0`
- google-api-client-android: `1.26.0` -> `1.32.2`
- android-image-cropper: `2.5.+` -> `2.8.0`
