### PR TITLE
Update flutter dependencies

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -29,14 +29,12 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.breez.client"
         minSdkVersion 24
         targetSdkVersion 30
         multiDexEnabled true
         versionCode 1
         versionName "0.12-beta"
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     signingConfigs {
@@ -88,31 +86,28 @@ configurations {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
-    implementation(name:'breez', ext:'aar')
-    implementation 'com.theartofdev.edmodo:android-image-cropper:2.5.+'
-    implementation 'androidx.exifinterface:exifinterface:1.0.0-beta01'
-    implementation 'com.google.android.material:material:1.0.0-beta01'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0-beta01'
-    implementation 'androidx.appcompat:appcompat:1.0.0-beta01'    
-    implementation 'com.google.android.gms:play-services-drive:16.0.0'
-    implementation('com.google.api-client:google-api-client-android:1.26.0') {
-        exclude group: 'org.apache.httpcomponents'        
+    implementation(name: 'breez', ext: 'aar')
+
+    implementation('com.google.api-client:google-api-client-android:1.32.2') {
+        exclude group: 'org.apache.httpcomponents'
     }
     implementation('com.google.apis:google-api-services-drive:v3-rev136-1.25.0') {
-        exclude group: 'org.apache.httpcomponents'        
+        exclude group: 'org.apache.httpcomponents'
     }
-    implementation 'com.felipecsl:gifimageview:2.1.0'
-    implementation ('commons-io:commons-io:2.4') {
+    implementation('commons-io:commons-io:2.4') {
         exclude group: 'com.google.guava', module: 'listenablefuture'
     }
-    implementation 'androidx.work:work-runtime:2.3.4'
-    implementation 'androidx.lifecycle:lifecycle-process:2.2.0'
-    implementation 'com.google.android.gms:play-services-auth:16.0.1'
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.3.20'
-    testImplementation 'org.jetbrains.kotlin:kotlin-test-junit:1.3.20'
-    implementation "androidx.biometric:biometric:1.0.0"
+
+    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.biometric:biometric:1.1.0'
+    implementation 'androidx.exifinterface:exifinterface:1.3.3'
+    implementation 'androidx.lifecycle:lifecycle-process:2.3.0'
+    implementation 'androidx.work:work-runtime:2.6.0'
+    implementation 'com.felipecsl:gifimageview:2.1.0'
+    implementation 'com.google.android.gms:play-services-auth:19.2.0'
+    implementation 'com.google.android.gms:play-services-drive:17.0.0'
+    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'com.theartofdev.edmodo:android-image-cropper:2.8.0'
 }
+
 apply plugin: 'com.google.gms.google-services'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.1'
+        classpath 'com.android.tools.build:gradle:7.0.3'
         classpath 'com.google.gms:google-services:4.3.10'
     }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 android.enableJetifier=true
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4G
 android.enableR8=true
 android.enableR8.fullMode=true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,58 +7,60 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  app_settings: ^4.1.0
-  archive: ^3.1.2
-  auto_size_text: ^2.1.0
+  app_settings: ^4.1.1
+  archive: ^3.1.6
+  auto_size_text: ^2.1.0 # TODO Version 3 with anytime player update needed
   badges: ^2.0.1
   bip39: ^1.0.6
   collection: ^1.15.0
-  confetti: ^0.5.5
-  connectivity: ^3.0.3
+  confetti: ^0.6.0
+  connectivity: ^3.0.6
   crypto: ^3.0.1
   csv: ^5.0.0
-  dio: ^4.0.0
-  drag_and_drop_lists: 0.3.2
-  duration: ^3.0.6
-  file_picker: ^3.0.1
-  firebase_core: 0.4.0+3
-  firebase_database: ^3.0.0
-  firebase_messaging: ^5.0.1+1
-  firebase_dynamic_links: ^0.5.0
+  dio: ^4.0.0 # TODO Version 4.0.1 with firebase_core update needed
+  drag_and_drop_lists: 0.3.2+1 # TODO Version 0.3.2+2 with dart upgrade needed
+  duration: ^3.0.8
+  email_validator: ^2.0.1
+  extended_image: ^4.2.1 # TODO Version 5 with breaking changes
+  file_picker: ^3.0.1 # TODO version 4 with breaking changes or version 3.0.2 with firebase_core update needed
+  firebase_core: 0.4.2 # TODO version 1 with breaking changes
+                       # or version 0.4.5 with uni_links update needed, (uni_links has not update the platform interface yet)
+                       # or version 0.4.3 with dio update needed
+  firebase_database: ^3.1.6 # TODO version 5 with breaking changes or version 4 with firebase_core update needed
+  firebase_dynamic_links: ^0.5.3 # TODO version 1 with breaking changes or version 0.6 with firebase_core update needed
+  firebase_messaging: ^5.1.8 # TODO version 6 with breaking changes
   flushbar: ^1.10.4
-  flutter_secure_storage: ^4.2.0
-  flutter_svg: ^0.22.0
-  flutter_web_browser: ^0.14.0
-  grpc: ^3.0.0
+  flutter_secure_storage: ^4.2.1
+  flutter_svg: ^0.22.0 # TODO version 0.23 with breaking changes
+  flutter_web_browser: ^0.15.0
+  grpc: ^3.0.2
   hex: ^0.2.0
-  image: ^3.0.2
-  image_cropper: ^1.4.0
-  image_picker: ^0.7.4
+  image: ^3.0.8
+  image_cropper: ^1.4.1
+  image_picker: ^0.7.5+4 # TODO version 0.8 with breaking changes
   ini: ^2.1.0
   intl: ^0.17.0
-  json_annotation: ^4.0.1
-  logging: ^1.0.1
+  json_annotation: ^4.0.1 # TODO version 4.2 with json_serializable update needed
+  logging: ^1.0.2
   nfc_in_flutter: ^2.0.5
-  extended_image: ^4.1.0
-  package_info: ^2.0.0
-  path_provider: ^2.0.1
-  printing: ^5.2.1
+  package_info: ^2.0.2
+  path_provider: ^2.0.4 # TODO version 2.0.6 with dart upgrade needed
+  printing: ^5.5.0 # TODO version 5.6 with dart upgrade needed
   protobuf: ^2.0.0
-  qr_code_scanner: ^0.4.0
+  qr_code_scanner: ^0.6.1
   qr_code_tools: ^0.0.7
   qr_flutter: ^4.0.0
-  rxdart: ^0.26.0
-  shared_preferences: ^2.0.6
-  simple_animations: ^1.3.12
-  sqflite: ^2.0.0+3
+  rxdart: ^0.26.0 # TODO version 0.27 with breaking changes
+  shared_preferences: ^2.0.7 # TODO version 2.0.8 with dart upgrade needed
+  simple_animations: ^1.3.12 # TODO version 2 with breaking changes
+  sqflite: ^2.0.0+4
   timeago: ^3.1.0
-  tutorial_coach_mark: ^1.0.0
+  tutorial_coach_mark: ^1.1.1
   uni_links: ^0.5.1
-  url_launcher: ^6.0.4
-  webview_flutter: ^2.0.8
-  webdav_client: ^1.0.0
-  email_validator: ^2.0.1
+  url_launcher: ^6.0.10 # TODO version 6.0.11 with dart upgrade needed
   validators: ^3.0.0
+  webdav_client: ^1.1.2
+  webview_flutter: ^2.0.13 # TODO version 2.1 with dart upgrade needed
 
   anytime:
     git:
@@ -87,24 +89,23 @@ dependency_overrides:
       url: https://github.com/breez/podcast_search.git
       ref: 5e867e794261da9b35331261c52ba4d380894a80
 
-
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  build_runner: ^2.0.4
-  json_serializable: ^4.1.3
-  mockito: ^5.0.9
-  sqflite_common_ffi: ^2.0.0+1
+  build_runner: ^2.1.2 # TODO version 2.1.3 with dart upgrade needed
+  json_serializable: ^4.1.3 # TODO version 5 with breaking changes
+  mockito: ^5.0.15 # TODO version 5.0.16 with json_serializable upgrade needed
+  sqflite_common_ffi: ^2.1.0
   test: any
 
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: ^2.10.5
+  flutter: ^2.2.3
 
-# For information on the generic Dart part of this file, see the
-# following page: https://www.dartlang.org/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
+  uses-material-design: true
+  generate: true
+
   assets:
     - cert/letsencrypt.cert
     - conf/lnd.conf
@@ -122,44 +123,6 @@ flutter:
     - assets/images/
     - assets/icons/
 
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
-  uses-material-design: true
-
-  # Generates translation dart files from *.arb files
-  generate: true
-
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #  - images/a_dot_burr.jpeg
-  #  - images/a_dot_ham.jpeg
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.io/assets-and-images/#resolution-aware.
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.io/assets-and-images/#from-packages
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies, 
-  # see https://flutter.io/custom-fonts/#from-packages
   fonts:
     - family: IBMPlexSans
       fonts:


### PR DESCRIPTION
# Fully updated

- app_settings: `4.1.0` -> `4.1.1`
- archive: `3.1.2` -> `3.1.6`
- confetti: `0.5.5` -> `0.6.0`
- connectivity: `3.0.3` -> `3.0.6`
- duration: `3.0.6` -> `3.0.8`
- flutter_secure_storage: `4.2.0` -> `4.2.1`
- flutter_web_browser: `0.14.0` -> `0.15.0`
- grpc: `3.0.0` -> `3.0.2`
- image: `3.0.2` -> `3.0.8`
- image_cropper: `1.4.0` -> `1.4.1`
- logging: `1.0.1` -> `1.0.2`
- package_info: `2.0.0` -> `2.0.2`
- qr_code_scanner: `0.4.0` -> `0.6.1`
- sqflite: `2.0.0+3` -> `2.0.0+4`
- sqflite_common_ffi: `2.0.0+1` -> `2.1.0`
- tutorial_coach_mark: `1.0.0` -> `1.1.1`
- webdav_client: `1.0.0` -> `1.1.2`

# Partially updated

## Dart upgrade needed to fully update
- build_runner: `2.0.4` -> `2.1.2`
- drag_and_drop_lists: `0.3.2` -> `0.3.2+1`
- path_provider: `2.0.1` -> `2.0.4`
- printing: `5.2.1` -> `5.5.0`
- shared_preferences: `2.0.6` -> `2.0.7`
- url_launcher: `6.0.4` -> `6.0.10`
- webview_flutter: `2.0.8` -> `2.0.13`

## Break changes migration to fully update
- extended_image: `4.1.0` -> `4.2.1`
- firebase_core: `0.4.0+3` -> `0.4.2`
- firebase_database: `3.0.0` -> `3.1.6`
- firebase_dynamic_links: `0.5.0` -> `0.5.3`
- firebase_messaging: `5.0.1+1` -> `5.1.8`
- image_picker: `0.7.4` -> `0.7.5+4`
- mockito: `5.0.9` -> `5.0.15`

# Not updated

## Other dependencies to fully upgrade
- auto_size_text: Version 3 with anytime player update needed
- dio: Version 4.0.1 with firebase_core update needed
- json_annotation: Version 4.2 with json_serializable update needed

## Break changes migration to fully update
- file_picker
- flutter_svg
- json_serializable
- rxdart
- simple_animations

# Other changes

- Specify flutter and dart sdk version to have predictable builds
- Ordered dependencies in alphabetically order to better readability
- Remove tutorial commentaries of pubspec.yaml
