### PR TITLE
Extract view switch component and make it dynamic

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -121,5 +121,7 @@
       }
     }
   },
+  "pos_invoice_tab_keypad": "Keypad",
+  "pos_invoice_tab_items": "Items",
   "app_name": "Breez"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -121,5 +121,7 @@
       }
     }
   },
+  "pos_invoice_tab_keypad": "Teclado",
+  "pos_invoice_tab_items": "Elementos",
   "app_name": "Breez"
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -121,5 +121,7 @@
       }
     }
   },
+  "pos_invoice_tab_keypad": "Näppäimistö",
+  "pos_invoice_tab_items": "Tuotteet",
   "app_name": "Breez"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -121,5 +121,7 @@
       }
     }
   },
+  "pos_invoice_tab_keypad": "Teclado",
+  "pos_invoice_tab_items": "Itens",
   "app_name": "Breez"
 }

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -29,9 +29,11 @@ import 'package:breez/widgets/flushbar.dart';
 import 'package:breez/widgets/loader.dart';
 import 'package:breez/widgets/print_parameters.dart';
 import 'package:breez/widgets/transparent_page_route.dart';
+import 'package:breez/widgets/view_switch.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../sync_progress_dialog.dart';
 import 'items/item_avatar.dart';
@@ -461,92 +463,26 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
   }
 
   Widget _buildViewSwitch(BuildContext context) {
-    // This method is a work-around to center align the buttons
-    // Use Align to stick items to center and set padding to give equal distance
-    return Row(
-      mainAxisSize: MainAxisSize.max,
-      children: <Widget>[
-        Flexible(
-          flex: 1,
-          child: Align(
-            alignment: Alignment.centerRight,
-            child: GestureDetector(
-                behavior: HitTestBehavior.translucent,
-                onTap: () => AppBlocsProvider.of<PosCatalogBloc>(context)
-                    .actionsSink
-                    .add(UpdatePosSelectedTab("KEYPAD")),
-                child: Padding(
-                  padding: EdgeInsets.only(right: itemWidth / 4),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: <Widget>[
-                      Padding(
-                        padding: const EdgeInsets.only(right: 8.0),
-                        child: Icon(Icons.dialpad,
-                            color: Theme.of(context)
-                                .primaryTextTheme
-                                .button
-                                .color
-                                .withOpacity(_isKeypadView ? 1 : 0.5)),
-                      ),
-                      Text(
-                        "Keypad",
-                        style: Theme.of(context).textTheme.button.copyWith(
-                            color: Theme.of(context)
-                                .textTheme
-                                .button
-                                .color
-                                .withOpacity(_isKeypadView ? 1 : 0.5)),
-                      )
-                    ],
-                  ),
-                )),
-          ),
+    final themeData = Theme.of(context);
+    final texts = AppLocalizations.of(context);
+    return ViewSwitch(
+      selected: _isKeypadView ? 0 : 1,
+      tint: themeData.primaryTextTheme.button.color,
+      textTint: themeData.textTheme.button.color,
+      items: [
+        ViewSwitchItem(
+          texts.pos_invoice_tab_keypad,
+          () => AppBlocsProvider.of<PosCatalogBloc>(context)
+              .actionsSink
+              .add(UpdatePosSelectedTab("KEYPAD")),
+          iconData: Icons.dialpad,
         ),
-        Container(
-          height: 20,
-          child: VerticalDivider(
-            color: Theme.of(context).primaryTextTheme.button.color,
-          ),
-        ),
-        Flexible(
-          flex: 1,
-          child: Align(
-            alignment: Alignment.centerLeft,
-            child: GestureDetector(
-                behavior: HitTestBehavior.translucent,
-                onTap: () => AppBlocsProvider.of<PosCatalogBloc>(context)
-                    .actionsSink
-                    .add(UpdatePosSelectedTab("ITEMS")),
-                child: Padding(
-                  padding: EdgeInsets.only(left: itemWidth / 4),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: <Widget>[
-                      Padding(
-                        padding: const EdgeInsets.only(right: 8.0),
-                        child: Icon(Icons.playlist_add,
-                            color: Theme.of(context)
-                                .primaryTextTheme
-                                .button
-                                .color
-                                .withOpacity(!_isKeypadView ? 1 : 0.5)),
-                      ),
-                      Text(
-                        "Items",
-                        style: Theme.of(context).textTheme.button.copyWith(
-                            color: Theme.of(context)
-                                .textTheme
-                                .button
-                                .color
-                                .withOpacity(!_isKeypadView ? 1 : 0.5)),
-                      )
-                    ],
-                  ),
-                )),
-          ),
+        ViewSwitchItem(
+          texts.pos_invoice_tab_items,
+          () => AppBlocsProvider.of<PosCatalogBloc>(context)
+              .actionsSink
+              .add(UpdatePosSelectedTab("ITEMS")),
+          iconData: Icons.playlist_add,
         ),
       ],
     );

--- a/lib/widgets/view_switch.dart
+++ b/lib/widgets/view_switch.dart
@@ -1,0 +1,141 @@
+import 'dart:math';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// Given 2 items, lets say "Big and long text" and "Small text", it will place items as follow:
+/// | <Nothing> <Text> <1/2 of space> <Divider centered on screen> <1/2 of space> <Text> <Nothing> |
+///
+/// To be able to properly center the divider and equally add spaces on its side
+/// and set text aligned to the divider we must precalculate the text size and check
+/// how much space we have left on the screen and based on that we set the divider width
+class ViewSwitch extends StatelessWidget {
+  final int selected;
+  final Color tint;
+  final Color textTint;
+  final List<ViewSwitchItem> items;
+
+  const ViewSwitch({
+    this.selected: 0,
+    this.tint: Colors.white,
+    this.textTint: Colors.white,
+    this.items: const [],
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final themeData = Theme.of(context);
+    final size = MediaQuery.of(context).size;
+
+    var maxTextWidth = 0.0;
+    var index = 0;
+    for (var item in items) {
+      final itemTextWidth = _textSize(themeData, index, item.text).width;
+      maxTextWidth = max(maxTextWidth, itemTextWidth);
+      index++;
+    }
+
+    var emptyWidth = size.width;
+    for (var item in items) {
+      emptyWidth -= maxTextWidth;
+      if (item.iconData != null) {
+        emptyWidth -= 24;
+      }
+    }
+
+    List<Widget> children = [];
+    index = 0;
+    for (var item in items) {
+      if (index > 0) {
+        children.add(
+          Container(
+            height: 20,
+            child: VerticalDivider(
+              width: max(16, emptyWidth / items.length),
+              color: tint,
+            ),
+          ),
+        );
+      }
+
+      children.add(
+        Flexible(
+          flex: 1,
+          child: Align(
+            alignment: _alignment(index),
+            child: GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onTap: item.onTap,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  _icon(themeData, item, index),
+                  Text(
+                    item.text,
+                    style: _textStyle(themeData, index),
+                  )
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      index++;
+    }
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(8.0, 0.0, 8.0, 0.0),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: children,
+      ),
+    );
+  }
+
+  Widget _icon(ThemeData themeData, ViewSwitchItem item, int index) {
+    if (item.iconData == null) return Container();
+    return Padding(
+      padding: const EdgeInsets.only(right: 8.0),
+      child: Icon(
+        item.iconData,
+        color: tint.withOpacity(selected == index ? 1 : 0.5),
+      ),
+    );
+  }
+
+  Alignment _alignment(int index) {
+    if (index == 0) return Alignment.centerRight;
+    if (index == items.length - 1) return Alignment.centerLeft;
+    return Alignment.center;
+  }
+
+  Size _textSize(ThemeData themeData, int index, String text) {
+    final textPainter = TextPainter(
+      text: TextSpan(text: text, style: _textStyle(themeData, index)),
+      maxLines: 1,
+      textDirection: TextDirection.ltr,
+    )..layout(minWidth: 0, maxWidth: double.infinity);
+    return textPainter.size;
+  }
+
+  TextStyle _textStyle(ThemeData themeData, index) {
+    return themeData.textTheme.button.copyWith(
+      color: textTint.withOpacity(selected == index ? 1 : 0.5),
+    );
+  }
+}
+
+class ViewSwitchItem {
+  final String text;
+  final IconData iconData;
+  final GestureTapCallback onTap;
+
+  const ViewSwitchItem(
+    this.text,
+    this.onTap, {
+    this.iconData,
+  });
+}


### PR DESCRIPTION
The idea is to re-use this component in a new screen being developed, to do it I had not only to extract but I had to make the spacing dynamic to work properly given the length of texts. I had to make the icons optional too.

How it looks like in different languages:

|KeyPad|Items|
|---|---|
|![after_en_1](https://user-images.githubusercontent.com/1225438/145051807-15814f0d-fe17-470b-acb0-10acca9417e4.png)|![after_en_2](https://user-images.githubusercontent.com/1225438/145051639-82513af6-efba-400d-90ab-a5f0f0c37635.png)|
|![after_pt_1](https://user-images.githubusercontent.com/1225438/145051648-8f9f590b-389f-49bd-bfa5-f907d27f0dfa.png)|![after_pt_2](https://user-images.githubusercontent.com/1225438/145051810-2c215943-2dfb-47df-866c-36be8f47937e.png)|
|![after_es_1](https://user-images.githubusercontent.com/1225438/145051514-cc2d8ac8-a307-4fbb-93b9-5dc93006cd2d.png)|![after_es_2](https://user-images.githubusercontent.com/1225438/145051519-959a663b-054a-40e1-a1a0-785f4950e84a.png)|
|![after_fi_1](https://user-images.githubusercontent.com/1225438/145051901-74dc7df4-58b4-4cb8-a039-9dc242791d01.png)|![after_fi_2](https://user-images.githubusercontent.com/1225438/145051908-6aeff5cb-6fc8-41df-baae-df7e43ee454c.png)|

Thank you @tlindi for the Finnish translations.