### PR TITLE
Add translations to POS item image picker

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -135,6 +135,8 @@
   "pos_invoice_item_management_dd_currency_title": "Currency",
   "pos_invoice_item_management_image_title": "Select Image",
   "pos_invoice_item_management_error_btc_rate": "Failed to retrieve BTC exchange rate.",
+  "pos_invoice_item_management_avatar_title": "Select Image",
+  "pos_invoice_item_management_avatar_search": "Search for an image",
   "pos_invoice_tab_keypad": "Keypad",
   "pos_invoice_tab_items": "Items",
   "pos_invoice_charge_label": "CHARGE {amount} {currencyName}",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -135,6 +135,8 @@
   "pos_invoice_item_management_dd_currency_title": "Moneda",
   "pos_invoice_item_management_image_title": "Seleccionar una imagen",
   "pos_invoice_item_management_error_btc_rate": "Las tasas de cambio de BTC no se recuperaron.",
+  "pos_invoice_item_management_avatar_title": "Seleccionar una imagen",
+  "pos_invoice_item_management_avatar_search": "Buscar una imagen",
   "pos_invoice_tab_keypad": "Teclado",
   "pos_invoice_tab_items": "Elementos",
   "pos_invoice_charge_label": "COBRAR {amount} {currencyName}",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -135,6 +135,8 @@
   "pos_invoice_item_management_dd_currency_title": "Valuutta",
   "pos_invoice_item_management_image_title": "Valitse kuva",
   "pos_invoice_item_management_error_btc_rate": "Bitcoin-vaihtokurssin noutaminen ei onnistunut (tarkista verkkoyhteys).",
+  "pos_invoice_item_management_avatar_title": "Valitse kuva",
+  "pos_invoice_item_management_avatar_search": "Etsi kuva",
   "pos_invoice_tab_keypad": "Näppäimistö",
   "pos_invoice_tab_items": "Tuotteet",
   "pos_invoice_charge_label": "VELOITA {amount} {currencyName}",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -135,6 +135,8 @@
   "pos_invoice_item_management_dd_currency_title": "Moeda",
   "pos_invoice_item_management_image_title": "Selecione uma imagem",
   "pos_invoice_item_management_error_btc_rate": "Houve uma falha na recuperação das taxas de câmbio do BTC.",
+  "pos_invoice_item_management_avatar_title": "Selecione uma imagem",
+  "pos_invoice_item_management_avatar_search": "Busque por uma imagem",
   "pos_invoice_tab_keypad": "Teclado",
   "pos_invoice_tab_items": "Itens",
   "pos_invoice_charge_label": "COBRAR {amount} {currencyName}",

--- a/lib/routes/charge/items/item_avatar_picker.dart
+++ b/lib/routes/charge/items/item_avatar_picker.dart
@@ -6,6 +6,7 @@ import 'package:breez/bloc/pos_catalog/model.dart';
 import 'package:breez/theme_data.dart';
 import 'package:breez/widgets/back_button.dart' as backBtn;
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/svg.dart';
 
 import '../../../utils/min_font_size.dart';
@@ -16,7 +17,11 @@ class ItemAvatarPicker extends StatefulWidget {
   final Function(String selectedImage) onImageSelected;
   final String itemName;
 
-  ItemAvatarPicker(this.itemImage, this.onImageSelected, {this.itemName});
+  ItemAvatarPicker(
+    this.itemImage,
+    this.onImageSelected, {
+    this.itemName,
+  });
 
   @override
   State<StatefulWidget> createState() {
@@ -33,24 +38,25 @@ class ItemAvatarPickerState extends State<ItemAvatarPicker> {
   void initState() {
     super.initState();
     _selectedImage = widget.itemImage ?? "";
-    _imageFilterController.addListener(
-      () {
-        setState(() {});
-      },
-    );
+    _imageFilterController.addListener(() {
+      setState(() {});
+    });
   }
 
   @override
   Widget build(BuildContext context) {
+    final themeData = Theme.of(context);
+    final texts = AppLocalizations.of(context);
+
     return Scaffold(
       appBar: AppBar(
-        iconTheme: Theme.of(context).appBarTheme.iconTheme,
-        textTheme: Theme.of(context).appBarTheme.textTheme,
-        backgroundColor: Theme.of(context).canvasColor,
+        iconTheme: themeData.appBarTheme.iconTheme,
+        textTheme: themeData.appBarTheme.textTheme,
+        backgroundColor: themeData.canvasColor,
         leading: backBtn.BackButton(),
         title: Text(
-          "Select Image",
-          style: Theme.of(context).appBarTheme.textTheme.headline6,
+          texts.pos_invoice_item_management_avatar_title,
+          style: themeData.appBarTheme.textTheme.headline6,
         ),
         elevation: 0.0,
       ),
@@ -64,7 +70,7 @@ class ItemAvatarPickerState extends State<ItemAvatarPicker> {
             SizedBox(height: 16),
             _buildSearchBar(context),
             SizedBox(height: 8),
-            _buildIconGrid(),
+            _buildIconGrid(context),
             SizedBox(height: 8),
           ],
         ),
@@ -72,29 +78,36 @@ class ItemAvatarPickerState extends State<ItemAvatarPicker> {
     );
   }
 
-  _buildItemAvatar(BuildContext context) {
+  Widget _buildItemAvatar(BuildContext context) {
+    final themeData = Theme.of(context);
+    final texts = AppLocalizations.of(context);
+
     return Badge(
       showBadge: _selectedImage != "",
       position: BadgePosition.topEnd(top: 5, end: -10),
       animationType: BadgeAnimationType.fade,
-      badgeColor: Theme.of(context).primaryTextTheme.subtitle2.color,
+      badgeColor: themeData.primaryTextTheme.subtitle2.color,
       badgeContent: _buildResetIconBadge(context),
       child: _selectedImage == "" && widget.itemName == ""
           ? Container(
               width: 96,
               height: 96,
               decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  border: Border.all(
-                      color: Colors.white,
-                      width: 1.0,
-                      style: BorderStyle.solid),
-                  image: DecorationImage(
-                      colorFilter: ColorFilter.mode(
-                          Theme.of(context).primaryColorLight,
-                          BlendMode.srcATop),
-                      image: AssetImage("src/images/avatarbg.png"),
-                      fit: BoxFit.cover)),
+                shape: BoxShape.circle,
+                border: Border.all(
+                  color: Colors.white,
+                  width: 1.0,
+                  style: BorderStyle.solid,
+                ),
+                image: DecorationImage(
+                  colorFilter: ColorFilter.mode(
+                    themeData.primaryColorLight,
+                    BlendMode.srcATop,
+                  ),
+                  image: AssetImage("src/images/avatarbg.png"),
+                  fit: BoxFit.cover,
+                ),
+              ),
               child: Column(
                 mainAxisSize: MainAxisSize.max,
                 mainAxisAlignment: MainAxisAlignment.center,
@@ -104,35 +117,42 @@ class ItemAvatarPickerState extends State<ItemAvatarPicker> {
                   Padding(
                     padding: const EdgeInsets.only(left: 8, right: 8),
                     child: AutoSizeText(
-                      "Select Image",
+                      texts.pos_invoice_item_management_avatar_title,
                       textAlign: TextAlign.center,
-                      maxLines: 1,
+                      maxLines: 2,
                       minFontSize: MinFontSize(context).minFontSize,
                       stepGranularity: 0.1,
                       style: TextStyle(
-                          fontSize: 12.3,
-                          color: Color.fromRGBO(255, 255, 255, 0.88),
-                          letterSpacing: 0.0,
-                          fontFamily: "IBMPlexSans"),
+                        fontSize: 12.3,
+                        color: Color.fromRGBO(255, 255, 255, 0.88),
+                        letterSpacing: 0.0,
+                        fontFamily: "IBMPlexSans",
+                      ),
                     ),
                   ),
                 ],
               ),
             )
-          : ItemAvatar(_selectedImage,
-              itemName: widget.itemName, radius: 48, useDecoration: true),
+          : ItemAvatar(
+              _selectedImage,
+              itemName: widget.itemName,
+              radius: 48,
+              useDecoration: true,
+            ),
     );
   }
 
-  GestureDetector _buildResetIconBadge(BuildContext context) {
+  Widget _buildResetIconBadge(BuildContext context) {
+    final themeData = Theme.of(context);
+
     return GestureDetector(
       child: Container(
         height: 24,
         width: 24,
         child: Icon(
           Icons.delete_outline,
-          size: Theme.of(context).iconTheme.deleteBadgeIconTheme.size,
-          color: Theme.of(context).iconTheme.deleteBadgeIconTheme.color,
+          size: themeData.iconTheme.deleteBadgeIconTheme.size,
+          color: themeData.iconTheme.deleteBadgeIconTheme.color,
         ),
       ),
       onTap: () {
@@ -144,7 +164,9 @@ class ItemAvatarPickerState extends State<ItemAvatarPicker> {
     );
   }
 
-  Row _buildSearchBar(BuildContext context) {
+  Widget _buildSearchBar(BuildContext context) {
+    final texts = AppLocalizations.of(context);
+
     return Row(
       children: <Widget>[
         Expanded(
@@ -153,57 +175,62 @@ class ItemAvatarPickerState extends State<ItemAvatarPicker> {
             controller: _imageFilterController,
             enabled: _iconList != null,
             decoration: InputDecoration(
-                hintText: "Search for an image",
-                contentPadding: const EdgeInsets.only(top: 16, left: 16),
-                suffixIcon: IconButton(
-                  icon: Icon(
-                    _imageFilterController.text.isEmpty
-                        ? Icons.search
-                        : Icons.close,
-                    size: 20,
-                  ),
-                  onPressed: _imageFilterController.text.isEmpty
-                      ? null
-                      : () {
-                          _imageFilterController.text = "";
-                          FocusScope.of(context).requestFocus(FocusNode());
-                        },
-                  padding: EdgeInsets.only(right: 24, top: 4),
+              hintText: texts.pos_invoice_item_management_avatar_search,
+              contentPadding: const EdgeInsets.only(top: 16, left: 16),
+              suffixIcon: IconButton(
+                icon: Icon(
+                  _imageFilterController.text.isEmpty
+                      ? Icons.search
+                      : Icons.close,
+                  size: 20,
                 ),
-                border: UnderlineInputBorder()),
+                onPressed: _imageFilterController.text.isEmpty
+                    ? null
+                    : () {
+                        _imageFilterController.text = "";
+                        FocusScope.of(context).requestFocus(FocusNode());
+                      },
+                padding: EdgeInsets.only(right: 24, top: 4),
+              ),
+              border: UnderlineInputBorder(),
+            ),
           ),
         )
       ],
     );
   }
 
-  _buildIconGrid() {
-    PosCatalogBloc posCatalogBloc =
-        AppBlocsProvider.of<PosCatalogBloc>(context);
-    return StreamBuilder<Object>(
-        stream: posCatalogBloc.productIconsStream,
-        builder: (context, snapshot) {
-          List<ProductIcon> allIcons = snapshot.data ?? [];
-          return Expanded(
-            child: GridView.count(
-              crossAxisCount: 5,
-              children: allIcons
-                  .where((icon) => icon.matches(
-                      _imageFilterController.text.toLowerCase().trim()))
-                  .map((icon) {
-                return IconButton(
-                  icon: SvgPicture.asset(icon.assetPath, color: Colors.white),
-                  iconSize: 36,
-                  onPressed: () {
-                    setState(() {
-                      _selectedImage = "icon:${icon.name}";
-                      widget.onImageSelected(_selectedImage);
-                    });
-                  },
-                );
-              }).toList(),
-            ),
-          );
-        });
+  Widget _buildIconGrid(BuildContext context) {
+    final posCatalogBloc = AppBlocsProvider.of<PosCatalogBloc>(context);
+
+    return StreamBuilder<List<ProductIcon>>(
+      stream: posCatalogBloc.productIconsStream,
+      builder: (context, snapshot) {
+        final allIcons = (snapshot.data ?? [])
+            .where((icon) => icon.matches(
+                  _imageFilterController.text.toLowerCase().trim(),
+                ))
+            .map((icon) => _icon(icon))
+            .toList();
+
+        return Expanded(
+          child: GridView.count(
+            crossAxisCount: 5,
+            children: allIcons,
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _icon(ProductIcon icon) {
+    return IconButton(
+      icon: SvgPicture.asset(icon.assetPath, color: Colors.white),
+      iconSize: 36,
+      onPressed: () => setState(() {
+        _selectedImage = "icon:${icon.name}";
+        widget.onImageSelected(_selectedImage);
+      }),
+    );
   }
 }

--- a/lib/routes/charge/items/item_page.dart
+++ b/lib/routes/charge/items/item_page.dart
@@ -335,7 +335,7 @@ class ItemPageState extends State<ItemPage> {
             child: AutoSizeText(
               texts.pos_invoice_item_management_image_title,
               textAlign: TextAlign.center,
-              maxLines: 1,
+              maxLines: 2,
               minFontSize: MinFontSize(context).minFontSize,
               stepGranularity: 0.1,
               style: TextStyle(


### PR DESCRIPTION
How it looks like:

|En / Fi|Pt / Es|
|---|---|
|![en](https://user-images.githubusercontent.com/1225438/146936078-f45b176b-5615-46c4-943d-49d6753c14a0.png)|![pt](https://user-images.githubusercontent.com/1225438/146936089-7e016320-c9b1-4180-9d3e-6fb07427e82f.png)|
|![fi](https://user-images.githubusercontent.com/1225438/146936087-9756364a-9ba4-499c-b046-2ac59d3d4db0.png)|![es](https://user-images.githubusercontent.com/1225438/146936084-c8df2489-4170-4e64-b4e0-5a7222823737.png)|


