### PR TITLE
Improve pos page on smaller screens

### DIFF
--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -52,8 +52,6 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
 
   TextEditingController _itemFilterController = TextEditingController();
 
-  double itemHeight;
-  double itemWidth;
   bool _useFiat = false;
   CurrencyWrapper currentCurrency;
   bool _isKeypadView = true;
@@ -72,10 +70,6 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
   void didChangeDependencies() {
     final texts = AppLocalizations.of(context);
     final posCatalogBloc = AppBlocsProvider.of<PosCatalogBloc>(context);
-    final size = MediaQuery.of(context).size;
-
-    itemHeight = (size.height - kToolbarHeight - 16) / 4;
-    itemWidth = size.width / 2;
 
     if (accountSubscription == null) {
       AccountBloc accountBloc = AppBlocsProvider.of<AccountBloc>(context);
@@ -280,36 +274,13 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
               decoration: BoxDecoration(
                 color: Theme.of(context).backgroundColor,
               ),
-              height: MediaQuery.of(context).size.height * 0.29,
+              height: max(184.0, MediaQuery.of(context).size.height * 0.3),
             ),
-            Expanded(
-              child: _isKeypadView
-                  ? PosInvoiceNumPad(
-                      currentSale: currentSale,
-                      width: itemWidth,
-                      height: itemHeight,
-                      approveClear: () => _approveClear(context, currentSale),
-                      clearAmounts: () => _clearAmounts(currentSale),
-                      onAddition: () => setState(() {
-                        currentPendingItem = null;
-                      }),
-                      onNumberPressed: (number) => _onNumButtonPressed(
-                        currentSale,
-                        number,
-                      ),
-                    )
-                  : PosInvoiceItemsView(
-                      currentSale: currentSale,
-                      accountModel: accountModel,
-                      itemFilterController: _itemFilterController,
-                      addItem: (item, avatarKey) => _addItem(
-                        posCatalogBloc,
-                        currentSale,
-                        accountModel,
-                        item,
-                        avatarKey,
-                      ),
-                    ),
+            _tabBody(
+              context,
+              posCatalogBloc,
+              accountModel,
+              currentSale,
             ),
           ],
         ),
@@ -401,6 +372,52 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
           iconData: Icons.playlist_add,
         ),
       ],
+    );
+  }
+
+  Widget _tabBody(
+    BuildContext context,
+    PosCatalogBloc posCatalogBloc,
+    AccountModel accountModel,
+    Sale currentSale,
+  ) {
+    return Expanded(
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final height = constraints.maxHeight;
+          final width = constraints.maxWidth;
+          return Container(
+            height: constraints.maxHeight,
+            child: _isKeypadView
+                ? PosInvoiceNumPad(
+                    currentSale: currentSale,
+                    approveClear: () => _approveClear(context, currentSale),
+                    clearAmounts: () => _clearAmounts(currentSale),
+                    onAddition: () => setState(() {
+                      currentPendingItem = null;
+                    }),
+                    onNumberPressed: (number) => _onNumButtonPressed(
+                      currentSale,
+                      number,
+                    ),
+                    width: width,
+                    height: height,
+                  )
+                : PosInvoiceItemsView(
+                    currentSale: currentSale,
+                    accountModel: accountModel,
+                    itemFilterController: _itemFilterController,
+                    addItem: (item, avatarKey) => _addItem(
+                      posCatalogBloc,
+                      currentSale,
+                      accountModel,
+                      item,
+                      avatarKey,
+                    ),
+                  ),
+          );
+        },
+      ),
     );
   }
 

--- a/lib/routes/charge/pos_invoice_num_pad.dart
+++ b/lib/routes/charge/pos_invoice_num_pad.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez/bloc/pos_catalog/model.dart';
 import 'package:breez/theme_data.dart' as theme;
 import 'package:flutter/cupertino.dart';
@@ -26,62 +27,70 @@ class PosInvoiceNumPad extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final texts = AppLocalizations.of(context);
-    final themeData = Theme.of(context);
-
-    return GridView.count(
-        crossAxisCount: 3,
-        childAspectRatio: (width / height),
-        padding: EdgeInsets.zero,
-        children: List<int>.generate(9, (i) => i)
-            .map((index) => _numberButton(
-                  context,
-                  (index + 1).toString(),
-                ))
-            .followedBy([
-          Container(
-            decoration: BoxDecoration(
-              border: Border.all(
-                color: themeData.backgroundColor,
-                width: 0.5,
-              ),
-            ),
-            child: GestureDetector(
-              onLongPress: approveClear,
-              child: TextButton(
-                onPressed: clearAmounts,
-                child: Text(
-                  texts.pos_invoice_num_pad_clear,
-                  style: theme.numPadNumberStyle,
-                ),
-              ),
+    return Container(
+      width: width,
+      height: height,
+      child: Column(
+        mainAxisSize: MainAxisSize.max,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Expanded(
+            child: Row(
+              mainAxisSize: MainAxisSize.max,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _numberButton(context, "1"),
+                _numberButton(context, "2"),
+                _numberButton(context, "3"),
+              ],
             ),
           ),
-          _numberButton(context, "0"),
-          Container(
-            decoration: BoxDecoration(
-              border: Border.all(
-                color: themeData.backgroundColor,
-                width: 0.5,
-              ),
-            ),
-            child: TextButton(
-              onPressed: onAddition,
-              child: Text(
-                texts.pos_invoice_num_pad_plus,
-                style: theme.numPadAdditionStyle,
-              ),
+          Expanded(
+            child: Row(
+              mainAxisSize: MainAxisSize.max,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _numberButton(context, "4"),
+                _numberButton(context, "5"),
+                _numberButton(context, "6"),
+              ],
             ),
           ),
-        ]).toList());
+          Expanded(
+            child: Row(
+              mainAxisSize: MainAxisSize.max,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _numberButton(context, "7"),
+                _numberButton(context, "8"),
+                _numberButton(context, "9"),
+              ],
+            ),
+          ),
+          Expanded(
+            child: Row(
+              mainAxisSize: MainAxisSize.max,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _clearButton(context),
+                _numberButton(context, "0"),
+                _additionButton(context),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
   }
 
-  Container _numberButton(
+  Widget _numberButton(
     BuildContext context,
     String number,
   ) {
     final themeData = Theme.of(context);
     return Container(
+      width: width / 3.0,
+      height: height / 4.0,
       decoration: BoxDecoration(
         border: Border.all(
           color: themeData.backgroundColor,
@@ -89,11 +98,70 @@ class PosInvoiceNumPad extends StatelessWidget {
         ),
       ),
       child: TextButton(
+        style: TextButton.styleFrom(
+          padding: EdgeInsets.zero,
+          alignment: Alignment.center,
+        ),
         onPressed: () => onNumberPressed(number),
         child: Text(
           number,
           textAlign: TextAlign.center,
           style: theme.numPadNumberStyle,
+        ),
+      ),
+    );
+  }
+
+  Widget _clearButton(BuildContext context) {
+    final texts = AppLocalizations.of(context);
+    final themeData = Theme.of(context);
+    return Container(
+      width: width / 3.0,
+      height: height / 4.0,
+      decoration: BoxDecoration(
+        border: Border.all(
+          color: themeData.backgroundColor,
+          width: 0.5,
+        ),
+      ),
+      child: GestureDetector(
+        onLongPress: approveClear,
+        child: TextButton(
+          onPressed: clearAmounts,
+          style: TextButton.styleFrom(
+            padding: EdgeInsets.zero,
+            alignment: Alignment.center,
+          ),
+          child: Text(
+            texts.pos_invoice_num_pad_clear,
+            style: theme.numPadNumberStyle,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _additionButton(BuildContext context) {
+    final texts = AppLocalizations.of(context);
+    final themeData = Theme.of(context);
+    return Container(
+      width: width / 3.0,
+      height: height / 4.0,
+      decoration: BoxDecoration(
+        border: Border.all(
+          color: themeData.backgroundColor,
+          width: 0.5,
+        ),
+      ),
+      child: TextButton(
+        onPressed: onAddition,
+        style: TextButton.styleFrom(
+          padding: EdgeInsets.zero,
+          alignment: Alignment.center,
+        ),
+        child: AutoSizeText(
+          texts.pos_invoice_num_pad_plus,
+          style: theme.numPadAdditionStyle,
         ),
       ),
     );


### PR DESCRIPTION
POS page has some issues on small screens, this PR fixes them.

How it looks like:
*notice I'm using split-screen to simulate smaller screens.

|Before|After|
|---|---|
|![before_1](https://user-images.githubusercontent.com/1225438/147127294-71ba0fb7-0a1e-4083-a92e-59ef1c6fc0c0.png)|![after_1](https://user-images.githubusercontent.com/1225438/147127282-a37b4152-d12a-440e-92ed-e732ac3ccca0.png)|
|![before_2](https://user-images.githubusercontent.com/1225438/147127296-2d16e04f-f9c8-4250-94b0-bb293815cb3b.png)|![after_2](https://user-images.githubusercontent.com/1225438/147127287-ecd08998-c217-40d0-b9d7-22348c60663f.png)|
|![before_3](https://user-images.githubusercontent.com/1225438/147127297-f9a7a4ef-344a-4a22-b728-3836f2f045b6.png)|![after_3](https://user-images.githubusercontent.com/1225438/147127291-800652a0-21d8-42cf-a4e2-60c8d3c26350.png)|
|![before_4](https://user-images.githubusercontent.com/1225438/147127301-e9ba10a5-644c-42ce-acc9-755c306a6d2d.png)|![after_4](https://user-images.githubusercontent.com/1225438/147127292-00fcfaab-4330-4a7f-a91f-1972deba0ffb.png)|

