### PR TITLE
Better identification of payment items

### DIFF
--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -663,25 +663,29 @@ class AccountBloc {
     DateTime _firstDate;
     print("refreshing payments...");
 
+    final hashedSales = await _posRepository.fetchSalesPaymentHashes();
     return _breezLib.getPayments().then((payments) {
-      List<PaymentInfo> _paymentsList = payments.paymentsList.map((payment) {
-        var singlePaymentInfo =
-            SinglePaymentInfo(payment, _accountController.value);
-
-        return singlePaymentInfo;
-      }).toList();
+      List<PaymentInfo> _paymentsList = payments.paymentsList
+          .map((payment) => SinglePaymentInfo(
+                payment,
+                _accountController.value,
+                hashedSales.contains(payment.paymentHash),
+              ))
+          .toList();
 
       if (_paymentsList.length > 0) {
         _firstDate = DateTime.fromMillisecondsSinceEpoch(
-            _paymentsList.last.creationTimestamp.toInt() * 1000);
+          _paymentsList.last.creationTimestamp.toInt() * 1000,
+        );
       }
       print("refresh payments finished " +
           payments.paymentsList.length.toString());
       return PaymentsModel(
-          _paymentsList,
-          _filterPayments(_paymentsList),
-          _paymentFilterController.value,
-          _firstDate ?? DateTime(DateTime.now().year));
+        _paymentsList,
+        _filterPayments(_paymentsList),
+        _paymentFilterController.value,
+        _firstDate ?? DateTime(DateTime.now().year),
+      );
     });
   }
 

--- a/lib/bloc/pos_catalog/repository.dart
+++ b/lib/bloc/pos_catalog/repository.dart
@@ -18,4 +18,5 @@ abstract class Repository {
   Future<int> addSale(Sale sale, String paymentHash);
   Future<Sale> fetchSaleByID(int id);
   Future<Sale> fetchSaleByPaymentHash(String paymentHash);
+  Future<Set<String>> fetchSalesPaymentHashes();
 }

--- a/lib/bloc/pos_catalog/sqlite/repository.dart
+++ b/lib/bloc/pos_catalog/sqlite/repository.dart
@@ -187,4 +187,15 @@ class SqliteRepository implements Repository {
     }
     return items.map((row) => fromMapFunc(row)).toList();
   }
+
+  @override
+  Future<Set<String>> fetchSalesPaymentHashes() async {
+    return Set.from(
+      await _fetchDBItems(
+        await getDB(),
+        "sale_payments",
+        (e) => e["payment_hash"],
+      ),
+    );
+  }
 }


### PR DESCRIPTION
This PR is a purpose on how to fix the misidentified sale items.

e.g., on the following videos, you can see a Sale (first item +206 sats) and a Connect to Pay transaction (third item +100 sats).

Before these changes, because of the heuristics, both are shown in the list as a Sale Item, after the changes only the real Sale item is shown.

A bad side effect of these changes is the load that sometimes some transactions will show, on the videos I leave, and I back to the Balance page to show some items being loaded.

Please let me know your thoughts about this approach and the code, Happy new year 🥳 

# Before

https://user-images.githubusercontent.com/1225438/147827241-e8e49a9e-04b5-40a6-b59d-3e20d258fb5e.mp4

# After

https://user-images.githubusercontent.com/1225438/147827263-23758db1-1675-4b58-b31a-c478b88e6b0f.mp4


