### PR TITLE
Fix bitcoin uppercase coming from camera scanner

### DIFF
--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -952,7 +952,7 @@
   "get_refund_action_continue": "SEGUIR",
   "get_refund_transaction": "Transacción de Reembolso",
   "get_refund_failed": "falló",
-  "send_on_chain_broadcast": "TRANSMITIDO",
+  "send_on_chain_broadcast": "TRANSMITIR",
   "send_on_chain_btc_address": "Dirección BTC",
   "send_on_chain_scan_barcode": "Escanear código de barras",
   "send_on_chain_invalid_btc_address": "Por favor ingrese una dirección BTC válida",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -952,7 +952,7 @@
   "get_refund_action_continue": "CONTINUAR",
   "get_refund_transaction": "Transação de Reembolso",
   "get_refund_failed": "falhou",
-  "send_on_chain_broadcast": "TRANSMITIDA",
+  "send_on_chain_broadcast": "TRANSMITIR",
   "send_on_chain_btc_address": "Endereço BTC",
   "send_on_chain_scan_barcode": "Ler código de barras",
   "send_on_chain_invalid_btc_address": "Por favor insira um endereço BTC válido",

--- a/lib/services/breezlib/breez_bridge.dart
+++ b/lib/services/breezlib/breez_bridge.dart
@@ -664,7 +664,7 @@ class BreezBridge {
     if (address == null) {
       return Future.error("empty address");
     }
-    if (addr.startsWith("bitcoin:")) {
+    if (addr.toLowerCase().startsWith("bitcoin:")) {
       addr = addr.substring(8);
     }
     return _invokeMethodWhenReady("validateAddress", {"argument": addr})


### PR DESCRIPTION
Fixes https://github.com/breez/breezmobile/issues/688

For some reason the camera scanner is sending the address as uppercase, I did add a `.toLowerCase()` to fix it,

Fixed a translation text too, the action should be in present mode "TRANSMITIR" instead of past mode "TRANSMITIDO/TRANSMITIDA".