### PR TITLE
Add deep link support for LUD17 links

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -90,6 +90,46 @@
             </intent-filter>
 
             <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <action android:name="android.nfc.action.TECH_DISCOVERED" />
+                <action android:name="android.nfc.action.TAG_DISCOVERED" />
+                <data android:scheme="lnurlc" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <action android:name="android.nfc.action.TECH_DISCOVERED" />
+                <action android:name="android.nfc.action.TAG_DISCOVERED" />
+                <data android:scheme="lnurlw" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <action android:name="android.nfc.action.TECH_DISCOVERED" />
+                <action android:name="android.nfc.action.TAG_DISCOVERED" />
+                <data android:scheme="lnurlp" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <action android:name="android.nfc.action.TECH_DISCOVERED" />
+                <action android:name="android.nfc.action.TAG_DISCOVERED" />
+                <data android:scheme="keyauth" />
+            </intent-filter>
+
+            <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT"/>

--- a/android/app/src/main/java/com/breez/client/NfcHandler.java
+++ b/android/app/src/main/java/com/breez/client/NfcHandler.java
@@ -107,6 +107,11 @@ public class NfcHandler implements MethodChannel.MethodCallHandler, FlutterPlugi
                     Log.d(TAG, "Discovered Lightning Link...");
                     return lnLink;
                 }
+                if (lnLink.startsWith("lnurlc:") || lnLink.startsWith("lnurlw:") ||
+                    lnLink.startsWith("lnurlp:") || lnLink.startsWith("keyauth:")) {
+                    Log.d(TAG, "Discovered LUD-17 Link...");
+                    return lnLink;
+                }
             } catch (UnsupportedEncodingException exc) {
                 Log.e(TAG, "Error", exc);
                 return "";

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -46,6 +46,10 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>lightning</string>
+				<string>lnurlc</string>
+				<string>lnurlw</string>
+				<string>lnurlp</string>
+				<string>keyauth</string>
 			</array>
 		</dict>
 		<dict>

--- a/lib/services/lightning_links.dart
+++ b/lib/services/lightning_links.dart
@@ -13,8 +13,7 @@ class LightningLinksService {
 
   LightningLinksService() {
     Rx.merge([getInitialLink().asStream(), linkStream])
-        .where((l) =>
-            l != null && (l.startsWith("lightning:") || l.startsWith("breez:")))
+        .where(_canHandle)
         .listen((l) {
       log.info("Got lightning link: $l");
       if (l.startsWith("breez:")) {
@@ -22,6 +21,16 @@ class LightningLinksService {
       }
       _linksNotificationsController.add(l);
     });
+  }
+
+  bool _canHandle(String link) {
+    if (link == null) return false;
+    return link.startsWith("breez:") ||
+        link.startsWith("lightning:") ||
+        link.startsWith("lnurlc:") ||
+        link.startsWith("lnurlp:") ||
+        link.startsWith("lnurlw:") ||
+        link.startsWith("keyauth:");
   }
 
   close() {


### PR DESCRIPTION
Add deep link support for [Lud 17](https://github.com/fiatjaf/lnurl-rfc/blob/luds/17.md) links.

How it looks like:

https://user-images.githubusercontent.com/1225438/150827676-c1b1111e-2811-46aa-8841-2007e7b191f9.mp4

Notice I did use the following HTML to make links clickable as the system does not recognize custom URL schemes properly

```
<html>
<head>
	<title>Text Lud-17</title>
</head>
<body>
	<p>
		<a href="lnurlp://lnurl.fiatjaf.com/lnurl-pay?session=13bc050935c0dc15ba82e3c76296725656a3edaa01a113a9fd439611687f250d">lnurlp://lnurl.fiatjaf.com/lnurl-pay?session=13bc050935c0dc15ba82e3c76296725656a3edaa01a113a9fd439611687f250d</a>
	</p>
	<p>
		<a href="lnurlw://lnurl.fiatjaf.com/lnurl-withdraw?session=854128f23d24a9a4b5d9a030db62b66543d23e8fb2509d18adfa254c318f4b32">lnurlw://lnurl.fiatjaf.com/lnurl-withdraw?session=854128f23d24a9a4b5d9a030db62b66543d23e8fb2509d18adfa254c318f4b32</a>
	</p>
	<p>
		<a href="lnurlc://lnurl.fiatjaf.com/lnurl-channel?session=c17657cfbd8dbdced7a19d952a665141ee2c1ce99214423ea6783be410061769">lnurlc://lnurl.fiatjaf.com/lnurl-channel?session=c17657cfbd8dbdced7a19d952a665141ee2c1ce99214423ea6783be410061769</a>
	</p>
	<p>
		<a href="keyauth://lnurl.fiatjaf.com/lnurl-login?tag=login&k1=224b4750d28cd2746bf21eb1e3d6bf033fa407bd57e5b805455182422b96ba22">keyauth://lnurl.fiatjaf.com/lnurl-login?tag=login&k1=224b4750d28cd2746bf21eb1e3d6bf033fa407bd57e5b805455182422b96ba22</a>
	</p>
</body>
</html>
```

⚠️  Important notice, I can't test it on iOS, if you can test on iOS please do it 🙏 