### PR TITLE
Fix warning box text cut

### DIFF
--- a/lib/routes/home/bottom_actions_bar.dart
+++ b/lib/routes/home/bottom_actions_bar.dart
@@ -345,7 +345,6 @@ Future showReceiveOptions(BuildContext parentContext, AccountModel account) {
                                   removeTrailingZeros: true,
                                 ),
                               ),
-                              maxLines: 1,
                               maxFontSize: Theme.of(context)
                                   .textTheme
                                   .subtitle1


### PR DESCRIPTION
Thank you @bitcoinuser for the error report 🙏 

How it looks like:

|Before|After|
|---|---|
|![before](https://user-images.githubusercontent.com/1225438/151666497-039f45df-4955-4a93-909b-f3f5575840ae.png)|![after](https://user-images.githubusercontent.com/1225438/151666495-ab86fa49-06ce-4ec2-9a45-719bf837ba8f.png)|

