### PR TITLE
Adjust transaction pdf layout to correct POS receipt layout error

### DIFF
--- a/lib/utils/print_pdf.dart
+++ b/lib/utils/print_pdf.dart
@@ -36,7 +36,9 @@ class PrintService {
               mainAxisSize: pw.MainAxisSize.min,
               crossAxisAlignment: pw.CrossAxisAlignment.start,
               children: [
-                _buildTitle(texts),
+                _buildTitle(),
+                pw.SizedBox(height: 8),
+                _buildTransactionTime(texts),
                 pw.SizedBox(height: 8),
                 _buildAddress(),
                 pw.SizedBox(height: 40),
@@ -58,18 +60,21 @@ class PrintService {
     }
   }
 
-  _buildTitle(AppLocalizations texts) {
+  _buildTitle() {
+    return pw.Text(
+      printParameters.currentUser.name,
+      style: pw.TextStyle(fontSize: 24, letterSpacing: 0.25),
+    );
+  }
+
+  _buildTransactionTime(AppLocalizations texts) {
     final creationTimestamp = printParameters.paymentInfo?.creationTimestamp;
 
     return pw.Row(
       mainAxisSize: pw.MainAxisSize.max,
       crossAxisAlignment: pw.CrossAxisAlignment.start,
-      mainAxisAlignment: pw.MainAxisAlignment.spaceBetween,
+      mainAxisAlignment: pw.MainAxisAlignment.end,
       children: [
-        pw.Text(
-          printParameters.currentUser.name,
-          style: pw.TextStyle(fontSize: 24, letterSpacing: 0.25),
-        ),
         creationTimestamp != null
             ? pw.Column(
                 children: [


### PR DESCRIPTION
"Transaction Time" text is the first item printed on POS receipts, then business title, then the tx time itself.
To correct this behavior transaction time is moved below business title.