### PR TITLE
Update firebase dependencies

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -101,15 +101,15 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.biometric:biometric:1.1.0'
     implementation 'androidx.exifinterface:exifinterface:1.3.3'
-    implementation 'androidx.lifecycle:lifecycle-process:2.4.0'
+    implementation 'androidx.lifecycle:lifecycle-process:2.4.1'
     implementation 'androidx.work:work-runtime:2.7.1'
     implementation 'com.felipecsl:gifimageview:2.1.0'
-    implementation 'com.google.android.gms:play-services-auth:20.0.1'
+    implementation 'com.google.android.gms:play-services-auth:20.1.0'
     implementation 'com.google.android.gms:play-services-drive:17.0.0'
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'com.theartofdev.edmodo:android-image-cropper:2.8.0'
 
-    implementation platform('com.google.firebase:firebase-bom:29.0.4')
+    implementation platform('com.google.firebase:firebase-bom:29.3.1')
     implementation 'com.google.firebase:firebase-messaging'
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,10 +23,10 @@ dependencies:
   email_validator: "2.0.1"
   extended_image: "6.0.2+1"
   file_picker: "4.5.1"
-  firebase_core: ^1.14.0
-  firebase_database: ^9.0.6
-  firebase_dynamic_links: ^4.0.5
-  firebase_messaging: ^11.2.6
+  firebase_core: "1.15.0"
+  firebase_database: "9.0.12"
+  firebase_dynamic_links: "4.2.0"
+  firebase_messaging: "11.2.14"
   flushbar: ^1.10.4 # discontinued
   flutter_secure_storage: ^5.0.2
   flutter_svg: ^1.0.3


### PR DESCRIPTION
In order to advance on the reproducible build issue referred to https://github.com/breez/breezmobile/issues/247  and https://github.com/breez/breezmobile/issues/504 I'm replacing the ranges syntax `^x.y.z` by specific static version `"x.y.z"` on this updating.

The list of updated depedencies:

- firebase_core: from `1.14.0` to `1.15.0`
- firebase_database: from `9.0.8` to `9.0.12`
- firebase_dynamic_links: from `4.0.8` to `4.2.0`
- firebase_messaging: explicit `11.2.14`
- lifecycle-process: from `2.4.0` to `2.4.1`
- play-services-auth: from `20.0.1` to `20.1.0`
- firebase-bom: from `29.0.4` to `29.3.1`