### PR TITLE
Specify the mutability of PendingIntents for Android 12+

### DIFF
--- a/android/app/src/main/java/com/breez/client/BreezFirebaseMessagingService.java
+++ b/android/app/src/main/java/com/breez/client/BreezFirebaseMessagingService.java
@@ -59,6 +59,7 @@ public class BreezFirebaseMessagingService extends FirebaseMessagingService {
     private void ShowNotification(Map<String, String> data, RemoteMessage remoteMessage) {
         int notificationID = (int)System.currentTimeMillis() / 1000;
         Bitmap icon = BitmapFactory.decodeResource(getResources(), R.mipmap.ic_launcher);
+        int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE : PendingIntent.FLAG_UPDATE_CURRENT;
         PendingIntent approvePendingIntent = PendingIntent.getBroadcast(
                 this,
                 REQUEST_CODE_OPEN,
@@ -66,7 +67,7 @@ public class BreezFirebaseMessagingService extends FirebaseMessagingService {
                         .putExtra(KEY_INTENT_APPROVE, REQUEST_CODE_OPEN)
                         .putExtra(NOTIFICATION_ID, notificationID)
                         .putExtra(EXTRA_REMOTE_MESSAGE, remoteMessage),
-                PendingIntent.FLAG_UPDATE_CURRENT
+                flags
         );
 
         String buttonTitle = data.get("button");

--- a/android/app/src/main/java/com/breez/client/plugins/breez/BreezShare.java
+++ b/android/app/src/main/java/com/breez/client/plugins/breez/BreezShare.java
@@ -2,6 +2,7 @@ package com.breez.client.plugins.breez;
 
 import android.content.Intent;
 import android.app.PendingIntent;
+import android.os.Build;
 
 import androidx.annotation.NonNull;
 
@@ -89,7 +90,8 @@ public class BreezShare implements MethodChannel.MethodCallHandler, PluginRegist
                 shareIntent.setType("text/plain");
 
                 Intent receiver = new Intent(binding.getActivity(), BreezShareReceiver.class);
-                PendingIntent pendingIntent = PendingIntent.getBroadcast(binding.getActivity(), 0, receiver, PendingIntent.FLAG_UPDATE_CURRENT);
+                int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE : PendingIntent.FLAG_UPDATE_CURRENT;
+                PendingIntent pendingIntent = PendingIntent.getBroadcast(binding.getActivity(), 0, receiver, flags);
 
                 Intent chooserIntent = Intent.createChooser(shareIntent,
                         call.argument("title") == null ? null : (String) call.argument("title"),

--- a/android/app/src/main/java/com/breez/client/plugins/breez/breezlib/Notification.java
+++ b/android/app/src/main/java/com/breez/client/plugins/breez/breezlib/Notification.java
@@ -30,12 +30,10 @@ public class Notification {
         notificationIntent.putExtra("click_action", "FLUTTER_NOTIFICATION_CLICK");
         notificationIntent.putExtra("user_click", "1");
 
-
         Bitmap icon = BitmapFactory.decodeResource(ctx.getResources(), R.mipmap.ic_launcher);
 
-        PendingIntent appIntent = PendingIntent.getActivity(ctx, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
-
-
+        int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE : PendingIntent.FLAG_UPDATE_CURRENT;
+        PendingIntent appIntent = PendingIntent.getActivity(ctx, 0, notificationIntent, flags);
 
         NotificationCompat.Action action =
                 new NotificationCompat.Action.Builder(ic_delete,


### PR DESCRIPTION
Not specifying mutability of PendingIntent's broke functionality for Android 12 devices due to[ this change](https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability).

I've specified mutability of each PendingIntent we use.