### PR TITLE
fix dropdown clearing for pos screen

### DIFF
--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -263,11 +263,8 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
                       context,
                       currentSale,
                     ),
-                    changeCurrency: (currency) => _changeCurrency(
-                      currentSale,
-                      currency,
-                      userProfileBloc,
-                    ),
+                    changeCurrency: (currency) => _changeCurrency(currentSale,
+                        currency, userProfileBloc, currentCurrency),
                   ),
                 ],
               ),
@@ -774,11 +771,11 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
     });
   }
 
-  void _changeCurrency(
-    Sale currentSale,
-    String value,
-    UserProfileBloc userProfileBloc,
-  ) {
+  void _changeCurrency(Sale currentSale, String value,
+      UserProfileBloc userProfileBloc, CurrencyWrapper currentCurrency) {
+    if (currentCurrency.shortName.toUpperCase() == value) {
+      return;
+    }
     print(">> _changeCurrency $value");
     setState(() {
       Currency currency = Currency.fromTickerSymbol(value);


### PR DESCRIPTION
Fixes #901 

On the POS keypad screen, the currency type drop-down was clearing the entered number after choosing the same currency from the drop-down.
This PR fixes it. Entered numbers are cleared only if the chosen currency is different.