### PR TITLE
Fix default value for override (link to default const value)

### DIFF
--- a/lib/bloc/payment_options/payment_options_bloc.dart
+++ b/lib/bloc/payment_options/payment_options_bloc.dart
@@ -68,7 +68,7 @@ class PaymentOptionsBloc with AsyncActionsHandler {
     if (prefs.containsKey(_kPaymentOptionOverrideFee)) {
       paymentFeeEnabled = prefs.getBool(_kPaymentOptionOverrideFee);
     } else {
-      paymentFeeEnabled = true;
+      paymentFeeEnabled = _kDefaultOverrideFee;
     }
     _paymentOptionsFeeEnabledStreamController.add(paymentFeeEnabled);
   }


### PR DESCRIPTION
On a fresh first run, the default was a hardcoded true instead of the actual value stored in the proper constant, this commit fixes it.