### PR TITLE
Change satoshi symbol and print currencies tickers instead of symbol

### DIFF
--- a/lib/bloc/user_profile/currency.dart
+++ b/lib/bloc/user_profile/currency.dart
@@ -55,7 +55,7 @@ class Currency extends Object {
       case "BTC":
         return "₿";
       case "SAT":
-        return "Ş";
+        return "丰";
       default:
         return "₿";
     }

--- a/lib/routes/charge/sale_view.dart
+++ b/lib/routes/charge/sale_view.dart
@@ -358,11 +358,10 @@ class _TotalSaleCharge extends StatelessWidget {
     final totalAmountInFiat = currentSale.totalAmountInFiat;
 
     final satCurrency = CurrencyWrapper.fromBTC(Currency.SAT);
-    final satMessage = satCurrency.format(
+    final satMessage = (satCurrency.format(
       totalAmountInSats,
       removeTrailingZeros: true,
-      includeDisplayName: true,
-    ).toUpperCase();
+    ) + " " + satCurrency.shortName).toUpperCase();
 
     if (totalAmountInFiat.length == 1) {
       final currency = totalAmountInFiat.entries.first.key;

--- a/lib/utils/print_pdf.dart
+++ b/lib/utils/print_pdf.dart
@@ -204,7 +204,7 @@ class PrintService {
         final fiatTotalMsg = saleCurrency.format(
           total,
           removeTrailingZeros: true,
-          includeCurrencySymbol: true,
+          includeDisplayName: true,
         );
         totalMsg = "$totalMsg ($fiatTotalMsg)";
       }
@@ -256,14 +256,14 @@ class PrintService {
             ? [
                 pw.Text(
                   (addParenthesis ? "(" : "") +
-                      "${saleCurrency.format(amount, removeTrailingZeros: true, includeCurrencySymbol: false)} ",
+                      "${_buildPriceValue(saleCurrency, amount)} ",
                   style: pw.TextStyle(
                     font: pw.Font.ttf(fontMap["ltr"]),
                     fontSize: 12.3,
                   ),
                 ),
                 pw.Text(
-                  "${saleCurrency.symbol}",
+                  "${saleCurrency.shortName}",
                   textDirection: pw.TextDirection.rtl,
                   textAlign: pw.TextAlign.right,
                   style: pw.TextStyle(
@@ -282,7 +282,7 @@ class PrintService {
             : [
                 pw.Text(
                   (addParenthesis ? "(" : "") +
-                      "${saleCurrency.format(amount, removeTrailingZeros: true, includeCurrencySymbol: true)}" +
+                      "${_buildPriceValue(saleCurrency, amount)}" +
                       (addParenthesis ? ")" : ""),
                   textDirection: saleCurrency.rtl
                       ? pw.TextDirection.rtl
@@ -296,6 +296,18 @@ class PrintService {
                 ),
               ],
       ),
+    );
+  }
+
+  String _buildPriceValue(CurrencyWrapper saleCurrency, double amount) {
+    if (saleCurrency.shortName == _satCurrency.shortName) {
+      final value = _satCurrency.format(amount, removeTrailingZeros: true);
+      return "$value ${_satCurrency.shortName}";
+    }
+    return saleCurrency.format(
+      amount,
+      removeTrailingZeros: true,
+      includeDisplayName: true,
     );
   }
 


### PR DESCRIPTION
Apply the changes proposals from https://github.com/breez/breezmobile/issues/916

- Changes the satoshi symbol from `Ş` to `丰`
- Uses currency ticker (3 letters) instead of the currency symbol.

# How it looks like

|Before|After|
|---|---|
|![before-1](https://user-images.githubusercontent.com/1225438/172475339-5c55fff3-1e98-4047-9b1d-87cabe39d2df.png)|![after-1](https://user-images.githubusercontent.com/1225438/172475346-71120abe-6f0f-4bab-82e8-1ba2af187feb.png)|
|![before-2](https://user-images.githubusercontent.com/1225438/172475341-baa7bdfc-71b0-4a57-a4f7-97a0e21f82f1.png)|![after-2](https://user-images.githubusercontent.com/1225438/172475343-8b0083b8-ac5c-4495-ac6e-c469b2817883.png)|
|![before-3](https://user-images.githubusercontent.com/1225438/172475334-b7e7ee85-49ba-42b7-9833-91ad4ab897e5.png)|![after-3](https://user-images.githubusercontent.com/1225438/172690903-5767c8d7-527c-44f4-9840-d1f169eb7815.png)|
|![before-4](https://user-images.githubusercontent.com/1225438/172475332-f1a1f102-fa6c-4aee-a2ef-765121d0b8ab.png)|![after-4](https://user-images.githubusercontent.com/1225438/172690910-f6c84a2f-851f-49fe-8492-ab614b5079e4.png)|


