### PR TITLE
funds_over_limit_dialog_redeem_hours localization improvements

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -946,16 +946,17 @@
       }
     }
   },
-  "funds_over_limit_dialog_redeem_hour": "You will be able to redeem your funds after block {lockHeight} (in about an hour).",
-  "@funds_over_limit_dialog_redeem_hour": {
+  "approximately_an_hour": "(in about an hour)",
+  "approximate_hours": "(~{hours} hours)",
+  "@approximate_hours": {
     "placeholders": {
-      "lockHeight": {
+      "hours": {
         "type": "String",
-        "example": "140659"
+        "example": "42"
       }
     }
   },
-  "funds_over_limit_dialog_redeem_hours": "You will be able to redeem your funds after block {lockHeight} (~{hoursToUnlock} hours).",
+  "funds_over_limit_dialog_redeem_hours": "You will be able to redeem your funds after block {lockHeight} {hoursToUnlock}.",
   "@funds_over_limit_dialog_redeem_hours": {
     "placeholders": {
       "lockHeight": {
@@ -964,7 +965,7 @@
       },
       "hoursToUnlock": {
         "type": "String",
-        "example": "7"
+        "example": "(~42 hours)"
       }
     }
   },

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -946,16 +946,17 @@
       }
     }
   },
-  "funds_over_limit_dialog_redeem_hour": "Podrá retirar sus fondos después del bloque {lockHeight} (en aproximadamente 1 hora).",
-  "@funds_over_limit_dialog_redeem_hour": {
+  "approximately_an_hour": "(en aproximadamente 1 hora)",
+  "approximate_hours": "(en aproximadamente {hours} horas)",
+  "@approximate_hours": {
     "placeholders": {
-      "lockHeight": {
+      "hours": {
         "type": "String",
-        "example": "140659"
+        "example": "42"
       }
     }
   },
-  "funds_over_limit_dialog_redeem_hours": "Podrá retirar sus fondos después del bloque {lockHeight} (en aproximadamente {hoursToUnlock} horas).",
+  "funds_over_limit_dialog_redeem_hours": "Podrá retirar sus fondos después del bloque {lockHeight} {hoursToUnlock}.",
   "@funds_over_limit_dialog_redeem_hours": {
     "placeholders": {
       "lockHeight": {
@@ -964,7 +965,7 @@
       },
       "hoursToUnlock": {
         "type": "String",
-        "example": "7"
+        "example": "(en aproximadamente 42 horas)"
       }
     }
   },

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -946,16 +946,17 @@
       }
     }
   },
-  "funds_over_limit_dialog_redeem_hour": "Voit lunastaa varasi Bitcoin-lohkon {lockHeight} jälkeen eli noin tunnin kuluttua.",
-  "@funds_over_limit_dialog_redeem_hour": {
+  "approximately_an_hour": "jälkeen eli noin tunnin kuluttua",
+  "approximate_hours": "jälkeen eli noin (~{hours} tunnin kuluttua)",
+  "@approximate_hours": {
     "placeholders": {
-      "lockHeight": {
+      "hours": {
         "type": "String",
-        "example": "140659"
+        "example": "42"
       }
     }
   },
-  "funds_over_limit_dialog_redeem_hours": "Voit lunastaa varasi Bitcoin-lohkon {lockHeight} jälkeen eli noin (~{hoursToUnlock} tunnin kuluttua).",
+  "funds_over_limit_dialog_redeem_hours": "Voit lunastaa varasi Bitcoin-lohkon {lockHeight} {hoursToUnlock}.",
   "@funds_over_limit_dialog_redeem_hours": {
     "placeholders": {
       "lockHeight": {
@@ -964,7 +965,7 @@
       },
       "hoursToUnlock": {
         "type": "String",
-        "example": "7"
+        "example": "jälkeen eli noin (~42 tunnin kuluttua)"
       }
     }
   },

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -946,16 +946,17 @@
       }
     }
   },
-  "funds_over_limit_dialog_redeem_hour": "Vous pourrez racheter vos fonds après le bloc {lockHeight} (dans environ une heure).",
-  "@funds_over_limit_dialog_redeem_hour": {
+  "approximately_an_hour": "(dans environ une heure)",
+  "approximate_hours": "(~{hours} heures)",
+  "@approximate_hours": {
     "placeholders": {
-      "lockHeight": {
+      "hours": {
         "type": "String",
-        "example": "140659"
+        "example": "42"
       }
     }
   },
-  "funds_over_limit_dialog_redeem_hours": "Vous pourrez racheter vos fonds après le bloc {lockHeight} (~{hoursToUnlock} heures).",
+  "funds_over_limit_dialog_redeem_hours": "Vous pourrez racheter vos fonds après le bloc {lockHeight} {hoursToUnlock}.",
   "@funds_over_limit_dialog_redeem_hours": {
     "placeholders": {
       "lockHeight": {
@@ -964,7 +965,7 @@
       },
       "hoursToUnlock": {
         "type": "String",
-        "example": "7"
+        "example": "(~42 heures)"
       }
     }
   },

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -946,16 +946,17 @@
       }
     }
   },
-  "funds_over_limit_dialog_redeem_hour": "Você poderá resgatar seus fundos após o bloco {lockHeight} (aproximadamente em 1 hora).",
-  "@funds_over_limit_dialog_redeem_hour": {
+  "approximately_an_hour": "(aproximadamente em 1 hora)",
+  "approximate_hours": "(aproximadamente em {hours} horas)",
+  "@approximate_hours": {
     "placeholders": {
-      "lockHeight": {
+      "hours": {
         "type": "String",
-        "example": "140659"
+        "example": "42"
       }
     }
   },
-  "funds_over_limit_dialog_redeem_hours": "Você poderá resgatar seus fundos após o bloco {lockHeight} (aproximadamente em {hoursToUnlock} horas).",
+  "funds_over_limit_dialog_redeem_hours": "Você poderá resgatar seus fundos após o bloco {lockHeight} {hoursToUnlock}.",
   "@funds_over_limit_dialog_redeem_hours": {
     "placeholders": {
       "lockHeight": {
@@ -964,7 +965,7 @@
       },
       "hoursToUnlock": {
         "type": "String",
-        "example": "7"
+        "example": "(aproximadamente em 42 horas)"
       }
     }
   },

--- a/lib/routes/funds_over_limit_dialog.dart
+++ b/lib/routes/funds_over_limit_dialog.dart
@@ -99,19 +99,14 @@ class SwapRefundDialogState extends State<SwapRefundDialog> {
       reason = texts.funds_over_limit_dialog_transfer_fail_no_reason_know;
     }
 
-    int roundedHoursToUnlock = hoursToUnlock.round();
     List<TextSpan> redeemText = <TextSpan>[];
     if (hoursToUnlock > 0) {
       redeemText.add(
         TextSpan(
-          text: roundedHoursToUnlock > 1
-              ? texts.funds_over_limit_dialog_redeem_hours(
-                  lockHeight.toString(),
-                  '${hoursToUnlock.ceil()}',
-                )
-              : texts.funds_over_limit_dialog_redeem_hour(
-                  lockHeight.toString(),
-                ),
+          text: texts.funds_over_limit_dialog_redeem_hours(
+            lockHeight.toString(),
+            _getHoursToUnlockString(hoursToUnlock),
+          ),
           style: themeData.dialogTheme.contentTextStyle,
         ),
       );
@@ -146,5 +141,13 @@ class SwapRefundDialogState extends State<SwapRefundDialog> {
         children: redeemText,
       ),
     );
+  }
+
+  String _getHoursToUnlockString(double hoursToUnlock) {
+    final texts = AppLocalizations.of(context);
+    int roundedValue = hoursToUnlock.ceil();
+    if (roundedValue <= 0) return '';
+    if (roundedValue <= 1) return texts.approximately_an_hour;
+    return texts.approximate_hours(roundedValue.toString());
   }
 }


### PR DESCRIPTION
 - Added approximately_an_hour and approximate_hours texts to help with pre-formatting hoursToUnlock string and removed funds_over_limit_dialog_redeem_hour text. 
- funds_over_limit_dialog_redeem_hours now uses pre-formatted hoursToUnlock string.