### PR TITLE
Update dependencies fixing date NPE on some podcast episodes

### DIFF
--- a/lib/routes/podcast/podcast_index_api.dart
+++ b/lib/routes/podcast/podcast_index_api.dart
@@ -46,14 +46,16 @@ class PodcastIndexAPI extends PodcastApi {
   }
 
   static Future<SearchResult> _search(String term) {
-    return Search(userAgent: Environment.userAgent())
-        .search(
-          term,
-          queryParams: {"val": "lightning"},
+    return Search(
+          userAgent: Environment.userAgent(),
           searchProvider: PodcastIndexProvider(
             key: 'XXWQEGULBJABVHZUM8NF',
             secret: 'KZ2uy4upvq4t3e\$m\$3r2TeFS2fEpFTAaF92xcNdX',
           ),
+        )
+        .search(
+          term,
+          queryParams: {"val": "lightning"},
         )
         .timeout(Duration(seconds: 10));
   }
@@ -61,11 +63,11 @@ class PodcastIndexAPI extends PodcastApi {
   static Future<SearchResult> _charts(int size) {
     return Search(
       userAgent: Environment.userAgent(),
-    ).charts(
       searchProvider: PodcastIndexProvider(
         key: 'NBVJ9GPWMLPXJMFFD3KV',
         secret: 'be7kR2CWeCFk4nkKCKV4XAX35y2eXrDeCPvs#v4F',
       ),
+    ).charts(
       queryParams: {
         'val': 'lightning',
         'aponly': 'true',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -19,8 +19,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: a682f1bceb73ce676067385ba10e42b383f94391
-      resolved-ref: a682f1bceb73ce676067385ba10e42b383f94391
+      ref: "4373ff9a9bc6d006729f80f34a1dd9cd72b0722b"
+      resolved-ref: "4373ff9a9bc6d006729f80f34a1dd9cd72b0722b"
       url: "https://github.com/breez/anytime_podcast_player.git"
     source: git
     version: "1.1.65"
@@ -58,7 +58,7 @@ packages:
       name: audio_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.18.4"
+    version: "0.18.6"
   audio_service_platform_interface:
     dependency: transitive
     description:
@@ -79,7 +79,7 @@ packages:
       name: audio_session
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.7"
+    version: "0.1.8"
   auto_size_text:
     dependency: "direct main"
     description:
@@ -233,7 +233,7 @@ packages:
       name: connectivity_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.4"
+    version: "2.3.5"
   connectivity_plus_linux:
     dependency: transitive
     description:
@@ -247,7 +247,7 @@ packages:
       name: connectivity_plus_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.3"
+    version: "1.2.4"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -322,8 +322,8 @@ packages:
     dependency: transitive
     description:
       path: "."
-      ref: "42ee70e"
-      resolved-ref: "42ee70e3ce549a4f71032ebe078fd3b1167195db"
+      ref: f58e8efa745e0dc2e14e63717c755ccd57c3fe43
+      resolved-ref: f58e8efa745e0dc2e14e63717c755ccd57c3fe43
       url: "https://github.com/breez/dart-rss"
     source: git
     version: "2.0.1"
@@ -459,77 +459,77 @@ packages:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.4.1"
+    version: "4.4.3"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.5"
+    version: "1.6.6"
   firebase_database:
     dependency: "direct main"
     description:
       name: firebase_database
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.0.16"
+    version: "9.0.18"
   firebase_database_platform_interface:
     dependency: transitive
     description:
       name: firebase_database_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1+8"
+    version: "0.2.1+10"
   firebase_database_web:
     dependency: transitive
     description:
       name: firebase_database_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0+15"
+    version: "0.2.0+17"
   firebase_dynamic_links:
     dependency: "direct main"
     description:
       name: firebase_dynamic_links
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.6"
+    version: "4.3.1"
   firebase_dynamic_links_platform_interface:
     dependency: transitive
     description:
       name: firebase_dynamic_links_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3+4"
+    version: "0.2.3+6"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "11.4.2"
+    version: "11.4.4"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.2"
+    version: "3.5.4"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.4"
   fixnum:
     dependency: transitive
     description:
@@ -903,14 +903,14 @@ packages:
       name: just_audio
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.24"
+    version: "0.9.27"
   just_audio_platform_interface:
     dependency: transitive
     description:
       name: just_audio_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.0"
   just_audio_web:
     dependency: transitive
     description:
@@ -1206,11 +1206,11 @@ packages:
     dependency: "direct overridden"
     description:
       path: "."
-      ref: e5edaea
-      resolved-ref: e5edaea59e85d45464492afb60ce2e8685b34b00
+      ref: "13bc13bda6432d53905b7b72217b810c5f2db92e"
+      resolved-ref: "13bc13bda6432d53905b7b72217b810c5f2db92e"
       url: "https://github.com/breez/podcast_search.git"
     source: git
-    version: "0.4.2"
+    version: "0.5.1"
   pointycastle:
     dependency: transitive
     description:
@@ -1534,7 +1534,7 @@ packages:
       name: sqflite_common_ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.1+1"
   sqlite3:
     dependency: transitive
     description:
@@ -1660,7 +1660,7 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.3"
+    version: "6.1.4"
   url_launcher_android:
     dependency: transitive
     description:
@@ -1779,7 +1779,7 @@ packages:
       name: webview_flutter_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.11"
+    version: "2.8.14"
   webview_flutter_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,7 +75,7 @@ dependencies:
   anytime:
     git:
       url: https://github.com/breez/anytime_podcast_player.git
-      ref: a682f1bceb73ce676067385ba10e42b383f94391
+      ref: 4373ff9a9bc6d006729f80f34a1dd9cd72b0722b
   flutter_typeahead:
     git:
       url: https://github.com/breez/flutter_typeahead.git
@@ -100,7 +100,7 @@ dependency_overrides:
   podcast_search:
     git:
       url: https://github.com/breez/podcast_search.git
-      ref: e5edaea
+      ref: 13bc13bda6432d53905b7b72217b810c5f2db92e
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Some podcast episodes use a non-standard date format.

e.g. `Podcasting 4 Value` episode 1 uses the expected format `<pubDate>Mon, 17 Jan 2022 04:02:29 -0700</pubDate>` but episode 16 doesn't `<pubDate>20 June 2022 15:12:29 -0700</pubDate>` as you can see it is missing the day of the week in the beginning.

so what I did:

- I did add this pattern to the parser: https://github.com/breez/podcast_search/commit/13bc13bda6432d53905b7b72217b810c5f2db92e so now that pattern without the day of the week is supported
- I did add a check and a warning for whenever a similar problem happens in the future so the app will ignore the date and log a warning so we can implement that specific date pattern later. https://github.com/breez/anytime_podcast_player/commit/4373ff9a9bc6d006729f80f34a1dd9cd72b0722b

# Result

|Before|After|
|---|---|
|![Screenshot_2022-07-03-22-24-12-22_73a31df444cba46df764485ac1a8c3ef](https://user-images.githubusercontent.com/1225438/177184716-ea20f2ef-70ee-4719-a62a-a128c376276e.jpeg)|![Screenshot_20220704-122900_Breez Debug](https://user-images.githubusercontent.com/1225438/177184727-0653824c-203f-4d34-94e8-8c41a6ff9731.jpg)|

