### PR TITLE
Update QR code scanner plugin

### DIFF
--- a/lib/routes/qr_scan.dart
+++ b/lib/routes/qr_scan.dart
@@ -1,13 +1,13 @@
-import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:qr_code_scanner/qr_code_scanner.dart';
-import 'package:qr_code_tools/qr_code_tools.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:scan/scan.dart';
+
+import '../widgets/scan_overlay.dart';
 
 class QRScan extends StatefulWidget {
   @override
@@ -17,122 +17,166 @@ class QRScan extends StatefulWidget {
 }
 
 class QRScanState extends State<QRScan> {
-  final qrKey = GlobalKey(debugLabel: 'QR');
-  QRViewController controller;
+  final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
+  MobileScannerController cameraController = MobileScannerController(
+    facing: CameraFacing.back,
+    torchEnabled: false,
+  );
 
   @override
   Widget build(BuildContext context) {
-    final texts = AppLocalizations.of(context);
-
-    return Material(
-      child: Stack(
+    return Scaffold(
+      body: Stack(
         children: [
-          Positioned(
-            left: 0,
-            right: 0,
-            bottom: 0.0,
-            top: 0.0,
-            child: Column(
-              children: [
-                Expanded(
-                  flex: 5,
-                  child: QRView(
-                    key: qrKey,
-                    onQRViewCreated: _onQRViewCreated,
-                    overlay: QrScannerOverlayShape(
-                      borderColor: Colors.white,
-                      borderRadius: 10,
-                      borderLength: 30,
-                      borderWidth: 10,
-                      cutOutSize: 300,
-                    ),
-                  ),
-                )
-              ],
+          buildScanner(context),
+          buildImagePicker(),
+          buildCancelButton(context),
+          const ScanOverlay(),
+        ],
+      ),
+    );
+  }
+
+  Positioned buildScanner(BuildContext context) {
+    return Positioned(
+      left: 0,
+      right: 0,
+      bottom: 0.0,
+      top: 0.0,
+      child: Column(
+        children: <Widget>[
+          Expanded(
+            flex: 5,
+            child: MobileScanner(
+              key: qrKey,
+              allowDuplicates: false,
+              controller: cameraController,
+              onDetect: (barcode, args) {
+                if (barcode.rawValue == null) {
+                  debugPrint('Failed to scan QR code.');
+                } else {
+                  final String code = barcode.rawValue;
+                  Navigator.of(context).pop(code);
+                }
+              },
             ),
-          ),
-          Positioned(
-            right: 10,
-            top: 5,
-            child: Container(
-              child: IconButton(
-                padding: const EdgeInsets.fromLTRB(0, 32, 24, 0),
-                icon: SvgPicture.asset(
-                  "src/icon/image.svg",
-                  color: Colors.white,
-                  width: 32,
-                  height: 32,
-                ),
-                onPressed: () async {
-                  final _picker = ImagePicker();
-                  XFile pickedFile = await _picker
-                      .pickImage(source: ImageSource.gallery)
-                      .catchError((err) {});
-                  final File file = File(pickedFile.path);
-                  try {
-                    if (file == null) {
-                      return;
-                    }
-                    String data = await QrCodeToolsPlugin.decodeFrom(file.path);
-                    Navigator.of(context).pop(data);
-                  } catch (e) {}
-                },
-              ),
-            ),
-          ),
-          Positioned(
-            bottom: 30.0,
-            right: 0,
-            left: 0,
-            child: defaultTargetPlatform == TargetPlatform.iOS
-                ? Center(
-                    child: Container(
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.all(
-                          const Radius.circular(12.0),
-                        ),
-                        border: Border.all(
-                          color: Colors.white.withOpacity(0.8),
-                        ),
-                      ),
-                      child: TextButton(
-                        style: TextButton.styleFrom(
-                          padding: const EdgeInsets.only(right: 35, left: 35),
-                        ),
-                        onPressed: () => Navigator.of(context).pop(),
-                        child: Text(
-                          texts.qr_scan_action_cancel,
-                          style: TextStyle(
-                            color: Colors.white,
-                          ),
-                        ),
-                      ),
-                    ),
-                  )
-                : SizedBox(),
           )
         ],
       ),
     );
   }
 
-  @override
-  void dispose() {
-    if (defaultTargetPlatform == TargetPlatform.iOS) {
-      this.controller?.pauseCamera();
-    }
-    this.controller?.dispose();
-    super.dispose();
+  Positioned buildImagePicker() {
+    return Positioned(
+      right: 10,
+      top: 5,
+      child: IconButton(
+        padding: const EdgeInsets.fromLTRB(0, 32, 24, 0),
+        icon: SvgPicture.asset(
+          "src/icon/image.svg",
+          color: Colors.white,
+          width: 32,
+          height: 32,
+        ),
+        onPressed: () async {
+          final picker = ImagePicker();
+          XFile pickedFile = await picker
+              .pickImage(source: ImageSource.gallery)
+              .catchError((err) {});
+          final File file = File(pickedFile.path);
+          try {
+            String data = await Scan.parse(file.path);
+            if (!mounted) return;
+            Navigator.of(context).pop(data);
+          } catch (_) {}
+        },
+      ),
+    );
   }
 
-  void _onQRViewCreated(QRViewController controller) {
-    this.controller = controller;
-    StreamSubscription sub;
-    sub = controller.scannedDataStream.listen((scanData) async {
-      if (scanData.code?.isNotEmpty == true) {
-        await sub.cancel();
-        Navigator.of(context).pop(scanData.code);
-      }
-    });
+  /*
+  Positioned buildSwitchCameraButton() {
+    return Positioned(
+      right: 32,
+      bottom: 96,
+      child: IconButton(
+        color: Colors.white,
+        icon: ValueListenableBuilder(
+          valueListenable: cameraController.cameraFacingState,
+          builder: (context, state, child) {
+            switch (state as CameraFacing) {
+              case CameraFacing.front:
+                return const Icon(Icons.camera_rear_outlined);
+              case CameraFacing.back:
+                return const Icon(Icons.camera_front_outlined);
+            }
+          },
+        ),
+        iconSize: 32.0,
+        onPressed: () => cameraController.switchCamera(),
+      ),
+    );
+  }
+
+  Positioned buildToggleFlashButton() {
+    return Positioned(
+      left: 32,
+      bottom: 96,
+      child: ValueListenableBuilder(
+        valueListenable: cameraController.cameraFacingState,
+        builder: (context, state, child) {
+          switch (state as CameraFacing) {
+            case CameraFacing.front:
+              return const SizedBox();
+            case CameraFacing.back:
+              return IconButton(
+                color: Colors.white,
+                icon: ValueListenableBuilder(
+                  valueListenable: cameraController.torchState,
+                  builder: (context, state, child) {
+                    switch (state as TorchState) {
+                      case TorchState.off:
+                        return const Icon(Icons.flash_on_outlined);
+                      case TorchState.on:
+                        return const Icon(Icons.flash_off_outlined);
+                    }
+                  },
+                ),
+                iconSize: 32.0,
+                onPressed: () => cameraController.toggleTorch(),
+              );
+          }
+        },
+      ),
+    );
+  }
+  */
+
+  Positioned buildCancelButton(BuildContext context) {
+    return Positioned(
+      bottom: 30.0,
+      right: 0,
+      left: 0,
+      child: defaultTargetPlatform == TargetPlatform.iOS
+          ? Center(
+              child: Container(
+                decoration: BoxDecoration(
+                    borderRadius: const BorderRadius.all(Radius.circular(12.0)),
+                    border: Border.all(color: Colors.white.withOpacity(0.8))),
+                child: TextButton(
+                    style: TextButton.styleFrom(
+                      padding: const EdgeInsets.only(right: 35, left: 35),
+                    ),
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                    },
+                    child: const Text(
+                      "CANCEL",
+                      style: TextStyle(color: Colors.white),
+                    )),
+              ),
+            )
+          : const SizedBox(),
+    );
   }
 }

--- a/lib/routes/qr_scan.dart
+++ b/lib/routes/qr_scan.dart
@@ -73,63 +73,6 @@ class QRScanState extends State<QRScan> {
       ),
     );
   }
-  /*
-  Positioned buildSwitchCameraButton() {
-    return Positioned(
-      right: 32,
-      bottom: 96,
-      child: IconButton(
-        color: Colors.white,
-        icon: ValueListenableBuilder(
-          valueListenable: cameraController.cameraFacingState,
-          builder: (context, state, child) {
-            switch (state as CameraFacing) {
-              case CameraFacing.front:
-                return const Icon(Icons.camera_rear_outlined);
-              case CameraFacing.back:
-                return const Icon(Icons.camera_front_outlined);
-            }
-          },
-        ),
-        iconSize: 32.0,
-        onPressed: () => cameraController.switchCamera(),
-      ),
-    );
-  }
-
-  Positioned buildToggleFlashButton() {
-    return Positioned(
-      left: 32,
-      bottom: 96,
-      child: ValueListenableBuilder(
-        valueListenable: cameraController.cameraFacingState,
-        builder: (context, state, child) {
-          switch (state as CameraFacing) {
-            case CameraFacing.front:
-              return const SizedBox();
-            case CameraFacing.back:
-              return IconButton(
-                color: Colors.white,
-                icon: ValueListenableBuilder(
-                  valueListenable: cameraController.torchState,
-                  builder: (context, state, child) {
-                    switch (state as TorchState) {
-                      case TorchState.off:
-                        return const Icon(Icons.flash_on_outlined);
-                      case TorchState.on:
-                        return const Icon(Icons.flash_off_outlined);
-                    }
-                  },
-                ),
-                iconSize: 32.0,
-                onPressed: () => cameraController.toggleTorch(),
-              );
-          }
-        },
-      ),
-    );
-  }
-  */
 }
 
 class ImagePickerButton extends StatelessWidget {

--- a/lib/routes/qr_scan.dart
+++ b/lib/routes/qr_scan.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
@@ -168,6 +169,8 @@ class QRScanCancelButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final texts = AppLocalizations.of(context);
+
     return Center(
       child: Container(
         decoration: BoxDecoration(
@@ -180,8 +183,8 @@ class QRScanCancelButton extends StatelessWidget {
             onPressed: () {
               Navigator.of(context).pop();
             },
-            child: const Text(
-              "CANCEL",
+            child: Text(
+              texts.qr_scan_action_cancel,
               style: TextStyle(color: Colors.white),
             )),
       ),

--- a/lib/routes/qr_scan.dart
+++ b/lib/routes/qr_scan.dart
@@ -28,72 +28,50 @@ class QRScanState extends State<QRScan> {
     return Scaffold(
       body: Stack(
         children: [
-          buildScanner(context),
-          buildImagePicker(),
-          buildCancelButton(context),
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0.0,
+            top: 0.0,
+            child: Column(
+              children: <Widget>[
+                Expanded(
+                  flex: 5,
+                  child: MobileScanner(
+                    key: qrKey,
+                    allowDuplicates: false,
+                    controller: cameraController,
+                    onDetect: (barcode, args) {
+                      if (barcode.rawValue == null) {
+                        debugPrint('Failed to scan QR code.');
+                      } else {
+                        final String code = barcode.rawValue;
+                        Navigator.of(context).pop(code);
+                      }
+                    },
+                  ),
+                )
+              ],
+            ),
+          ),
+          Positioned(
+            right: 10,
+            top: 5,
+            child: const ImagePickerButton(),
+          ),
+          Positioned(
+            bottom: 30.0,
+            right: 0,
+            left: 0,
+            child: defaultTargetPlatform == TargetPlatform.iOS
+                ? const QRScanCancelButton()
+                : const SizedBox(),
+          ),
           const ScanOverlay(),
         ],
       ),
     );
   }
-
-  Positioned buildScanner(BuildContext context) {
-    return Positioned(
-      left: 0,
-      right: 0,
-      bottom: 0.0,
-      top: 0.0,
-      child: Column(
-        children: <Widget>[
-          Expanded(
-            flex: 5,
-            child: MobileScanner(
-              key: qrKey,
-              allowDuplicates: false,
-              controller: cameraController,
-              onDetect: (barcode, args) {
-                if (barcode.rawValue == null) {
-                  debugPrint('Failed to scan QR code.');
-                } else {
-                  final String code = barcode.rawValue;
-                  Navigator.of(context).pop(code);
-                }
-              },
-            ),
-          )
-        ],
-      ),
-    );
-  }
-
-  Positioned buildImagePicker() {
-    return Positioned(
-      right: 10,
-      top: 5,
-      child: IconButton(
-        padding: const EdgeInsets.fromLTRB(0, 32, 24, 0),
-        icon: SvgPicture.asset(
-          "src/icon/image.svg",
-          color: Colors.white,
-          width: 32,
-          height: 32,
-        ),
-        onPressed: () async {
-          final picker = ImagePicker();
-          XFile pickedFile = await picker
-              .pickImage(source: ImageSource.gallery)
-              .catchError((err) {});
-          final File file = File(pickedFile.path);
-          try {
-            String data = await Scan.parse(file.path);
-            if (!mounted) return;
-            Navigator.of(context).pop(data);
-          } catch (_) {}
-        },
-      ),
-    );
-  }
-
   /*
   Positioned buildSwitchCameraButton() {
     return Positioned(
@@ -151,32 +129,62 @@ class QRScanState extends State<QRScan> {
     );
   }
   */
+}
 
-  Positioned buildCancelButton(BuildContext context) {
-    return Positioned(
-      bottom: 30.0,
-      right: 0,
-      left: 0,
-      child: defaultTargetPlatform == TargetPlatform.iOS
-          ? Center(
-              child: Container(
-                decoration: BoxDecoration(
-                    borderRadius: const BorderRadius.all(Radius.circular(12.0)),
-                    border: Border.all(color: Colors.white.withOpacity(0.8))),
-                child: TextButton(
-                    style: TextButton.styleFrom(
-                      padding: const EdgeInsets.only(right: 35, left: 35),
-                    ),
-                    onPressed: () {
-                      Navigator.of(context).pop();
-                    },
-                    child: const Text(
-                      "CANCEL",
-                      style: TextStyle(color: Colors.white),
-                    )),
-              ),
-            )
-          : const SizedBox(),
+class ImagePickerButton extends StatelessWidget {
+  const ImagePickerButton({
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      padding: const EdgeInsets.fromLTRB(0, 32, 24, 0),
+      icon: SvgPicture.asset(
+        "src/icon/image.svg",
+        color: Colors.white,
+        width: 32,
+        height: 32,
+      ),
+      onPressed: () async {
+        final picker = ImagePicker();
+        XFile pickedFile = await picker
+            .pickImage(source: ImageSource.gallery)
+            .catchError((err) {});
+        final File file = File(pickedFile.path);
+        try {
+          String data = await Scan.parse(file.path);
+          Navigator.of(context).pop(data);
+        } catch (_) {}
+      },
+    );
+  }
+}
+
+class QRScanCancelButton extends StatelessWidget {
+  const QRScanCancelButton({
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        decoration: BoxDecoration(
+            borderRadius: const BorderRadius.all(Radius.circular(12.0)),
+            border: Border.all(color: Colors.white.withOpacity(0.8))),
+        child: TextButton(
+            style: TextButton.styleFrom(
+              padding: const EdgeInsets.only(right: 35, left: 35),
+            ),
+            onPressed: () {
+              Navigator.of(context).pop();
+            },
+            child: const Text(
+              "CANCEL",
+              style: TextStyle(color: Colors.white),
+            )),
+      ),
     );
   }
 }

--- a/lib/widgets/scan_overlay.dart
+++ b/lib/widgets/scan_overlay.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+class ScanOverlay extends StatelessWidget {
+  const ScanOverlay({
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: CustomPaint(
+        painter: BorderPainter(),
+        child: SizedBox(
+          width: MediaQuery.of(context).size.width - 72,
+          height: MediaQuery.of(context).size.width - 72,
+        ),
+      ),
+    );
+  }
+}
+
+class BorderPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    const width = 4.0;
+    const radius = 16.0;
+    const tRadius = 2 * radius;
+    final rect = Rect.fromLTWH(
+      width,
+      width,
+      size.width - 2 * width,
+      size.height - 2 * width,
+    );
+    final rrect = RRect.fromRectAndRadius(rect, const Radius.circular(radius));
+    const clippingRect0 = Rect.fromLTWH(
+      0,
+      0,
+      tRadius,
+      tRadius,
+    );
+    final clippingRect1 = Rect.fromLTWH(
+      size.width - tRadius,
+      0,
+      tRadius,
+      tRadius,
+    );
+    final clippingRect2 = Rect.fromLTWH(
+      0,
+      size.height - tRadius,
+      tRadius,
+      tRadius,
+    );
+    final clippingRect3 = Rect.fromLTWH(
+      size.width - tRadius,
+      size.height - tRadius,
+      tRadius,
+      tRadius,
+    );
+
+    final path = Path()
+      ..addRect(clippingRect0)
+      ..addRect(clippingRect1)
+      ..addRect(clippingRect2)
+      ..addRect(clippingRect3);
+
+    canvas.clipPath(path);
+    canvas.drawRRect(
+      rrect,
+      Paint()
+        ..color = Colors.white
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = width,
+    );
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) {
+    return false;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1011,6 +1011,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  mobile_scanner:
+    dependency: "direct main"
+    description:
+      name: mobile_scanner
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   mockito:
     dependency: "direct dev"
     description:
@@ -1337,20 +1344,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
-  qr_code_scanner:
-    dependency: "direct main"
-    description:
-      name: qr_code_scanner
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
-  qr_code_tools:
-    dependency: "direct main"
-    description:
-      name: qr_code_tools
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.7"
   qr_flutter:
     dependency: "direct main"
     description:
@@ -1374,6 +1367,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.27.5"
+  scan:
+    dependency: "direct main"
+    description:
+      name: scan
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.6.0"
   screenshot:
     dependency: "direct main"
     description:
@@ -1849,7 +1849,7 @@ packages:
       name: webview_flutter_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.14"
+    version: "2.9.0"
   webview_flutter_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,8 +51,8 @@ dependencies:
   path_provider: ^2.0.11
   printing: ^5.9.1
   protobuf: ^2.1.0
-  qr_code_scanner: ^1.0.0
-  qr_code_tools: ^0.0.7
+  mobile_scanner: ^2.0.0
+  scan: ^1.6.0
   # qr_flutter has already fixed the build issue with the qr package but did not publish an updated
   # version, they will publish as 4.0.1 for now they recommend to use the master but instead of that
   # we are using an specific commit to avoid unexpected behaviour in future builds.
@@ -136,7 +136,6 @@ flutter:
     - src/pos-icons/
     - assets/images/
     - assets/icons/
-    - assets/icons/layout/
 
   fonts:
     - family: IBMPlexSans


### PR DESCRIPTION
qr_code_scanner isn't working as expected after Flutter 3.0.x update, it requires going into Gallery and returning back to QR screen to start scanning. This is likely a render order/state management issue but I think this is a great opportunity to upgrade [qr_code_scanner](https://pub.dev/packages/qr_code_scanner) that's in maintenance only mode to [mobile_scanner](https://pub.dev/packages/mobile_scanner) by the same author.
- qr_code_scanner's underlying frameworks are no longer maintained,
  - Replaced qr_code_scanner with mobile_scanner, that uses the latest version of MLKit for detecting barcodes and QR codes
  - Created a ScanOverlay widget to match overlay behavior of qr_code_scanner
  - Replaced helper methods with Widgets