### PR TITLE
Fix player control alignment

### DIFF
--- a/lib/routes/podcast/transport_controls.dart
+++ b/lib/routes/podcast/transport_controls.dart
@@ -149,14 +149,17 @@ class _PlayerTransportControlsState extends State<PlayerTransportControls>
               ),
             ),
             Expanded(flex: 1, child: Container()),
-            SpeedSelectorWidget(
-              onChanged: (double value) {
-                print('Speed callback of $value');
-                audioBloc.playbackSpeed(value);
-              },
+            // Speed selector uses 16-37 as width so we use a container with
+            // the maximum size and centers it to proper alignment
+            Container(
+              width: 37,
+              child: Center(
+                child: SpeedSelectorWidget(
+                  onChanged: (value) => audioBloc.playbackSpeed(value),
+                ),
+              ),
             ),
             Expanded(flex: 1, child: Container()),
-            SizedBox(width: 22.0, height: 0.0),
           ],
         );
       },


### PR DESCRIPTION
The recent changes on Anytime broken the alignment as the `SpeedSelectorWidget` changes its width depending on the speed selected, this PR fixes it. Solves https://github.com/breez/breez-issues/issues/7

|1x|2.25x|
|---|---|
|![1x](https://user-images.githubusercontent.com/1225438/183434011-d949772e-587f-44bf-ac6b-9357465f1066.png)|![2 25x](https://user-images.githubusercontent.com/1225438/183433997-a2a09661-5f72-486d-8d72-8fae902c3d4d.png)|


