### PR TITLE
Fix crash when cam reads multiple QR codes

### DIFF
--- a/lib/routes/qr_scan.dart
+++ b/lib/routes/qr_scan.dart
@@ -19,6 +19,7 @@ class QRScan extends StatefulWidget {
 
 class QRScanState extends State<QRScan> {
   final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
+  var popped = false;
   MobileScannerController cameraController = MobileScannerController(
     facing: CameraFacing.back,
     torchEnabled: false,
@@ -43,9 +44,11 @@ class QRScanState extends State<QRScan> {
                     allowDuplicates: false,
                     controller: cameraController,
                     onDetect: (barcode, args) {
+                      if (popped || !mounted) return;
                       if (barcode.rawValue == null) {
                         debugPrint('Failed to scan QR code.');
                       } else {
+                        popped = true;
                         final String code = barcode.rawValue;
                         Navigator.of(context).pop(code);
                       }


### PR DESCRIPTION
Bug reported here: https://t.me/breez_lightning/25654 

The bug happens when a valid QR code is read, but a previous QR code has already consumed and released the widget.