### PR TITLE
13 add locktx info

### DIFF
--- a/lib/bloc/reverse_swap/reverse_swap_model.dart
+++ b/lib/bloc/reverse_swap/reverse_swap_model.dart
@@ -66,19 +66,13 @@ class InProgressReverseSwaps {
 
   InProgressReverseSwaps(this._statuses, this.claimTxId);
 
-  int get lockupTxETA {
-    if (_statuses.paymentsStatus.length == 0) {
-      return -1;
-    }
-    return _statuses.paymentsStatus[0].eta;
-  }
+  int get lockupTxETA => (_statuses.paymentsStatus.isNotEmpty)
+      ? _statuses.paymentsStatus[0].eta
+      : -1;
 
-  String get lockTxID {
-    if (_statuses.paymentsStatus.length == 0) {
-      return "";
-    }
-    return _statuses.paymentsStatus[0].txID;
-  }
+  String get lockTxID => (_statuses.paymentsStatus.isNotEmpty)
+      ? _statuses.paymentsStatus[0].txID
+      : "";
 
   bool get isEmpty => _statuses == null && claimTxId == null;
 }

--- a/lib/bloc/reverse_swap/reverse_swap_model.dart
+++ b/lib/bloc/reverse_swap/reverse_swap_model.dart
@@ -73,5 +73,12 @@ class InProgressReverseSwaps {
     return _statuses.paymentsStatus[0].eta;
   }
 
+  String get lockTxID {
+    if (_statuses.paymentsStatus.length == 0) {
+      return "";
+    }
+    return _statuses.paymentsStatus[0].txID;
+  }
+
   bool get isEmpty => _statuses == null && claimTxId == null;
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -926,7 +926,7 @@
   "withdraw_funds_action_next": "NEXT",
   "swap_in_progress_title": "Send to BTC Address",
   "swap_in_progress_transaction_id_copied": "Transaction ID was copied to your clipboard.",
-  "swap_in_progress_message_waiting_confirmation": "Breez is waiting for your transaction to be confirmed.",
+  "swap_in_progress_message_waiting_confirmation": "Breez is waiting for the following transaction to be confirmed before sending your funds to the specified address.",
   "swap_in_progress_message_processing_previous_request": "Breez is currently processing your previous request. You'll be notified once processing is completed to send your funds to the address you've specified.",
   "market_place_no_vendors": "There are no available vendors at the moment.",
   "account_required_actions_backup": "Backup",

--- a/lib/routes/withdraw_funds/swap_in_progress.dart
+++ b/lib/routes/withdraw_funds/swap_in_progress.dart
@@ -1,7 +1,6 @@
 import 'package:breez/bloc/reverse_swap/reverse_swap_model.dart';
+import 'package:breez/routes/withdraw_funds/tx_widget_with_info_message.dart';
 import 'package:breez/widgets/back_button.dart' as backBtn;
-import 'package:breez/widgets/loader.dart';
-import 'package:breez/widgets/payment_details_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -17,7 +16,6 @@ class SwapInProgress extends StatelessWidget {
   Widget build(BuildContext context) {
     final texts = AppLocalizations.of(context);
     final themeData = Theme.of(context);
-    final txId = swapInProgress.claimTxId ?? swapInProgress.lockTxID;
 
     return Scaffold(
       appBar: AppBar(
@@ -31,31 +29,7 @@ class SwapInProgress extends StatelessWidget {
         ),
         elevation: 0.0,
       ),
-      body: (swapInProgress == null)
-          ? Center(child: Loader())
-          : Column(
-              mainAxisSize: MainAxisSize.max,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Padding(
-                  padding: EdgeInsets.only(top: 50.0, left: 30.0, right: 30.0),
-                  child: Text(
-                    txId.isEmpty
-                        ? texts
-                            .swap_in_progress_message_processing_previous_request
-                        : texts.swap_in_progress_message_waiting_confirmation,
-                    textAlign: TextAlign.center,
-                  ),
-                ),
-                txId.isNotEmpty
-                    ? TxWidget(
-                        txID: txId,
-                        txURL: "https://blockstream.info/tx/$txId",
-                        padding: EdgeInsets.fromLTRB(30.0, 30.0, 30.0, 0.0),
-                      )
-                    : SizedBox(),
-              ],
-            ),
+      body: TxWidgetWithInfoMsg(swapInProgress: swapInProgress),
     );
   }
 }

--- a/lib/routes/withdraw_funds/swap_in_progress.dart
+++ b/lib/routes/withdraw_funds/swap_in_progress.dart
@@ -1,9 +1,7 @@
 import 'package:breez/bloc/reverse_swap/reverse_swap_model.dart';
-import 'package:breez/services/injector.dart';
 import 'package:breez/widgets/back_button.dart' as backBtn;
-import 'package:breez/widgets/flushbar.dart';
-import 'package:breez/widgets/link_launcher.dart';
 import 'package:breez/widgets/loader.dart';
+import 'package:breez/widgets/payment_details_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -58,25 +56,10 @@ class SwapInProgress extends StatelessWidget {
           ),
         ),
         txId.isNotEmpty
-            ? Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(30.0, 30.0, 30.0, 0.0),
-                    child: LinkLauncher(
-                      linkName: txId,
-                      linkAddress: "https://blockstream.info/tx/$txId",
-                      onCopy: () {
-                        ServiceInjector().device.setClipboardText(txId);
-                        showFlushbar(
-                          context,
-                          message: texts.swap_in_progress_transaction_id_copied,
-                          duration: Duration(seconds: 3),
-                        );
-                      },
-                    ),
-                  ),
-                ],
+            ? TxWidget(
+                txID: txId,
+                txURL: "https://blockstream.info/tx/$txId",
+                padding: EdgeInsets.fromLTRB(30.0, 30.0, 30.0, 0.0),
               )
             : SizedBox(),
       ],

--- a/lib/routes/withdraw_funds/swap_in_progress.dart
+++ b/lib/routes/withdraw_funds/swap_in_progress.dart
@@ -17,52 +17,45 @@ class SwapInProgress extends StatelessWidget {
   Widget build(BuildContext context) {
     final texts = AppLocalizations.of(context);
     final themeData = Theme.of(context);
+    final txId = swapInProgress.claimTxId ?? swapInProgress.lockTxID;
 
     return Scaffold(
       appBar: AppBar(
         iconTheme: themeData.appBarTheme.iconTheme,
         textTheme: themeData.appBarTheme.textTheme,
         backgroundColor: themeData.canvasColor,
-        leading: backBtn.BackButton(onPressed: () {
-          Navigator.of(context).pop();
-        }),
+        leading: backBtn.BackButton(),
         title: Text(
           texts.swap_in_progress_title,
           style: themeData.appBarTheme.textTheme.headline6,
         ),
         elevation: 0.0,
       ),
-      body: _body(context),
-    );
-  }
-
-  Widget _body(BuildContext context) {
-    if (swapInProgress == null) return Center(child: Loader());
-
-    final texts = AppLocalizations.of(context);
-    final txId = swapInProgress.claimTxId ?? swapInProgress.lockTxID;
-
-    return Column(
-      mainAxisSize: MainAxisSize.max,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Padding(
-          padding: EdgeInsets.only(top: 50.0, left: 30.0, right: 30.0),
-          child: Text(
-            txId.isEmpty
-                ? texts.swap_in_progress_message_processing_previous_request
-                : texts.swap_in_progress_message_waiting_confirmation,
-            textAlign: TextAlign.center,
-          ),
-        ),
-        txId.isNotEmpty
-            ? TxWidget(
-                txID: txId,
-                txURL: "https://blockstream.info/tx/$txId",
-                padding: EdgeInsets.fromLTRB(30.0, 30.0, 30.0, 0.0),
-              )
-            : SizedBox(),
-      ],
+      body: (swapInProgress == null)
+          ? Center(child: Loader())
+          : Column(
+              mainAxisSize: MainAxisSize.max,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Padding(
+                  padding: EdgeInsets.only(top: 50.0, left: 30.0, right: 30.0),
+                  child: Text(
+                    txId.isEmpty
+                        ? texts
+                            .swap_in_progress_message_processing_previous_request
+                        : texts.swap_in_progress_message_waiting_confirmation,
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                txId.isNotEmpty
+                    ? TxWidget(
+                        txID: txId,
+                        txURL: "https://blockstream.info/tx/$txId",
+                        padding: EdgeInsets.fromLTRB(30.0, 30.0, 30.0, 0.0),
+                      )
+                    : SizedBox(),
+              ],
+            ),
     );
   }
 }

--- a/lib/routes/withdraw_funds/swap_in_progress.dart
+++ b/lib/routes/withdraw_funds/swap_in_progress.dart
@@ -40,7 +40,7 @@ class SwapInProgress extends StatelessWidget {
     if (swapInProgress == null) return Center(child: Loader());
 
     final texts = AppLocalizations.of(context);
-    final txId = swapInProgress.claimTxId;
+    final txId = swapInProgress.claimTxId ?? swapInProgress.lockTxID;
 
     return Column(
       mainAxisSize: MainAxisSize.max,

--- a/lib/routes/withdraw_funds/tx_widget_with_info_message.dart
+++ b/lib/routes/withdraw_funds/tx_widget_with_info_message.dart
@@ -33,13 +33,13 @@ class TxWidgetWithInfoMsg extends StatelessWidget {
                   textAlign: TextAlign.center,
                 ),
               ),
-              txId.isNotEmpty
-                  ? TxWidget(
-                      txID: txId,
-                      txURL: "https://blockstream.info/tx/$txId",
-                      padding: EdgeInsets.fromLTRB(30.0, 30.0, 30.0, 0.0),
-                    )
-                  : SizedBox(),
+              if (txId.isNotEmpty) ...[
+                TxWidget(
+                  txID: txId,
+                  txURL: "https://blockstream.info/tx/$txId",
+                  padding: EdgeInsets.fromLTRB(30.0, 30.0, 30.0, 0.0),
+                )
+              ]
             ],
           );
   }

--- a/lib/routes/withdraw_funds/tx_widget_with_info_message.dart
+++ b/lib/routes/withdraw_funds/tx_widget_with_info_message.dart
@@ -15,7 +15,7 @@ class TxWidgetWithInfoMsg extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final texts = AppLocalizations.of(context);
-    final txId = swapInProgress.claimTxId ?? swapInProgress.lockTxID;
+    final txId = swapInProgress?.claimTxId ?? swapInProgress?.lockTxID;
 
     return (swapInProgress == null)
         ? Center(child: Loader())

--- a/lib/routes/withdraw_funds/tx_widget_with_info_message.dart
+++ b/lib/routes/withdraw_funds/tx_widget_with_info_message.dart
@@ -1,0 +1,46 @@
+import 'package:breez/bloc/reverse_swap/reverse_swap_model.dart';
+import 'package:breez/widgets/loader.dart';
+import 'package:breez/widgets/payment_details_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class TxWidgetWithInfoMsg extends StatelessWidget {
+  const TxWidgetWithInfoMsg({
+    Key key,
+    @required this.swapInProgress,
+  }) : super(key: key);
+
+  final InProgressReverseSwaps swapInProgress;
+
+  @override
+  Widget build(BuildContext context) {
+    final texts = AppLocalizations.of(context);
+    final txId = swapInProgress.claimTxId ?? swapInProgress.lockTxID;
+
+    return (swapInProgress == null)
+        ? Center(child: Loader())
+        : Column(
+            mainAxisSize: MainAxisSize.max,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: EdgeInsets.only(top: 50.0, left: 30.0, right: 30.0),
+                child: Text(
+                  txId.isEmpty
+                      ? texts
+                          .swap_in_progress_message_processing_previous_request
+                      : texts.swap_in_progress_message_waiting_confirmation,
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              txId.isNotEmpty
+                  ? TxWidget(
+                      txID: txId,
+                      txURL: "https://blockstream.info/tx/$txId",
+                      padding: EdgeInsets.fromLTRB(30.0, 30.0, 30.0, 0.0),
+                    )
+                  : SizedBox(),
+            ],
+          );
+  }
+}

--- a/lib/services/breezlib/data/rpc.pb.dart
+++ b/lib/services/breezlib/data/rpc.pb.dart
@@ -3,7 +3,7 @@
 //  source: rpc.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
 import 'dart:core' as $core;
 
@@ -5542,6 +5542,7 @@ class PushNotificationDetails extends $pb.GeneratedMessage {
 class ReverseSwapPaymentStatus extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReverseSwapPaymentStatus', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'hash')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'txID', protoName: 'txID')
     ..a<$core.int>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'eta', $pb.PbFieldType.O3)
     ..hasRequiredFields = false
   ;
@@ -5549,11 +5550,15 @@ class ReverseSwapPaymentStatus extends $pb.GeneratedMessage {
   ReverseSwapPaymentStatus._() : super();
   factory ReverseSwapPaymentStatus({
     $core.String? hash,
+    $core.String? txID,
     $core.int? eta,
   }) {
     final _result = create();
     if (hash != null) {
       _result.hash = hash;
+    }
+    if (txID != null) {
+      _result.txID = txID;
     }
     if (eta != null) {
       _result.eta = eta;
@@ -5590,12 +5595,21 @@ class ReverseSwapPaymentStatus extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   void clearHash() => clearField(1);
 
+  @$pb.TagNumber(2)
+  $core.String get txID => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set txID($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasTxID() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearTxID() => clearField(2);
+
   @$pb.TagNumber(3)
-  $core.int get eta => $_getIZ(1);
+  $core.int get eta => $_getIZ(2);
   @$pb.TagNumber(3)
-  set eta($core.int v) { $_setSignedInt32(1, v); }
+  set eta($core.int v) { $_setSignedInt32(2, v); }
   @$pb.TagNumber(3)
-  $core.bool hasEta() => $_has(1);
+  $core.bool hasEta() => $_has(2);
   @$pb.TagNumber(3)
   void clearEta() => clearField(3);
 }

--- a/lib/services/breezlib/data/rpc.pbenum.dart
+++ b/lib/services/breezlib/data/rpc.pbenum.dart
@@ -3,7 +3,7 @@
 //  source: rpc.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
 // ignore_for_file: UNDEFINED_SHOWN_NAME
 import 'dart:core' as $core;

--- a/lib/services/breezlib/data/rpc.pbgrpc.dart
+++ b/lib/services/breezlib/data/rpc.pbgrpc.dart
@@ -3,7 +3,7 @@
 //  source: rpc.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
 import 'dart:async' as $async;
 

--- a/lib/services/breezlib/data/rpc.pbjson.dart
+++ b/lib/services/breezlib/data/rpc.pbjson.dart
@@ -3,7 +3,7 @@
 //  source: rpc.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
+// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
 import 'dart:core' as $core;
 import 'dart:convert' as $convert;
@@ -957,12 +957,13 @@ const ReverseSwapPaymentStatus$json = const {
   '1': 'ReverseSwapPaymentStatus',
   '2': const [
     const {'1': 'hash', '3': 1, '4': 1, '5': 9, '10': 'hash'},
+    const {'1': 'txID', '3': 2, '4': 1, '5': 9, '10': 'txID'},
     const {'1': 'eta', '3': 3, '4': 1, '5': 5, '10': 'eta'},
   ],
 };
 
 /// Descriptor for `ReverseSwapPaymentStatus`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List reverseSwapPaymentStatusDescriptor = $convert.base64Decode('ChhSZXZlcnNlU3dhcFBheW1lbnRTdGF0dXMSEgoEaGFzaBgBIAEoCVIEaGFzaBIQCgNldGEYAyABKAVSA2V0YQ==');
+final $typed_data.Uint8List reverseSwapPaymentStatusDescriptor = $convert.base64Decode('ChhSZXZlcnNlU3dhcFBheW1lbnRTdGF0dXMSEgoEaGFzaBgBIAEoCVIEaGFzaBISCgR0eElEGAIgASgJUgR0eElEEhAKA2V0YRgDIAEoBVIDZXRh');
 @$core.Deprecated('Use reverseSwapPaymentStatusesDescriptor instead')
 const ReverseSwapPaymentStatuses$json = const {
   '1': 'ReverseSwapPaymentStatuses',

--- a/lib/widgets/payment_details_dialog.dart
+++ b/lib/widgets/payment_details_dialog.dart
@@ -747,12 +747,14 @@ class TxWidget extends StatelessWidget {
   final String txURL;
   final String txID;
   final String txLabel;
+  final EdgeInsets padding;
 
   const TxWidget({
     Key key,
     this.txURL,
     this.txID,
     this.txLabel,
+    this.padding,
   }) : super(key: key);
 
   @override
@@ -770,7 +772,7 @@ class TxWidget extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         Padding(
-          padding: EdgeInsets.only(top: 20.0),
+          padding: padding ?? EdgeInsets.only(top: 20.0),
           child: LinkLauncher(
             linkTitle: txLabel ??
                 texts.payment_details_dialog_transaction_label_default,


### PR DESCRIPTION
This adds lockup transaction information when a user has sent an on chain transaction. 

Have updated the protocol buffer in since I added a new field to breez lib https://github.com/breez/breez/pull/165.  ⚙️ 

Pressing view transaction redirects me to the blockstream.info/tx/ 😃 


![pr_txinfo](https://user-images.githubusercontent.com/36157890/199676599-dfb0722f-f356-4a8c-b96b-633b4b1f4c24.png)
