### PR TITLE
Extract error message on send BTC flow

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -897,6 +897,15 @@
   "reverse_swap_confirmation_error_funds_fee": "You don't have enough funds for this payment network fee.",
   "reverse_swap_notification_title": "Action Required",
   "reverse_swap_notification_body": "Please open Breez to complete your requested transaction.",
+  "reverse_swap_upstream_generic_error_message": "{errorMessage}. Please try again later.",
+  "@reverse_swap_upstream_generic_error_message": {
+    "placeholders": {
+      "errorMessage": {
+        "type": "String",
+        "example": "Failed to retrieve fees"
+      }
+    }
+  },
   "sync_progress_server_ready": "Synchronizing to the network",
   "sync_progress_waiting_network": "Waiting for network",
   "withdraw_funds_error_min_value": "Must be at least {minValue}",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -897,6 +897,15 @@
   "reverse_swap_confirmation_error_funds_fee": "No hay fondos suficientes para pagar la tarifa de pago en la red.",
   "reverse_swap_notification_title": "Acción requerida",
   "reverse_swap_notification_body": "Abra Breez para completar la transacción solicitada.",
+  "reverse_swap_upstream_generic_error_message": "{errorMessage}. Por favor intente de nuevo más tarde.",
+  "@reverse_swap_upstream_generic_error_message": {
+    "placeholders": {
+      "errorMessage": {
+        "type": "String",
+        "example": "Failed to retrieve fees"
+      }
+    }
+  },
   "sync_progress_server_ready": "Sincronizando con la red",
   "sync_progress_waiting_network": "Esperando la red",
   "withdraw_funds_error_min_value": "Debe ser al menos {minValue}",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -897,6 +897,15 @@
   "reverse_swap_confirmation_error_funds_fee": "Varasi eivät riitä tapahtumakulujen maksamiseen.",
   "reverse_swap_notification_title": "Toimenpiteitä tarvitaan",
   "reverse_swap_notification_body": "Avaa Breez käynnistämäsi tapahtuman päättämiseksi.",
+  "reverse_swap_upstream_generic_error_message": "{errorMessage}. Please try again later.",
+  "@reverse_swap_upstream_generic_error_message": {
+    "placeholders": {
+      "errorMessage": {
+        "type": "String",
+        "example": "Failed to retrieve fees"
+      }
+    }
+  },
   "sync_progress_server_ready": "Odota, sovellus synkronoi tietoja",
   "sync_progress_waiting_network": "Odotetaan verkkoyhteyttä",
   "withdraw_funds_error_min_value": "Nostettava minimimäärä on {minValue}",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -897,6 +897,15 @@
   "reverse_swap_confirmation_error_funds_fee": "Vous n'avez pas assez de fonds pour payer ces frais de réseau de paiement.",
   "reverse_swap_notification_title": "Action requise",
   "reverse_swap_notification_body": "Veuillez ouvrir Breez pour effectuer la transaction demandée.",
+  "reverse_swap_upstream_generic_error_message": "{errorMessage}. Please try again later.",
+  "@reverse_swap_upstream_generic_error_message": {
+    "placeholders": {
+      "errorMessage": {
+        "type": "String",
+        "example": "Failed to retrieve fees"
+      }
+    }
+  },
   "sync_progress_server_ready": "Synchronisation avec le réseau",
   "sync_progress_waiting_network": "En attente du réseau",
   "withdraw_funds_error_min_value": "Doit être au moins {minValue}",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -897,6 +897,15 @@
     "reverse_swap_confirmation_error_funds_fee": "Non hai fondi sufficienti per questa commissione di rete.",
     "reverse_swap_notification_title": "Azione richiesta",
     "reverse_swap_notification_body": "Si prega di aprire Breez per completare la transazione richiesta.",
+    "reverse_swap_upstream_generic_error_message": "{errorMessage}. Please try again later.",
+    "@reverse_swap_upstream_generic_error_message": {
+        "placeholders": {
+            "errorMessage": {
+                "type": "String",
+                "example": "Failed to retrieve fees"
+            }
+        }
+    },
     "sync_progress_server_ready": "Sincronizzazione con la rete",
     "sync_progress_waiting_network": "In attesa della rete",
     "withdraw_funds_error_min_value": "Deve essere almeno {minValue}",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -897,6 +897,15 @@
   "reverse_swap_confirmation_error_funds_fee": "Você não possui fundos suficientes para esta taxa da rede de pagamento.",
   "reverse_swap_notification_title": "Ação requerida",
   "reverse_swap_notification_body": "Abra a Breez para concluir a transação solicitada.",
+  "reverse_swap_upstream_generic_error_message": "{errorMessage}. Por favor, tente novamente.",
+  "@reverse_swap_upstream_generic_error_message": {
+    "placeholders": {
+      "errorMessage": {
+        "type": "String",
+        "example": "Failed to retrieve fees"
+      }
+    }
+  },
   "sync_progress_server_ready": "Sincronizando com a rede",
   "sync_progress_waiting_network": "Aguardando a rede",
   "withdraw_funds_error_min_value": "Deve ser pelo menos {minValue}",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -897,6 +897,15 @@
   "reverse_swap_confirmation_error_funds_fee": "Du har inte tillräckligt med pengar för denna nätverksavgift.",
   "reverse_swap_notification_title": "Ååtgärd krävs",
   "reverse_swap_notification_body": "Öppna Breez för att slutföra din begärda transaktion.",
+  "reverse_swap_upstream_generic_error_message": "{errorMessage}. Please try again later.",
+  "@reverse_swap_upstream_generic_error_message": {
+    "placeholders": {
+      "errorMessage": {
+        "type": "String",
+        "example": "Failed to retrieve fees"
+      }
+    }
+  },
   "sync_progress_server_ready": "Synkronisera till nätverket",
   "sync_progress_waiting_network": "Väntar på nätverk",
   "withdraw_funds_error_min_value": "Måste vara minst {minValue}",

--- a/lib/routes/withdraw_funds/reverse_swap_page.dart
+++ b/lib/routes/withdraw_funds/reverse_swap_page.dart
@@ -6,6 +6,7 @@ import 'package:breez/bloc/blocs_provider.dart';
 import 'package:breez/bloc/reverse_swap/reverse_swap_actions.dart';
 import 'package:breez/bloc/reverse_swap/reverse_swap_bloc.dart';
 import 'package:breez/bloc/reverse_swap/reverse_swap_model.dart';
+import 'package:breez/utils/exceptions.dart';
 import 'package:breez/widgets/back_button.dart' as backBtn;
 import 'package:breez/widgets/error_dialog.dart';
 import 'package:breez/widgets/loader.dart';
@@ -92,7 +93,7 @@ class ReverseSwapPageState extends State<ReverseSwapPage> {
     return StreamBuilder<AccountModel>(
       stream: accountBloc.accountStream,
       builder: (context, accSnapshot) {
-        final accountModel = accSnapshot.data;        
+        final accountModel = accSnapshot.data;
 
         return Scaffold(
           appBar: !_policyCompleter.isCompleted ||
@@ -112,12 +113,20 @@ class ReverseSwapPageState extends State<ReverseSwapPage> {
               : null,
           body: FutureBuilder<Object>(
             future: _policyCompleter.future,
-            builder: (context, snapshot) {              
+            builder: (context, snapshot) {
               if (snapshot.error != null) {
                 return Center(
-                  child: Text(
-                    snapshot.error.toString(),
-                    textAlign: TextAlign.center,
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(32, 0, 32, 0),
+                    child: Text(
+                      texts.reverse_swap_upstream_generic_error_message(
+                        extractExceptionMessage(
+                          snapshot.error,
+                          clearTrailingDot: true,
+                        ),
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
                   ),
                 );
               }
@@ -259,7 +268,7 @@ class ReverseSwapPageState extends State<ReverseSwapPage> {
     return swap.future.then((value) {
       Navigator.of(context).pop();
     }).catchError((err) async {
-      await promptError(context, null, Text(err.toString()));
+      await promptError(context, null, Text(extractExceptionMessage(err)));
     });
   }
 }

--- a/lib/utils/exceptions.dart
+++ b/lib/utils/exceptions.dart
@@ -1,7 +1,14 @@
-String extractExceptionMessage(Object exception) {
+String extractExceptionMessage(
+  Object exception, {
+  bool clearTrailingDot = false,
+}) {
   final detailRegex = r'((?<=\"detail\":\")(.*)(?=.*\"}))';
   final nsLocalizedRegex = r'((?<={NSLocalizedDescription=)(.*)(?=}))';
   final lnUrlRegex = r'((?<=LNURL:.)(.*)(?=.method:))';
   final grouped = RegExp('$nsLocalizedRegex|$lnUrlRegex|$detailRegex');
-  return grouped.stringMatch(exception.toString()) ?? exception.toString();
+  var message = grouped.stringMatch(exception.toString()) ?? exception.toString();
+  if (clearTrailingDot) {
+    message = message.replaceAll(RegExp(r'([.!?:])\s*$'), '');
+  }
+  return message;
 }

--- a/test/utils/exceptions_test.dart
+++ b/test/utils/exceptions_test.dart
@@ -3,25 +3,60 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('extractExceptionMessage on known string', () {
-    test('detail message', () {
-      expect(
-        extractExceptionMessage('"lnurlw://sats.pw/withdraw/api/v1/lnurl/5NGw5bvHKudKNDWiaQeAai" does not contain an LNURL : unknown response tag {"detail":"Withdraw link does not exist."} method: fetchLnurl'),
-        'Withdraw link does not exist.',
-      );
-    });
+    for (var clearTrailingDot in [true, false]) {
+      test('detail message (clearTrailingDot=$clearTrailingDot)', () {
+        expect(
+          extractExceptionMessage(
+            '"lnurlw://sats.pw/withdraw/api/v1/lnurl/5NGw5bvHKudKNDWiaQeAai" '
+            'does not contain an LNURL : unknown response tag {"detail":'
+            '"Withdraw link does not exist."} method: fetchLnurl',
+            clearTrailingDot: clearTrailingDot,
+          ),
+          clearTrailingDot ? 'Withdraw link does not exist' : 'Withdraw link does not exist.',
+        );
+      });
 
-    test('nsLocalized message', () {
-      expect(
-        extractExceptionMessage('Error Domain=go Code=1 "Link not working" UserInfo={NSLocalizedDescription=Link not working}'),
-        'Link not working',
-      );
-    });
+      test('nsLocalized message (clearTrailingDot=$clearTrailingDot)', () {
+        expect(
+          extractExceptionMessage(
+            'Error Domain=go Code=1 "Link not working" UserInfo={'
+            'NSLocalizedDescription=Link not working}',
+            clearTrailingDot: clearTrailingDot,
+          ),
+          'Link not working',
+        );
+      });
 
-    test('lnUrl message', () {
-      expect(
-        extractExceptionMessage('"lnurlw://legend.Inbits.com/boltcards/api/v1/scan/redacted?p=60239397C290247187E63D6D341CDF65&c=7D2F283B09C41D8F" does not contain an LNURL: Max daily limit spent. method: fetchLnurl'),
-        'Max daily limit spent.',
-      );
-    });
+      test('nsLocalized message 2 (clearTrailingDot=$clearTrailingDot)', () {
+        expect(
+          extractExceptionMessage(
+            'Error Domain=go Code=1 "getpairs get https://boltz.exchange/api/'
+            'getpairs: Get "https://boltz.exchange/api/getnodes": http: server '
+            'gave HTTP response to HTTPS client" UserInfo={'
+            'NSLocalizedDescription=getpairs get https://boltz.exchange/api/'
+            'getpairs: Get "https://boltz.exchange/api/getnodes": http: server '
+            'gave HTTP response to HTTPS client!}',
+            clearTrailingDot: clearTrailingDot,
+          ),
+          clearTrailingDot
+              ? 'getpairs get https://boltz.exchange/api/getpairs: Get '
+                  '"https://boltz.exchange/api/getnodes": http: server gave '
+                  'HTTP response to HTTPS client'
+              : 'getpairs get https://boltz.exchange/api/getpairs: Get '
+                  '"https://boltz.exchange/api/getnodes": http: server gave '
+                  'HTTP response to HTTPS client!',
+        );
+      });
+
+      test('lnUrl message (clearTrailingDot=$clearTrailingDot)', () {
+        expect(
+          extractExceptionMessage(
+            '"lnurlw://legend.Inbits.com/boltcards/api/v1/scan/redacted?p=60239397C290247187E63D6D341CDF65&c=7D2F283B09C41D8F" does not contain an LNURL: Max daily limit spent. method: fetchLnurl',
+            clearTrailingDot: clearTrailingDot,
+          ),
+          clearTrailingDot ? 'Max daily limit spent' : 'Max daily limit spent.',
+        );
+      });
+    }
   });
 }


### PR DESCRIPTION
Fix the reported bug [add-error-extraction-on-send-btc-flow
//github.com/breez/breezmobile/pull/new/add-error-extraction-on-send-btc-flow](https://t.me/breez_lightning/26414)

I couldn't test on an actual iOS device; the error message already comes without the messy part on Android.

How it looks like, (Not exactly the same error as reported as it is on Android):

![Screenshot_20221205_192740_Breez Debug](https://user-images.githubusercontent.com/1225438/205758113-517ddbb0-085f-465d-861d-ad4b7219d611.png)

