### PR TITLE
display txid first and not claimTxID

### DIFF
--- a/lib/routes/withdraw_funds/tx_widget_with_info_message.dart
+++ b/lib/routes/withdraw_funds/tx_widget_with_info_message.dart
@@ -16,7 +16,7 @@ class TxWidgetWithInfoMsg extends StatelessWidget {
   Widget build(BuildContext context) {
     final texts = AppLocalizations.of(context);
 
-    final txId = swapInProgress.claimTxId ?? swapInProgress.lockTxID;
+    final txId = swapInProgress.lockTxID ?? swapInProgress.claimTxId;
 
     return Column(
       mainAxisSize: MainAxisSize.max,


### PR DESCRIPTION
This pr references a fix to displaying the lockup txID in #995 


Do we even need to display claim txID here ?

