### PR TITLE
remove wait for claimTxID

### DIFF
--- a/lib/bloc/reverse_swap/reverse_swap_bloc.dart
+++ b/lib/bloc/reverse_swap/reverse_swap_bloc.dart
@@ -90,12 +90,14 @@ class ReverseSwapBloc with AsyncActionsHandler {
   }
 
   Future _fetchInProgressSwap(FetchInProgressSwap action) async {
-    String unconfirmedTx =
-        await _breezLib.unconfirmedReverseSwapClaimTransaction();
+    // We will have to see if there are any in flight payments
     ReverseSwapPaymentStatuses payments = await _breezLib.reverseSwapPayments();
-    InProgressReverseSwaps swap = InProgressReverseSwaps(null);
-    if (unconfirmedTx.isNotEmpty && payments.paymentsStatus.length > 0) {
+    InProgressReverseSwaps swap;
+    // If there are any in flight payments we display the txid to the user.
+    if (payments.paymentsStatus.length > 0) {
       swap = InProgressReverseSwaps(payments);
+    } else {
+      swap = InProgressReverseSwaps(null);
     }
     _swapsInProgressController.add(swap);
     action.resolve(swap);

--- a/lib/bloc/reverse_swap/reverse_swap_bloc.dart
+++ b/lib/bloc/reverse_swap/reverse_swap_bloc.dart
@@ -93,9 +93,9 @@ class ReverseSwapBloc with AsyncActionsHandler {
     String unconfirmedTx =
         await _breezLib.unconfirmedReverseSwapClaimTransaction();
     ReverseSwapPaymentStatuses payments = await _breezLib.reverseSwapPayments();
-    InProgressReverseSwaps swap = InProgressReverseSwaps(null, null);
-    if (unconfirmedTx.isNotEmpty || payments.paymentsStatus.length > 0) {
-      swap = InProgressReverseSwaps(payments, unconfirmedTx);
+    InProgressReverseSwaps swap = InProgressReverseSwaps(null);
+    if (unconfirmedTx.isNotEmpty && payments.paymentsStatus.length > 0) {
+      swap = InProgressReverseSwaps(payments);
     }
     _swapsInProgressController.add(swap);
     action.resolve(swap);

--- a/lib/bloc/reverse_swap/reverse_swap_model.dart
+++ b/lib/bloc/reverse_swap/reverse_swap_model.dart
@@ -62,9 +62,8 @@ class ReverseSwapClaimFeeEstimates {
 
 class InProgressReverseSwaps {
   final ReverseSwapPaymentStatuses _statuses;
-  final String claimTxId;
 
-  InProgressReverseSwaps(this._statuses, this.claimTxId);
+  InProgressReverseSwaps(this._statuses);
 
   int get lockupTxETA => (_statuses?.paymentsStatus?.isNotEmpty == true)
       ? _statuses.paymentsStatus[0].eta
@@ -74,5 +73,5 @@ class InProgressReverseSwaps {
       ? _statuses.paymentsStatus[0].txID
       : "";
 
-  bool get isNotEmpty => _statuses != null && claimTxId != null;
+  bool get isNotEmpty => _statuses != null;
 }

--- a/lib/routes/withdraw_funds/tx_widget_with_info_message.dart
+++ b/lib/routes/withdraw_funds/tx_widget_with_info_message.dart
@@ -16,7 +16,7 @@ class TxWidgetWithInfoMsg extends StatelessWidget {
   Widget build(BuildContext context) {
     final texts = AppLocalizations.of(context);
 
-    final txId = swapInProgress.lockTxID ?? swapInProgress.claimTxId;
+    final txId = swapInProgress.lockTxID;
 
     return Column(
       mainAxisSize: MainAxisSize.max,


### PR DESCRIPTION
# About PR
References #1016 
This pr makes it possible to a user to send another onchain transaction once the lockTx is confirmed. 

Usually the user had to wait for the commitment transaction to confirm too.

## Tests
- [x] Tested with two onchain transaction after each other
- [x] Displays the the lockTx