### PR TITLE
Add divider back to network page

### DIFF
--- a/lib/routes/network/network.dart
+++ b/lib/routes/network/network.dart
@@ -6,7 +6,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez/logger.dart';
 import 'package:breez/services/breezlib/breez_bridge.dart';
 import 'package:breez/services/breezlib/data/rpc.pb.dart';
@@ -103,8 +102,8 @@ class NetworkPageState extends State<NetworkPage> {
               child: ListView(
                 scrollDirection: Axis.vertical,
                 children: [
-                  this._data.showTor
-                      ? Padding(
+                  if (this._data.showTor)
+                    Padding(
                           padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
                           child: Row(
                             mainAxisSize: MainAxisSize.max,
@@ -160,8 +159,9 @@ class NetworkPageState extends State<NetworkPage> {
                               ),
                             ],
                           ),
-                        )
-                      : Divider(),
+                        ),
+                  if (this._data.showTor)
+                    Divider(),
                   Padding(
                     padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
                     child: Column(


### PR DESCRIPTION
A regression on the network page was made by removing the divider after the tor switch

![Screenshot_20230120_085020](https://user-images.githubusercontent.com/1225438/213688718-f060e928-e366-4cd2-8d56-c38270cdb85b.png)
