### PR TITLE
Dark theme - Backup regression

### DIFF
--- a/lib/bloc/user_profile/backup_user_preferences.dart
+++ b/lib/bloc/user_profile/backup_user_preferences.dart
@@ -18,7 +18,7 @@ class BackupUserPreferences {
     this.color,
     this.animal, {
     this.image,
-    this.themeId = "BLUE",
+    this.themeId = "DARK",
     this.preferredCurrencies,
     this.cancellationTimeoutValue = 90.0,
     this.businessAddress,
@@ -55,7 +55,7 @@ class BackupUserPreferences {
         color = json['color'],
         animal = json['animal'],
         image = json['image'],
-        themeId = json['themeId'] ?? "BLUE",
+        themeId = json['themeId'] ?? "DARK",
         preferredCurrencies =
             (json['preferredCurrencies'] as List<dynamic>)?.cast<String>() ??
                 <String>['USD', 'EUR', 'GBP', 'JPY'],

--- a/lib/bloc/user_profile/breez_user_model.dart
+++ b/lib/bloc/user_profile/breez_user_model.dart
@@ -43,7 +43,7 @@ class BreezUserModel {
     this.securityModel,
     this.locked,
     this.token = '',
-    this.themeId = "BLUE",
+    this.themeId = "DARK",
     this.registrationRequested = false,
     this.hideBalance = false,
     this.cancellationTimeoutValue = 90.0,
@@ -135,7 +135,7 @@ class BreezUserModel {
             : SecurityModel.fromJson(
                 json['securityModel'],
               ),
-        themeId = json['themeId'] == null ? "BLUE" : json['themeId'],
+        themeId = json['themeId'] == null ? "DARK" : json['themeId'],
         registrationRequested =
             json['registrationRequested'] ?? json['token'] != null,
         hideBalance = json['hideBalance'] ?? false,

--- a/lib/bloc/user_profile/user_profile_bloc.dart
+++ b/lib/bloc/user_profile/user_profile_bloc.dart
@@ -346,9 +346,7 @@ class UserProfileBloc {
   }
 
   void _listenRegistrationRequests(ServiceInjector injector) {
-    _registrationController.stream.listen((request) async {      
-      SharedPreferences preferences = await _preferences;
-      await _saveChanges(preferences, _userStreamController.value.copyWith(themeId: "DARK"));
+    _registrationController.stream.listen((request) async {
       _refreshRegistration(_userStreamController.value);
     });
   }
@@ -368,7 +366,7 @@ class UserProfileBloc {
     } catch (e) {
       _registrationController.addError(e);
     }
-    userToRegister = _userStreamController.value.copyWith(registrationRequested: true);
+    userToRegister = userToRegister.copyWith(registrationRequested: true);
     await _saveChanges(preferences, userToRegister);
   }
 

--- a/lib/routes/initial_walkthrough.dart
+++ b/lib/routes/initial_walkthrough.dart
@@ -11,15 +11,16 @@ import 'package:breez/bloc/user_profile/user_actions.dart';
 import 'package:breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:breez/logger.dart';
 import 'package:breez/theme_data.dart' as theme;
+import 'package:breez/theme_data.dart';
 import 'package:breez/widgets/backup_provider_selection_dialog.dart';
 import 'package:breez/widgets/error_dialog.dart';
 import 'package:breez/widgets/flushbar.dart';
 import 'package:breez/widgets/loader.dart';
 import 'package:breez/widgets/restore_dialog.dart';
 import 'package:breez/widgets/route.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:crypto/crypto.dart';
 import 'package:flutter/material.dart';
-import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:hex/hex.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -295,91 +296,94 @@ class InitialWalkthroughPageState extends State<InitialWalkthroughPage>
     final texts = context.texts();
     final themeData = Theme.of(context);
 
-    return Scaffold(
-      key: _scaffoldKey,
-      body: WillPopScope(
-        onWillPop: _onWillPop,
-        child: Padding(
-          padding: EdgeInsets.only(top: 24.0),
-          child: Stack(
-            children: [
-              Column(
-                children: [
-                  Expanded(
-                    flex: 200,
-                    child: Container(),
-                  ),
-                  Expanded(
-                    flex: 171,
-                    child: AnimatedBuilder(
-                      animation: _animation,
-                      builder: (BuildContext context, Widget child) {
-                        String frame =
-                            _animation.value.toString().padLeft(2, '0');
-                        return Image.asset(
-                          'src/animations/welcome/frame_${frame}_delay-0.04s.png',
-                          gaplessPlayback: true,
-                          fit: BoxFit.cover,
-                        );
-                      },
+    return Theme(
+      data: blueTheme,
+      child: Scaffold(
+        key: _scaffoldKey,
+        body: WillPopScope(
+          onWillPop: _onWillPop,
+          child: Padding(
+            padding: EdgeInsets.only(top: 24.0),
+            child: Stack(
+              children: [
+                Column(
+                  children: [
+                    Expanded(
+                      flex: 200,
+                      child: Container(),
                     ),
-                  ),
-                  Expanded(
-                    flex: 200,
-                    child: Container(),
-                  ),
-                  Expanded(
-                    flex: 48,
-                    child: Padding(
-                      padding: EdgeInsets.only(left: 24, right: 24),
-                      child: AutoSizeText(
-                        texts.initial_walk_through_welcome_message,
-                        textAlign: TextAlign.center,
-                        style: theme.welcomeTextStyle,
+                    Expanded(
+                      flex: 171,
+                      child: AnimatedBuilder(
+                        animation: _animation,
+                        builder: (BuildContext context, Widget child) {
+                          String frame =
+                              _animation.value.toString().padLeft(2, '0');
+                          return Image.asset(
+                            'src/animations/welcome/frame_${frame}_delay-0.04s.png',
+                            gaplessPlayback: true,
+                            fit: BoxFit.cover,
+                          );
+                        },
                       ),
                     ),
-                  ),
-                  Expanded(
-                    flex: 60,
-                    child: Container(),
-                  ),
-                  Container(
-                    height: 48.0,
-                    width: 168.0,
-                    child: ElevatedButton(
-                      style: ElevatedButton.styleFrom(
-                        padding: EdgeInsets.fromLTRB(16, 4, 16, 4),
-                        primary: themeData.buttonColor,
-                        elevation: 0.0,
-                        shape: const StadiumBorder(),
-                      ),
-                      child: Text(
-                        texts.initial_walk_through_lets_breeze,
-                        style: themeData.textTheme.button,
-                      ),
-                      onPressed: () => _letsBreez(context),
+                    Expanded(
+                      flex: 200,
+                      child: Container(),
                     ),
-                  ),
-                  Expanded(
-                    flex: 40,
-                    child: Padding(
-                      padding: EdgeInsets.only(top: 10.0),
-                      child: GestureDetector(
-                        onTap: () => _restoreFromBackup(context),
-                        child: Text(
-                          texts.initial_walk_through_restore_from_backup,
-                          style: theme.restoreLinkStyle,
+                    Expanded(
+                      flex: 48,
+                      child: Padding(
+                        padding: EdgeInsets.only(left: 24, right: 24),
+                        child: AutoSizeText(
+                          texts.initial_walk_through_welcome_message,
+                          textAlign: TextAlign.center,
+                          style: theme.welcomeTextStyle,
                         ),
                       ),
                     ),
-                  ),
-                  Expanded(
-                    flex: 120,
-                    child: Container(),
-                  ),
-                ],
-              ),
-            ],
+                    Expanded(
+                      flex: 60,
+                      child: Container(),
+                    ),
+                    Container(
+                      height: 48.0,
+                      width: 168.0,
+                      child: ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          padding: EdgeInsets.fromLTRB(16, 4, 16, 4),
+                          primary: themeData.buttonColor,
+                          elevation: 0.0,
+                          shape: const StadiumBorder(),
+                        ),
+                        child: Text(
+                          texts.initial_walk_through_lets_breeze,
+                          style: themeData.textTheme.button,
+                        ),
+                        onPressed: () => _letsBreez(context),
+                      ),
+                    ),
+                    Expanded(
+                      flex: 40,
+                      child: Padding(
+                        padding: EdgeInsets.only(top: 10.0),
+                        child: GestureDetector(
+                          onTap: () => _restoreFromBackup(context),
+                          child: Text(
+                            texts.initial_walk_through_restore_from_backup,
+                            style: theme.restoreLinkStyle,
+                          ),
+                        ),
+                      ),
+                    ),
+                    Expanded(
+                      flex: 120,
+                      child: Container(),
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/routes/splash_page.dart
+++ b/lib/routes/splash_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:breez/bloc/user_profile/breez_user_model.dart';
+import 'package:breez/theme_data.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -44,16 +45,22 @@ class SplashPageState extends State<SplashPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-        body: Stack(children: <Widget>[
-      Center(
-        child: Image.asset(
-          'src/images/splash-animation.gif',
-          fit: BoxFit.contain,
-          gaplessPlayback: true,
-          width: MediaQuery.of(context).size.width / 3,
+    return Theme(
+      data: blueTheme,
+      child: Scaffold(
+        body: Stack(
+          children: <Widget>[
+            Center(
+              child: Image.asset(
+                'src/images/splash-animation.gif',
+                fit: BoxFit.contain,
+                gaplessPlayback: true,
+                width: MediaQuery.of(context).size.width / 3,
+              ),
+            ),
+          ],
         ),
       ),
-    ]));
+    );
   }
 }

--- a/lib/theme_data.dart
+++ b/lib/theme_data.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-String themeId = "BLUE";
+String themeId = "DARK";
 
 class CustomData {
   BlendMode loaderColorBlendMode;


### PR DESCRIPTION
Changes in [update theme to dark after initial walkthrough](https://github.com/breez/breezmobile/commit/2a709589918b1540e5fda438f2907d1ef2cde1d8#diff-dc818ab51dfc8f9e518dee3af008fae6a792af8196eb38770bd71005b2608c47R371) 2a709589918b1540e5fda438f2907d1ef2cde1d8 introduced a regression with backup where the restored user model was not being used.

The proposed solution in that commit is implemented;
- Blue theme is forced on initial flow pages
  - Wrapped topmost widget of their build() with Theme using blue theme.
- Default themeID is set to Dark,
- Restored user preferences are being used on restore again.
