### PR TITLE
Revert from /dav to /webdav and error better

### DIFF
--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -187,7 +187,7 @@ class AccountBloc {
 
   void _start() async {
     log.info("Account bloc started");
-    this.torBloc.torConfig = await _startTorIfNeeded();
+    torBloc.torConfig = await _startTorIfNeeded();
     ServiceInjector().sharedPreferences.then((preferences) {
       _handleRegisterDeviceNode();
       _refreshAccountAndPayments();
@@ -554,17 +554,17 @@ class AccountBloc {
       if (useTor) {
         log.info('accountBloc.listenUserChanges: using Tor');
         try {
-          this.torBloc.torConfig ??= await torBloc.startTor();
+          torBloc.torConfig ??= await torBloc.startTor();
         } catch (e) {
           _lightningDownController.add(false);
         }
-        //throw error
-        if (this.torBloc.torConfig != null) {
-          _breezLib.setBackupTorConfig(this.torBloc.torConfig);
+        // throw error
+        if (torBloc.torConfig != null) {
+          _breezLib.setBackupTorConfig(torBloc.torConfig);
         }
       }
     }
-    return this.torBloc.torConfig;
+    return torBloc.torConfig;
   }
 
   _listenUserChanges(Stream<BreezUserModel> userProfileStream) {
@@ -608,9 +608,9 @@ class AccountBloc {
           });
           log.info("account: starting lightning...");
           try {
-            TorConfig c = this.torBloc.torConfig;
+            TorConfig c = torBloc.torConfig;
             log.info("Starting lightning with $c");
-            await _breezLib.startLightning(this.torBloc.torConfig);
+            await _breezLib.startLightning(torBloc.torConfig);
             log.info("account: lightning started");
             if (user.token != null) {
               _breezLib.registerPeriodicSync(user.token);

--- a/lib/bloc/backup/backup_bloc.dart
+++ b/lib/bloc/backup/backup_bloc.dart
@@ -534,7 +534,7 @@ class BackupBloc {
       if (error is PlatformException) {
         var e = error;
         // Handle PlatformException(ResultError, "AuthError", Failed to invoke testBackupAuth, null)
-        switch (e.message) {
+        switch (e.code) {
           case _signInFailedCode:
             throw SignInFailedException(provider);
             break;

--- a/lib/bloc/backup/backup_bloc.dart
+++ b/lib/bloc/backup/backup_bloc.dart
@@ -172,7 +172,6 @@ class BackupBloc {
       var map = settings.remoteServerAuthData.toJson();
       authData = json.encode(map);
     }
-
     await _breezLib.setBackupProvider(settings.backupProvider.name, authData);
   }
 
@@ -417,10 +416,12 @@ class BackupBloc {
 
   Future<void> _savePosDB() async {
     // Copy POS items to backup directory
-    final posDbPath = '${await databaseFactory.getDatabasesPath()}${Platform.pathSeparator}product-catalog.db';
+    final posDbPath =
+        '${await databaseFactory.getDatabasesPath()}${Platform.pathSeparator}product-catalog.db';
     if (await databaseExists(posDbPath)) {
       File(posDbPath)
-          .copy('$_backupAppDataDirPath${Platform.pathSeparator}product-catalog.db')
+          .copy(
+              '$_backupAppDataDirPath${Platform.pathSeparator}product-catalog.db')
           .catchError((err) {
         throw Exception("Failed to copy pos items.");
       });
@@ -586,7 +587,8 @@ class BackupBloc {
   Future<void> _restorePosDB() async {
     final backupPosDbPath =
         '$_backupAppDataDirPath${Platform.pathSeparator}product-catalog.db';
-    final posDbPath = '${await databaseFactory.getDatabasesPath()}${Platform.pathSeparator}product-catalog.db';
+    final posDbPath =
+        '${await databaseFactory.getDatabasesPath()}${Platform.pathSeparator}product-catalog.db';
     if (await File(backupPosDbPath).exists()) {
       await File(backupPosDbPath).copy(posDbPath).catchError((err) {
         throw Exception("Failed to restore pos items.");
@@ -660,6 +662,7 @@ class SignInFailedException implements Exception {
 class MethodNotFoundException implements Exception {
   MethodNotFoundException();
 
+  @override
   String toString() {
     return "Method not found";
   }
@@ -668,15 +671,13 @@ class MethodNotFoundException implements Exception {
 class NoBackupFoundException implements Exception {
   NoBackupFoundException();
 
+  @override
   String toString() {
     return "No backup found, please use double check the address";
   }
 }
 
 class RemoteServerNotFoundException implements Exception {
-  final BackupProvider provider;
-  RemoteServerNotFoundException(this.provider);
-
   @override
   String toString() {
     return "The server was not found. Please check the address";

--- a/lib/bloc/backup/backup_bloc.dart
+++ b/lib/bloc/backup/backup_bloc.dart
@@ -27,7 +27,6 @@ class BackupBloc {
   static const String _methodNotFound = "405";
   static const String _notFoundCode = "404";
   static const String _noAccess = "403";
-  static const String _resultError = "ResultError";
   static const String USER_DETAILS_PREFERENCES_KEY = "BreezUserModel.userID";
 
   static const _kDefaultOverrideFee = false;
@@ -500,8 +499,7 @@ class BackupBloc {
               .sort((s1, s2) => s2.modifiedTime.compareTo(s1.modifiedTime));
           _multipleRestoreController.add(snapshots);
           if (backups == null) {
-            throw NoBackupFoundException(
-                _backupSettingsController.value.backupProvider);
+            throw NoBackupFoundException();
           }
         }).catchError((error) {
           if (error.runtimeType == PlatformException) {
@@ -510,8 +508,7 @@ class BackupBloc {
               error = SignInFailedException(
                   _backupSettingsController.value.backupProvider);
             } else if (e.message == _noAccess) {
-              error = NoBackupFoundException(
-                  _backupSettingsController.value.backupProvider);
+              error = NoBackupFoundException();
             } else {
               error = (error as PlatformException).message;
             }
@@ -549,16 +546,14 @@ class BackupBloc {
               throw SignInFailedException(provider);
               break;
             case _methodNotFound:
-              throw MethodNotFoundException(provider);
+              throw MethodNotFoundException();
               break;
             case _noAccess:
-              throw NoBackupFoundException(provider);
+              throw NoBackupFoundException();
               break;
             case _notFoundCode:
               throw RemoteServerNotFoundException();
               break;
-            case _resultError:
-              throw NoBackupFoundException(provider);
           }
         }
         throw error;
@@ -663,8 +658,7 @@ class SignInFailedException implements Exception {
 }
 
 class MethodNotFoundException implements Exception {
-  final BackupProvider provider;
-  MethodNotFoundException(this.provider);
+  MethodNotFoundException();
 
   String toString() {
     return "Method not found";
@@ -672,20 +666,20 @@ class MethodNotFoundException implements Exception {
 }
 
 class NoBackupFoundException implements Exception {
-  final BackupProvider provider;
-  NoBackupFoundException(this.provider);
+  NoBackupFoundException();
 
   String toString() {
-    return "No backup found, please use full URL";
+    return "No backup found, please use double check the address";
   }
 }
 
 class RemoteServerNotFoundException implements Exception {
-  RemoteServerNotFoundException();
+  final BackupProvider provider;
+  RemoteServerNotFoundException(this.provider);
 
   @override
   String toString() {
-    return "The server/url was not found.";
+    return "The server was not found. Please check the address";
   }
 }
 

--- a/lib/bloc/backup/backup_bloc.dart
+++ b/lib/bloc/backup/backup_bloc.dart
@@ -23,9 +23,10 @@ import '../async_action.dart';
 import 'backup_actions.dart';
 
 class BackupBloc {
-  static const String _signInFailedCode = "AuthError";
+  static const String _signInFailedCode = "401";
+  static const String _signInFailedMessage = "AuthError";
   static const String _methodNotFound = "405";
-  static const String _notFoundCode = "404";
+  static const String _notFoundMessage = "404";
   static const String _noAccess = "403";
   static const String _empty = "empty";
   static const String USER_DETAILS_PREFERENCES_KEY = "BreezUserModel.userID";
@@ -503,7 +504,10 @@ class BackupBloc {
         }).catchError((error) {
           if (error.runtimeType == PlatformException) {
             PlatformException e = (error as PlatformException);
-            if (e.code == _signInFailedCode || e.message == "401") {
+            // the error code equals the message from the go library so
+            // not to confuse the two.
+            if (e.code == _signInFailedMessage ||
+                e.message == _signInFailedCode) {
               error = SignInFailedException(
                   _backupSettingsController.value.backupProvider);
             } else if (e.code == _empty) {
@@ -543,13 +547,16 @@ class BackupBloc {
             case _signInFailedCode:
               throw SignInFailedException(provider);
               break;
+            case _signInFailedMessage:
+              throw SignInFailedException(provider);
+              break;
             case _methodNotFound:
               throw MethodNotFoundException();
               break;
             case _noAccess:
               throw NoBackupFoundException();
               break;
-            case _notFoundCode:
+            case _notFoundMessage:
               throw RemoteServerNotFoundException();
               break;
             case _empty:

--- a/lib/bloc/tor/bloc.dart
+++ b/lib/bloc/tor/bloc.dart
@@ -40,13 +40,11 @@ class TorBloc {
         torConfig.http = "$port";
         log.info('torBloc.startTor: torConfig.http: ${torConfig.http}');
 
-        log.info(
-            'TorBloc.startTor: tor has started with config : $torConfig');
+        log.info('TorBloc.startTor: tor has started with config : $torConfig');
       }
     } on PlatformException catch (e) {
       log.info('TorBloc.startTor failed: $e');
     }
-
     return torConfig;
   }
 }

--- a/lib/routes/security_pin/remote_server_auth.dart
+++ b/lib/routes/security_pin/remote_server_auth.dart
@@ -172,9 +172,8 @@ class RemoteServerAuthPageState extends State<RemoteServerAuthPage> {
                               optionText: texts
                                   .remote_server_onion_warning_dialog_default_action_cancel,
                               optionFunc: () {
-                                // TODO ubbabeck don't attempt to query
-                                // navigator pop something
-                                return;
+                                connectionWarningResponse = false;
+                                Navigator.pop(context);
                               },
                               okText: texts
                                   .remote_server_onion_warning_dialog_settings,
@@ -184,7 +183,6 @@ class RemoteServerAuthPageState extends State<RemoteServerAuthPage> {
                                   builder: (_) =>
                                       withBreezTheme(context, NetworkPage()),
                                 ));
-                                // Navigator.of(context).popUntil((route) => route is RemoteServerAuthPage);
                                 return false;
                               });
                         }

--- a/lib/routes/security_pin/remote_server_auth.dart
+++ b/lib/routes/security_pin/remote_server_auth.dart
@@ -412,22 +412,6 @@ class RemoteServerAuthPageState extends State<RemoteServerAuthPage> {
     } on MethodNotFoundException {
       return DiscoverResult.METHOD_NOT_FOUND;
     }
-
-    // Since we are restoring we cannot be sure whenever the account has any
-    // backups.
-    if (widget.restore) {
-      try {
-        await injector.breezBridge.getAvailableBackups();
-      } on Exception catch (error) {
-        if (error.runtimeType == PlatformException) {
-          PlatformException e = (error as PlatformException);
-          if (e.code == "empty") {
-            failNoBackupFound = true;
-            return DiscoverResult.BACKUP_NOT_FOUND;
-          }
-        }
-      }
-    }
     return DiscoverResult.SUCCESS;
   }
 }

--- a/lib/routes/security_pin/remote_server_auth.dart
+++ b/lib/routes/security_pin/remote_server_auth.dart
@@ -251,7 +251,7 @@ class RemoteServerAuthPageState extends State<RemoteServerAuthPage> {
         if (!failDiscoverURL && validURL) {
           return null;
         }
-        return texts.remote_server_error_invalid_url;
+        return NoBackupFoundException().toString();
       },
       decoration: InputDecoration(
         hintText: texts.remote_server_server_url_hint,
@@ -385,7 +385,7 @@ class RemoteServerAuthPageState extends State<RemoteServerAuthPage> {
     } on MethodNotFoundException {
       return DiscoverResult.METHOD_NOT_FOUND;
     } on NoBackupFoundException {
-      return DiscoverResult.INVALID_URL;
+      return DiscoverResult.BACKUP_NOT_FOUND;
     }
 
     return DiscoverResult.SUCCESS;

--- a/lib/routes/security_pin/remote_server_auth.dart
+++ b/lib/routes/security_pin/remote_server_auth.dart
@@ -7,6 +7,8 @@ import 'package:breez/bloc/tor/bloc.dart';
 import 'package:breez/logger.dart';
 import 'package:breez/routes/network/network.dart';
 import 'package:breez/routes/podcast/theme.dart';
+import 'package:breez/services/breezlib/breez_bridge.dart';
+import 'package:breez/services/injector.dart';
 import 'package:breez/widgets/back_button.dart' as backBtn;
 import 'package:breez/widgets/error_dialog.dart';
 import 'package:breez/widgets/loader.dart';
@@ -54,8 +56,13 @@ class RemoteServerAuthPageState extends State<RemoteServerAuthPage> {
   final _passwordController = TextEditingController();
 
   bool failDiscoverURL = false;
+  bool failNoBackupFound = false;
   bool failAuthenticate = false;
   bool _passwordObscured = true;
+
+  ServiceInjector injector = ServiceInjector();
+
+  BreezBridge _breezLib;
 
   String appendPath(String uri, List<String> pathSegments) {
     var uriObject = Uri.parse(uri);
@@ -67,19 +74,22 @@ class RemoteServerAuthPageState extends State<RemoteServerAuthPage> {
   @override
   void initState() {
     super.initState();
-    widget._backupBloc.backupSettingsStream.first.then((value) {
-      var data = value.remoteServerAuthData;
-      if (data != null) {
-        var backupDirPathSegments = data.breezDir.split("/");
-        _urlController.text = data.url;
-        if (backupDirPathSegments.length > 1) {
-          backupDirPathSegments.removeLast();
-          _urlController.text = appendPath(data.url, backupDirPathSegments);
+    _breezLib = injector.breezBridge;
+    widget._backupBloc.backupSettingsStream.first.then(
+      (value) {
+        var data = value.remoteServerAuthData;
+        if (data != null) {
+          var backupDirPathSegments = data.breezDir.split("/");
+          _urlController.text = data.url;
+          if (backupDirPathSegments.length > 1) {
+            backupDirPathSegments.removeLast();
+            _urlController.text = appendPath(data.url, backupDirPathSegments);
+          }
+          _userController.text = data.user;
+          _passwordController.text = data.password;
         }
-        _userController.text = data.user;
-        _passwordController.text = data.password;
-      }
-    });
+      },
+    );
   }
 
   @override
@@ -162,7 +172,9 @@ class RemoteServerAuthPageState extends State<RemoteServerAuthPage> {
                               optionText: texts
                                   .remote_server_onion_warning_dialog_default_action_cancel,
                               optionFunc: () {
-                                Navigator.of(context).pop();
+                                // TODO ubbabeck don't attempt to query
+                                // navigator pop something
+                                return;
                               },
                               okText: texts
                                   .remote_server_onion_warning_dialog_settings,
@@ -170,7 +182,7 @@ class RemoteServerAuthPageState extends State<RemoteServerAuthPage> {
                                 connectionWarningResponse = false;
                                 Navigator.of(context).push(FadeInRoute(
                                   builder: (_) =>
-                                      withBreezTheme(context, const NetworkPage()),
+                                      withBreezTheme(context, NetworkPage()),
                                 ));
                                 // Navigator.of(context).popUntil((route) => route is RemoteServerAuthPage);
                                 return false;
@@ -216,6 +228,8 @@ class RemoteServerAuthPageState extends State<RemoteServerAuthPage> {
                                   error == DiscoverResult.INVALID_URL;
                               failAuthenticate =
                                   error == DiscoverResult.INVALID_AUTH;
+                              failNoBackupFound =
+                                  error == DiscoverResult.BACKUP_NOT_FOUND;
                             });
                             _formKey.currentState.validate();
                           }).catchError((err) {
@@ -251,7 +265,10 @@ class RemoteServerAuthPageState extends State<RemoteServerAuthPage> {
         if (!failDiscoverURL && validURL) {
           return null;
         }
-        return NoBackupFoundException().toString();
+        if (failNoBackupFound) {
+          return NoBackupFoundException().toString();
+        }
+        return texts.remote_server_error_invalid_url;
       },
       decoration: InputDecoration(
         hintText: texts.remote_server_server_url_hint,

--- a/lib/services/injector.dart
+++ b/lib/services/injector.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:breez/bloc/tor/bloc.dart';
 import 'package:breez/services/breez_server/server.dart';
 import 'package:breez/services/breezlib/breez_bridge.dart';
 import 'package:breez/services/currency_service.dart';
@@ -27,6 +28,7 @@ class ServiceInjector {
   DeepLinksService _deepLinksService;
   LightningLinksService _lightningLinksService;
   Device _device;
+  TorBloc _torBloc;
   Future<SharedPreferences> _sharedPreferences =
       SharedPreferences.getInstance();
   Permissions _permissions;
@@ -64,6 +66,10 @@ class ServiceInjector {
 
   Device get device {
     return _device ??= Device();
+  }
+
+  TorBloc get torBloc {
+    return _torBloc ?? TorBloc();
   }
 
   DeepLinksService get deepLinks => _deepLinksService ??= DeepLinksService();


### PR DESCRIPTION
# About PR
Earlier I changed the attempting url from `/remote.php/ in this f128ee6f5c59f775a18484488e7841868c17749a commit.

This creates a successful sign-in, but the app is not able to locate or upload backup files successfully. Though this is not good it does at least not cause any issues in regards to us having to maintain the `remote.php/dav` url.

The app will first try the url the user inserted, but it this does not work it will attempt to try connect to the shorturl + remote.php/webdav.

## Depends

This pr depends on https://github.com/breez/breez/pull/182 


## Todo

- [x] Pass torconfig to the breez libary so we can restore from an instance behind tor.

## Test

- [x] with invalid url that is not a nextcloud or dav instance
- [x] restore from backup using short url
- [x] upload using short url 

### Test if regression
- [x] Test with google 
- [x] iCloud

@erdemyerebasmaz  if you have an old instance can you help with testing with an old instance of nextcloud ?
- [x] restore from old instance 
- [x] upload to old instance 


