### PR TITLE
Fix NPE when accessing tag on a null action

### DIFF
--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_lnurl_message.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_lnurl_message.dart
@@ -21,9 +21,10 @@ class PaymentDetailsDialogLnurlMessage extends StatelessWidget {
     final texts = context.texts();
     final action = paymentInfo.lnurlPayInfo?.successAction;
     final message = action?.message?.trim();
+    final tag = action?.tag;
 
     if (paymentInfo.type != PaymentType.SENT ||
-        (action.tag != 'message' && action.tag != 'aes') ||
+        (tag != 'message' && tag != 'aes') ||
         message == null ||
         message.isEmpty) {
       return Container();


### PR DESCRIPTION
How it looks:

|Before|After|
|---|---|
|![before](https://user-images.githubusercontent.com/1225438/220121961-0f13b80b-63bd-48de-85d0-022563b12e83.png)|![after](https://user-images.githubusercontent.com/1225438/220121973-6d254732-5f7d-40d2-96b1-31af31375de9.png)|
