### PR TITLE
defer tor initialisation

### DIFF
--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -135,7 +135,7 @@ class AccountBloc {
   CurrencyService _currencyService;
   final Completer _onBoardingCompleter = Completer();
   Stream<BreezUserModel> userProfileStream;
-  TorBloc torBloc;
+  TorBloc torBloc = ServiceInjector().torBloc;
   Completer<bool> startDaemonCompleter = Completer<bool>();
   final PaymentOptionsBloc _paymentOptionsBloc;
 
@@ -156,7 +156,6 @@ class AccountBloc {
     _device = injector.device;
     _backgroundService = injector.backgroundTaskService;
     _currencyService = injector.currencyService;
-    torBloc = injector.torBloc;
     _actionHandlers = {
       SendPaymentFailureReport: _handleSendQueryRoute,
       ResetNetwork: _handleResetNetwork,
@@ -185,15 +184,16 @@ class AccountBloc {
     _start();
   }
 
-  void _start() async {
+  void _start() {
     log.info("Account bloc started");
-    torBloc.torConfig = await _startTorIfNeeded();
-    ServiceInjector().sharedPreferences.then((preferences) {
+
+    ServiceInjector().sharedPreferences.then((preferences) async {
       _handleRegisterDeviceNode();
       _refreshAccountAndPayments();
       //listen streams
       _listenAccountActions();
       _handleAccountSettings();
+      torBloc.torConfig = await _startTorIfNeeded();
       _listenUserChanges(userProfileStream);
       _listenFilterChanges();
       _listenAccountChanges();


### PR DESCRIPTION
This pr is related to #1099 which happens when tor is active.

The cause of the issue was that tor is being activated before we gather account information. This can be deferred until before we start lighting which happens in __listenUserChanges_. 

As a result the initial loading seems to go faster.
## Test

- [x] Backup from tor in new install 
- [x] backup to webdav instance behind tor.
