### PR TITLE
support in-app NTAG 4xx on iOS

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -408,6 +408,7 @@
         <string>D27600002545500100</string>
         <string>D27600002547410100</string>
         <string>D276000060</string>
+        <string>D2760000850101</string>
         <string>D276000118</string>
         <string>D2760001180101</string>
         <string>D27600012401</string>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -31,7 +31,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.15.9</string>
+	<string>0.15.10</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>


### PR DESCRIPTION
We got a report from a user that scanning an NTAG 424 DNA card on iOS doesn't do anything on iOS. It looks like we're missing the select-identifier for these tags in the Info.plist file.