### PR TITLE
allow comma in POS mode #1111

### DIFF
--- a/lib/bloc/account/fiat_conversion.dart
+++ b/lib/bloc/account/fiat_conversion.dart
@@ -27,7 +27,7 @@ class FiatConversion {
 
   RegExp get whitelistedPattern => currencyData.fractionSize == 0
       ? RegExp(r'\d+')
-      : RegExp("^\\d+\\.?\\d{0,${currencyData.fractionSize ?? 2}}");
+      : RegExp("^\\d+[.,]?\\d{0,${currencyData.fractionSize ?? 2}}");
 
   Int64 fiatToSat(double fiatAmount) {
     return Int64((fiatAmount / exchangeRate * 100000000).round());

--- a/lib/bloc/user_profile/currency.dart
+++ b/lib/bloc/user_profile/currency.dart
@@ -64,11 +64,11 @@ class Currency extends Object {
   RegExp get whitelistedPattern {
     switch (tickerSymbol) {
       case "BTC":
-        return RegExp("^\\d+\\.?\\d{0,8}");
+        return RegExp("^\\d+[.,]?\\d{0,8}");
       case "SAT":
         return RegExp(r'\d+');
       default:
-        return RegExp("^\\d+\\.?\\d{0,8}");
+        return RegExp("^\\d+[.,]?\\d{0,8}");
     }
   }
 

--- a/lib/routes/charge/items/item_page.dart
+++ b/lib/routes/charge/items/item_page.dart
@@ -198,6 +198,8 @@ class ItemPageState extends State<ItemPage> {
         FilteringTextInputFormatter.allow(
           _selectedCurrency.whitelistedPattern,
         ),
+        TextInputFormatter.withFunction((oldValue, newValue) =>
+            newValue.copyWith(text: newValue.text.replaceAll(',', '.'))),
       ],
       controller: _priceController,
       decoration: InputDecoration(


### PR DESCRIPTION
# About PR
This issue references #1111.  Which is a known issue on Samsung phones when using [`TextInputType.numberWithOptions`](https://github.com/flutter/flutter/issues/61175)

I have allowed for the use of either comma or dot in the `whitelistedPattern` function. 

We then proceed with replacing all commas with dots in order to adhere to the `double.parse` function. 
## Question 
Are there another place in the app we wish to or should accepts comma too?

https://github.com/breez/breezmobile/assets/36157890/e160cbc4-a4c1-4418-a0a0-c28a4d1391a6



