### PR TITLE
Check validity of Dynamic Fees when creating invoice

### DIFF
--- a/lib/bloc/invoice/invoice_bloc.dart
+++ b/lib/bloc/invoice/invoice_bloc.dart
@@ -109,7 +109,8 @@ class InvoiceBloc with AsyncActionsHandler {
               payeeName: invoiceRequest.payeeName,
               payeeImageURL: invoiceRequest.logo,
               description: invoiceRequest.description,
-              expiry: invoiceRequest.expiry)
+              expiry: invoiceRequest.expiry,
+              inputLSP: invoiceRequest.lspInformation)
           .then((payReq) async {
         log.info("Payment Request: ${payReq.paymentRequest}");
         var memo = await _breezLib.decodePaymentRequest(payReq.paymentRequest);

--- a/lib/bloc/invoice/invoice_model.dart
+++ b/lib/bloc/invoice/invoice_model.dart
@@ -7,9 +7,10 @@ class InvoiceRequestModel {
   final String logo;
   final Int64 amount;
   final Int64 expiry;
+  final LSPInformation lspInformation;
 
   InvoiceRequestModel(this.payeeName, this.description, this.logo, this.amount,
-      {this.expiry});
+      {this.expiry, this.lspInformation});
 }
 
 class PaymentRequestModel {

--- a/lib/bloc/lsp/lsp_bloc.dart
+++ b/lib/bloc/lsp/lsp_bloc.dart
@@ -53,7 +53,7 @@ class LSPBloc with AsyncActionsHandler {
 
   Future _fetchLSPList(FetchLSPList action) async {
     try {
-      await _ensureLSPSFetched();
+      action.resolve(await _ensureLSPSFetched());
     } catch (err) {
       _lspsStatusController.add(_lspsStatusController.value
           .copyWith(lastConnectionError: err.toString()));
@@ -162,7 +162,7 @@ class LSPBloc with AsyncActionsHandler {
     await _lspPromptController.close();
   }
 
-  Future _ensureLSPSFetched() async {
+  Future<List<LSPInfo>> _ensureLSPSFetched() async {
     var list = await _breezLib.getLSPList();
     var lspInfoList = list.lsps.entries.map<LSPInfo>((entry) {
       return LSPInfo(entry.value, entry.key);
@@ -170,5 +170,6 @@ class LSPBloc with AsyncActionsHandler {
     _lspsStatusController.add(
       _lspsStatusController.value.copyWith(availableLSPs: lspInfoList),
     );
+    return lspInfoList;
   }
 }

--- a/lib/bloc/lsp/lsp_bloc.dart
+++ b/lib/bloc/lsp/lsp_bloc.dart
@@ -163,13 +163,12 @@ class LSPBloc with AsyncActionsHandler {
   }
 
   Future _ensureLSPSFetched() async {
-    if (_lspsStatusController.value.availableLSPs.isEmpty) {
-      var list = await _breezLib.getLSPList();
-      var lspInfoList = list.lsps.entries.map<LSPInfo>((entry) {
-        return LSPInfo(entry.value, entry.key);
-      }).toList();
-      _lspsStatusController.add(
-          _lspsStatusController.value.copyWith(availableLSPs: lspInfoList));
-    }
+    var list = await _breezLib.getLSPList();
+    var lspInfoList = list.lsps.entries.map<LSPInfo>((entry) {
+      return LSPInfo(entry.value, entry.key);
+    }).toList();
+    _lspsStatusController.add(
+      _lspsStatusController.value.copyWith(availableLSPs: lspInfoList),
+    );
   }
 }

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -142,20 +142,16 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
                       : texts.invoice_action_redeem,
                   onPressed: () {
                     if (_formKey.currentState.validate()) {
-                      final tempFees =
-                          lspStatus.currentLSP.cheapestOpeningFeeParams;
-                      _fetchLSPList().then((_) {
-                        _createInvoice(
-                          context,
-                          accountBloc,
-                          account,
-                          lspStatus.currentLSP.raw,
-                          hasFeeChanged(
-                            tempFees,
-                            lspStatus.currentLSP.cheapestOpeningFeeParams,
-                          ),
-                        );
-                      });
+                      _fetchLSPList().then(
+                        (_) {
+                          _createInvoice(
+                            context,
+                            accountBloc,
+                            account,
+                            lspStatus.currentLSP.raw,
+                          );
+                        },
+                      );
                     }
                   },
                 ),
@@ -528,7 +524,6 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
     AccountBloc accountBloc,
     AccountModel account,
     LSPInformation lspInformation,
-    bool hasFeeChanged,
   ) {
     final invoiceBloc = AppBlocsProvider.of<InvoiceBloc>(context);
     final lnurlBloc = AppBlocsProvider.of<LNUrlBloc>(context);
@@ -556,7 +551,6 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
             (result) {
               onPaymentFinished(result, currentRoute, navigator);
             },
-            hasFeeChanged: hasFeeChanged,
           );
     return _bgService.runAsTask(
         showDialog(

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -547,9 +547,15 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
         ? LNURlWithdrawDialog(invoiceBloc, accountBloc, lnurlBloc, (result) {
             onPaymentFinished(result, currentRoute, navigator);
           })
-        : QrCodeDialog(context, invoiceBloc, accountBloc, (result) {
-            onPaymentFinished(result, currentRoute, navigator);
-          });
+        : QrCodeDialog(
+            context,
+            invoiceBloc,
+            accountBloc,
+            (result) {
+              onPaymentFinished(result, currentRoute, navigator);
+            },
+            hasFeesChanged: !wasFeeParamsValid,
+          );
     return _bgService.runAsTask(
         showDialog(
           useRootNavigator: false,

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -587,12 +587,13 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
 
   Future<bool> validateFees(String validUntil) async {
     // Our invoices are created for 15 minutes and fees should be valid to the invoice expiration
-    final isFeeParamsInvalid =
-        DateTime.now().difference(DateTime.parse(validUntil)) >
-            const Duration(minutes: 15);
+    final expirationDifference = DateTime.parse(validUntil).difference(
+      DateTime.now(),
+    );
+    final isFeeParamsValid = expirationDifference.inMinutes > 15;
     // Refresh fees if they are invalid
-    if (isFeeParamsInvalid) await _fetchLSPList();
-    return isFeeParamsInvalid;
+    if (!isFeeParamsValid) await _fetchLSPList();
+    return isFeeParamsValid;
   }
 
   Future _fetchLSPList() async {

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -39,6 +39,8 @@ import 'package:fixnum/fixnum.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import 'setup_fees_dialog.dart';
+
 class CreateInvoicePage extends StatefulWidget {
   final WithdrawFetchResponse lnurlWithdraw;
 
@@ -147,7 +149,7 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
                       _fetchLSPList().then(
                         (_) {
                           // Show fee dialog if necessary and create invoice dialog
-                          _showFeeDialog(
+                          showSetupFeesDialog(
                             context,
                             hasFeesChanged(
                               tempFees,
@@ -609,30 +611,4 @@ bool hasFeesChanged(OpeningFeeParams oldFees, OpeningFeeParams newFees) {
   // Mark fee as changed only if new fees are higher
   return (newFees.minMsat > oldFees.minMsat) ||
       (newFees.proportional > oldFees.proportional);
-}
-
-Future _showFeeDialog(
-  BuildContext context,
-  bool hasFeesChanged,
-  Future Function() onNext,
-) async {
-  if (hasFeesChanged) {
-    await showDialog(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: const Text('Setup Fees'),
-          content: const Text(
-              'Please notice the updated setup fees under the QR code before receiving a payment.'),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('OK'),
-            )
-          ],
-        );
-      },
-    );
-  }
-  return onNext();
 }

--- a/lib/routes/create_invoice/qr_code_dialog.dart
+++ b/lib/routes/create_invoice/qr_code_dialog.dart
@@ -21,15 +21,13 @@ class QrCodeDialog extends StatefulWidget {
   final InvoiceBloc _invoiceBloc;
   final AccountBloc _accountBloc;
   final Function(dynamic result) _onFinish;
-  final bool hasFeeChanged;
 
   const QrCodeDialog(
     this.context,
     this._invoiceBloc,
     this._accountBloc,
-    this._onFinish, {
-    this.hasFeeChanged = false,
-  });
+    this._onFinish,
+  );
 
   @override
   State<StatefulWidget> createState() {
@@ -266,13 +264,6 @@ class QrCodeDialogState extends State<QrCodeDialog>
                               ),
                               const Padding(
                                   padding: EdgeInsets.only(top: 16.0)),
-                              if (widget.hasFeeChanged) ...[
-                                Text(
-                                  "Setup fees were updated.",
-                                  textAlign: TextAlign.center,
-                                  style: themeData.primaryTextTheme.bodySmall,
-                                )
-                              ],
                               SizedBox(
                                 width: MediaQuery.of(context).size.width,
                                 child: _buildExpiryAndFeeMessage(

--- a/lib/routes/create_invoice/qr_code_dialog.dart
+++ b/lib/routes/create_invoice/qr_code_dialog.dart
@@ -21,13 +21,15 @@ class QrCodeDialog extends StatefulWidget {
   final InvoiceBloc _invoiceBloc;
   final AccountBloc _accountBloc;
   final Function(dynamic result) _onFinish;
+  final bool hasFeesChanged;
 
   const QrCodeDialog(
     this.context,
     this._invoiceBloc,
     this._accountBloc,
-    this._onFinish,
-  );
+    this._onFinish, {
+    this.hasFeesChanged = false,
+  });
 
   @override
   State<StatefulWidget> createState() {
@@ -264,6 +266,13 @@ class QrCodeDialogState extends State<QrCodeDialog>
                               ),
                               const Padding(
                                   padding: EdgeInsets.only(top: 16.0)),
+                              if (widget.hasFeesChanged) ...[
+                                Text(
+                                  "Setup fees were updated.",
+                                  textAlign: TextAlign.center,
+                                  style: themeData.primaryTextTheme.bodySmall,
+                                )
+                              ],
                               SizedBox(
                                 width: MediaQuery.of(context).size.width,
                                 child: _buildExpiryAndFeeMessage(

--- a/lib/routes/create_invoice/qr_code_dialog.dart
+++ b/lib/routes/create_invoice/qr_code_dialog.dart
@@ -21,14 +21,14 @@ class QrCodeDialog extends StatefulWidget {
   final InvoiceBloc _invoiceBloc;
   final AccountBloc _accountBloc;
   final Function(dynamic result) _onFinish;
-  final bool hasFeesChanged;
+  final bool hasFeeChanged;
 
   const QrCodeDialog(
     this.context,
     this._invoiceBloc,
     this._accountBloc,
     this._onFinish, {
-    this.hasFeesChanged = false,
+    this.hasFeeChanged = false,
   });
 
   @override
@@ -266,7 +266,7 @@ class QrCodeDialogState extends State<QrCodeDialog>
                               ),
                               const Padding(
                                   padding: EdgeInsets.only(top: 16.0)),
-                              if (widget.hasFeesChanged) ...[
+                              if (widget.hasFeeChanged) ...[
                                 Text(
                                   "Setup fees were updated.",
                                   textAlign: TextAlign.center,

--- a/lib/routes/create_invoice/setup_fees_dialog.dart
+++ b/lib/routes/create_invoice/setup_fees_dialog.dart
@@ -1,0 +1,39 @@
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+
+class SetupFeesDialog extends StatelessWidget {
+  const SetupFeesDialog({
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final texts = context.texts();
+    return AlertDialog(
+      title: Text(texts.setup_fees_dialog_title),
+      content: Text(texts.setup_fees_dialog_message),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(texts.error_dialog_default_action_ok),
+        )
+      ],
+    );
+  }
+}
+
+Future showSetupFeesDialog(
+  BuildContext context,
+  bool hasFeesChanged,
+  Future Function() onNext,
+) async {
+  if (hasFeesChanged) {
+    await showDialog(
+      context: context,
+      builder: (context) {
+        return const SetupFeesDialog();
+      },
+    );
+  }
+  return onNext();
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "405666cd3cf0ee0a48d21ec67e65406aad2c726d9fa58840d3375e7bdcd32a07"
+      sha256: ae92f5d747aee634b87f89d9946000c2de774be1d6ac3e58268224348cd0101a
       url: "https://pub.dev"
     source: hosted
-    version: "60.0.0"
+    version: "61.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "1952250bd005bacb895a01bf1b4dc00e3ba1c526cf47dca54dfe24979c65f5b3"
+      sha256: ea3d8652bda62982addfd92fdc2d0214e5f82e43325104990d4f4c4a2a313562
       url: "https://pub.dev"
     source: hosted
-    version: "5.12.0"
+    version: "5.13.0"
   another_flushbar:
     dependency: "direct main"
     description:
@@ -126,10 +126,10 @@ packages:
     dependency: transitive
     description:
       name: barcode
-      sha256: "52570564684bbb0240a9f1fdb6bad12adc5e0540103c1c96d6dd550bd928b1c9"
+      sha256: "789f898eef0bd88312470bdb2cc996f895ad7dd5f89e9adde84b204546a90b45"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
   bidi:
     dependency: transitive
     description:
@@ -158,8 +158,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: b610d54ad7c105258afb6dd8da0075ccba765cd6
-      resolved-ref: b610d54ad7c105258afb6dd8da0075ccba765cd6
+      ref: e01261e4359277126d4599f8de8dcb678653eb74
+      resolved-ref: e01261e4359277126d4599f8de8dcb678653eb74
       url: "https://github.com/breez/Breez-Translations.git"
     source: git
     version: "1.0.0"
@@ -223,10 +223,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "2f17434bd5d52a26762043d6b43bb53b3acd029b4d9071a329f46d67ef297e6d"
+      sha256: "7dd62d9faf105c434f3d829bbe9c4be02ec67f5ed94832222116122df67c5452"
       url: "https://pub.dev"
     source: hosted
-    version: "8.5.0"
+    version: "8.6.0"
   characters:
     dependency: transitive
     description:
@@ -295,10 +295,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "45262924896ff72a8cd92b722bb7e3d5020f9e0724531a3e10e22ddae2005991"
+      sha256: "8599ae9edca5ff96163fca3e36f8e481ea917d1e71cdad912c084b5579913f34"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -392,10 +392,10 @@ packages:
     dependency: transitive
     description:
       name: device_info_plus
-      sha256: "9b1a0c32b2a503f8fe9f8764fac7b5fcd4f6bd35d8f49de5350bccf9e2a33b8a"
+      sha256: "499c61743e13909c13374a8c209075385858c614b9c0f2487b5f9995eeaf7369"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "9.0.1"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -638,10 +638,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_keyboard_visibility
-      sha256: "4983655c26ab5b959252ee204c2fffa4afeb4413cd030455194ec0caa3b8e7cb"
+      sha256: be41db80ab7156d893878ca48a7520d667075c4841a0435d5544fd836197b55a
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.1"
+    version: "5.4.3"
   flutter_keyboard_visibility_linux:
     dependency: transitive
     description:
@@ -707,10 +707,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "96af49aa6b57c10a312106ad6f71deed5a754029c24789bbf620ba784f0bd0b0"
+      sha256: "950e77c2bbe1692bc0874fc7fb491b96a4dc340457f4ea1641443d0a6c1ea360"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.14"
+    version: "2.0.15"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -771,10 +771,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: f991fdb1533c3caeee0cdc14b04f50f0c3916f0dbcbc05237ccbe4e3c6b93f3f
+      sha256: "6ff8c902c8056af9736de2689f63f81c42e2d642b9f4c79dbf8790ae48b63012"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.6"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -814,10 +814,10 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   google_api_availability:
     dependency: "direct main"
     description:
@@ -966,10 +966,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "364967c8d581f5d75fc05f6c79fcf1115e3c05db3d3eee1aaca52e0da3f7501c"
+      sha256: c2f3c66400649bd132f721c88218945d6406f693092b2f741b79ae9cdb046e59
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.6+15"
+    version: "0.8.6+16"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -1216,10 +1216,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: d39e8fbff4c5aef4592737e25ad6ac500df006ce7a7a8e1f838ce1256e167542
+      sha256: "28386bbe89ab5a7919a47cea99cdd1128e5a6e0bbd7eaafe20440ead84a15de3"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1514,10 +1514,10 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "322a1ec9d9fe07e2e2252c098ce93d12dbd06133cc4c00ffe6a4ef505c295c17"
+      sha256: "44fc0bc2d35a8fafa1b564e1c6888bdc4fbb2d0197e4a4c21bac0e66123be9cd"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -1618,10 +1618,10 @@ packages:
     dependency: "direct main"
     description:
       name: shimmer
-      sha256: "1f1009b5845a1f88f1c5630212279540486f97409e9fc3f63883e71070d107bf"
+      sha256: "5f88c883a22e9f9f299e5ba0e4f7e6054857224976a5d9f839d4ebdc94a14ac9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   simple_animations:
     dependency: "direct main"
     description:
@@ -1919,26 +1919,26 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: "59a230f8bf37dd8b077335d1d64d895bccef0fb14f50730e3d79e8990bf3ed2b"
+      sha256: b96f10cbdfcbd03a65758633a43e7d04574438f059b1043104b5d61b23d38a4f
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.5+1"
+    version: "1.1.6"
   vector_graphics_codec:
     dependency: transitive
     description:
       name: vector_graphics_codec
-      sha256: "40781fe91c6d10a617c0289f7ec16cdb2d85a7f3654af2778c6d0adbf3bf45a3"
+      sha256: "57a8e6e24662a3bdfe3b3d61257db91768700c0b8f844e235877b56480f31c69"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.5+1"
+    version: "1.1.6"
   vector_graphics_compiler:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "6ca1298b70edcc3486fdb14032f1a186a593f1b5f6b5e82fb10febddcb1c61bb"
+      sha256: "7430f5d834d0db4560d7b19863362cd892f1e52b43838553a3c5cdfc9ab28e5b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.5+1"
+    version: "1.1.6"
   vector_math:
     dependency: transitive
     description:
@@ -2060,5 +2060,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=2.19.6 <3.0.0"
   flutter: ">=3.7.12"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,11 +17,11 @@ dependencies:
   breez_translations:
     git:
       url: https://github.com/breez/Breez-Translations.git
-      ref: b610d54ad7c105258afb6dd8da0075ccba765cd6
+      ref: e01261e4359277126d4599f8de8dcb678653eb74
   clipboard_watcher: ^0.2.0
   collection: ^1.17.2
   confetti: ^0.7.0
-  connectivity_plus: ^4.0.0
+  connectivity_plus: ^4.0.1
   convert: ^3.1.1
   crypto: ^3.0.3
   csv: ^5.0.2
@@ -40,7 +40,7 @@ dependencies:
   fixnum: ^1.1.0
   flutter_secure_storage: ^8.0.0
   flutter_spinkit: ^5.2.0
-  flutter_svg: ^2.0.5
+  flutter_svg: ^2.0.6
   flutter_web_browser: ^0.17.1
   google_api_availability: ^5.0.0
   grpc: ^3.1.0
@@ -58,7 +58,7 @@ dependencies:
     git:
       url: https://github.com/breez/md5_file_checksum.git
   nfc_manager: ^3.2.0
-  package_info_plus: ^4.0.0
+  package_info_plus: ^4.0.1
   path: ^1.8.3
   path_provider: ^2.0.15
   path_provider_platform_interface: ^2.0.6
@@ -78,9 +78,9 @@ dependencies:
       ref: 1fc6e38c198a76a6fd60b7bd3b4c190cd6c9330b
   rxdart: ^0.27.7
   screenshot: <2.0.0 # Requires Flutter 3.10
-  share_plus: ^7.0.0
+  share_plus: ^7.0.1
   shared_preferences: ^2.1.1
-  shimmer: ^2.0.0
+  shimmer: ^3.0.0
   simple_animations: ^5.0.0+3
   sqflite: ^2.2.8+4
   timeago: ^3.4.0


### PR DESCRIPTION
This PR addresses several issues one of which is where we're not able to create invoices ~1 hour after the app is opened, as LSPInformation is stale. Other is conveying the information that he setup fees has changed to the user in the rare occasion user spent ~1 hour in the Receive via Invoice page.

To address first issue:
- FetchLSPList action will list LSP's even if they've been already fetched.

Fees are fetched before creating each invoice. If there has been a change in fees, Setup fees dialog will be shown to the user before displaying the invoice dialog.

Added error handling & prevented clicking create invoice when an invoice is currently being created(rare case where fetching LSPInformation takes too long).
