### PR TITLE
Display a loader route when LSP's are being fetched

### DIFF
--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -267,42 +267,49 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
                       onInvoiceSubmit: () {
                         final navigator = Navigator.of(context);
                         var loaderRoute = createLoaderRoute(context);
-                        navigator.push(loaderRoute);
+                        try {
+                          navigator.push(loaderRoute);
 
-                        final tempFees =
-                            lspStatus.currentLSP.cheapestOpeningFeeParams;
-                        fetchLSPList(lspBloc).then(
-                          (lspList) {
-                            if (loaderRoute.isActive) {
-                              navigator.removeRoute(loaderRoute);
-                            }
-                            var refreshedLSP = lspList.firstWhere(
-                              (lsp) => lsp.lspID == lspStatus.currentLSP.lspID,
-                            );
-                            // Show fee dialog if necessary and submit invoice
-                            showSetupFeesDialog(
-                              context,
-                              hasFeesChanged(
-                                tempFees,
-                                refreshedLSP.cheapestOpeningFeeParams,
-                              ),
-                              () => _onInvoiceSubmitted(
+                          final tempFees =
+                              lspStatus.currentLSP.cheapestOpeningFeeParams;
+                          fetchLSPList(lspBloc).then(
+                            (lspList) {
+                              if (loaderRoute.isActive) {
+                                navigator.removeRoute(loaderRoute);
+                              }
+                              var refreshedLSP = lspList.firstWhere(
+                                (lsp) =>
+                                    lsp.lspID == lspStatus.currentLSP.lspID,
+                              );
+                              // Show fee dialog if necessary and submit invoice
+                              showSetupFeesDialog(
                                 context,
-                                currentSale,
-                                invoiceBloc,
-                                lnUrlBloc,
-                                userProfile,
-                                accountModel,
-                                refreshedLSP.raw,
-                              ),
-                            );
-                          },
-                          onError: (_) {
-                            if (loaderRoute.isActive) {
-                              navigator.removeRoute(loaderRoute);
-                            }
-                          },
-                        );
+                                hasFeesChanged(
+                                  tempFees,
+                                  refreshedLSP.cheapestOpeningFeeParams,
+                                ),
+                                () => _onInvoiceSubmitted(
+                                  context,
+                                  currentSale,
+                                  invoiceBloc,
+                                  lnUrlBloc,
+                                  userProfile,
+                                  accountModel,
+                                  refreshedLSP.raw,
+                                ),
+                              );
+                            },
+                            onError: (_) {
+                              if (loaderRoute.isActive) {
+                                navigator.removeRoute(loaderRoute);
+                              }
+                            },
+                          );
+                        } catch (e) {
+                          if (loaderRoute.isActive) {
+                            navigator.removeRoute(loaderRoute);
+                          }
+                        }
                       },
                       approveClear: () => _approveClear(
                         context,
@@ -396,41 +403,47 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
             onPressed: () {
               final navigator = Navigator.of(context);
               var loaderRoute = createLoaderRoute(context);
-              navigator.push(loaderRoute);
+              try {
+                navigator.push(loaderRoute);
 
-              final tempFees = lspStatus.currentLSP.cheapestOpeningFeeParams;
-              fetchLSPList(lspBloc).then(
-                (lspList) {
-                  if (loaderRoute.isActive) {
-                    navigator.removeRoute(loaderRoute);
-                  }
-                  var refreshedLSP = lspList.firstWhere(
-                    (lsp) => lsp.lspID == lspStatus.currentLSP.lspID,
-                  );
-                  // Show fee dialog if necessary and submit invoice
-                  showSetupFeesDialog(
-                    context,
-                    hasFeesChanged(
-                      tempFees,
-                      refreshedLSP.cheapestOpeningFeeParams,
-                    ),
-                    () => _onInvoiceSubmitted(
+                final tempFees = lspStatus.currentLSP.cheapestOpeningFeeParams;
+                fetchLSPList(lspBloc).then(
+                  (lspList) {
+                    if (loaderRoute.isActive) {
+                      navigator.removeRoute(loaderRoute);
+                    }
+                    var refreshedLSP = lspList.firstWhere(
+                      (lsp) => lsp.lspID == lspStatus.currentLSP.lspID,
+                    );
+                    // Show fee dialog if necessary and submit invoice
+                    showSetupFeesDialog(
                       context,
-                      currentSale,
-                      invoiceBloc,
-                      lnUrlBloc,
-                      userProfile,
-                      accountModel,
-                      refreshedLSP.raw,
-                    ),
-                  );
-                },
-                onError: (_) {
-                  if (loaderRoute.isActive) {
-                    navigator.removeRoute(loaderRoute);
-                  }
-                },
-              );
+                      hasFeesChanged(
+                        tempFees,
+                        refreshedLSP.cheapestOpeningFeeParams,
+                      ),
+                      () => _onInvoiceSubmitted(
+                        context,
+                        currentSale,
+                        invoiceBloc,
+                        lnUrlBloc,
+                        userProfile,
+                        accountModel,
+                        refreshedLSP.raw,
+                      ),
+                    );
+                  },
+                  onError: (_) {
+                    if (loaderRoute.isActive) {
+                      navigator.removeRoute(loaderRoute);
+                    }
+                  },
+                );
+              } catch (e) {
+                if (loaderRoute.isActive) {
+                  navigator.removeRoute(loaderRoute);
+                }
+              }
             },
           ),
         ),

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -265,10 +265,17 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
                       isKeypadView: _isKeypadView,
                       currentAmount: currentAmount,
                       onInvoiceSubmit: () {
+                        final navigator = Navigator.of(context);
+                        var loaderRoute = createLoaderRoute(context);
+                        navigator.push(loaderRoute);
+
                         final tempFees =
                             lspStatus.currentLSP.cheapestOpeningFeeParams;
                         fetchLSPList(lspBloc).then(
                           (lspList) {
+                            if (loaderRoute.isActive) {
+                              navigator.removeRoute(loaderRoute);
+                            }
                             var refreshedLSP = lspList.firstWhere(
                               (lsp) => lsp.lspID == lspStatus.currentLSP.lspID,
                             );
@@ -289,6 +296,11 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
                                 refreshedLSP.raw,
                               ),
                             );
+                          },
+                          onError: (_) {
+                            if (loaderRoute.isActive) {
+                              navigator.removeRoute(loaderRoute);
+                            }
                           },
                         );
                       },
@@ -382,9 +394,16 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
               style: theme.invoiceChargeAmountStyle,
             ),
             onPressed: () {
+              final navigator = Navigator.of(context);
+              var loaderRoute = createLoaderRoute(context);
+              navigator.push(loaderRoute);
+
               final tempFees = lspStatus.currentLSP.cheapestOpeningFeeParams;
               fetchLSPList(lspBloc).then(
                 (lspList) {
+                  if (loaderRoute.isActive) {
+                    navigator.removeRoute(loaderRoute);
+                  }
                   var refreshedLSP = lspList.firstWhere(
                     (lsp) => lsp.lspID == lspStatus.currentLSP.lspID,
                   );
@@ -405,6 +424,11 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
                       refreshedLSP.raw,
                     ),
                   );
+                },
+                onError: (_) {
+                  if (loaderRoute.isActive) {
+                    navigator.removeRoute(loaderRoute);
+                  }
                 },
               );
             },

--- a/lib/routes/connect_to_pay/payee_session_widget.dart
+++ b/lib/routes/connect_to_pay/payee_session_widget.dart
@@ -62,9 +62,16 @@ class PayeeSessionWidget extends StatelessWidget {
                     if (action == texts.connect_to_pay_payee_action_reject) {
                       _currentSession.rejectPaymentSink.add(null);
                     } else {
+                      final navigator = Navigator.of(context);
+                      var loaderRoute = createLoaderRoute(context);
+                      navigator.push(loaderRoute);
+
                       final currentLSP = lspSnapshot.data.currentLSP;
                       final tempFees = currentLSP.cheapestOpeningFeeParams;
                       fetchLSPList(lspBloc).then((lspList) {
+                        if (loaderRoute.isActive) {
+                          navigator.removeRoute(loaderRoute);
+                        }
                         var refreshedLSP = lspList.firstWhere(
                           (lsp) => lsp.lspID == currentLSP.lspID,
                         );
@@ -80,6 +87,10 @@ class PayeeSessionWidget extends StatelessWidget {
                             return;
                           },
                         );
+                      }, onError: (_) {
+                        if (loaderRoute.isActive) {
+                          navigator.removeRoute(loaderRoute);
+                        }
                       });
                     }
                   },

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -63,7 +63,6 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
   final _bgService = ServiceInjector().backgroundTaskService;
 
   bool _isInit = false;
-  bool _isInProgress = false;
   KeyboardDoneAction _doneAction;
   WithdrawFetchResponse _withdrawFetchResponse;
   StreamSubscription<PaymentRequestModel> _paidInvoicesSubscription;
@@ -145,63 +144,49 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
                   text: _withdrawFetchResponse == null
                       ? texts.invoice_action_create
                       : texts.invoice_action_redeem,
-                  onPressed: _isInProgress
-                      ? null
-                      : () {
-                          if (_formKey.currentState.validate()) {
-                            setState(() {
-                              _isInProgress = true;
-                            });
-                            final navigator = Navigator.of(context);
-                            var loaderRoute = createLoaderRoute(context);
-                            navigator.push(loaderRoute);
+                  onPressed: () {
+                    if (_formKey.currentState.validate()) {
+                      final navigator = Navigator.of(context);
+                      var loaderRoute = createLoaderRoute(context);
+                      navigator.push(loaderRoute);
 
-                            final tempFees =
-                                lspStatus.currentLSP.cheapestOpeningFeeParams;
-                            fetchLSPList(lspBloc).then(
-                              (lspList) {
-                                if (loaderRoute.isActive) {
-                                  navigator.removeRoute(loaderRoute);
-                                }
-                                var refreshedLSP = lspList.firstWhere(
-                                  (lsp) =>
-                                      lsp.lspID == lspStatus.currentLSP.lspID,
-                                );
-                                // Show fee dialog if necessary and create invoice dialog
-                                showSetupFeesDialog(
-                                  context,
-                                  hasFeesChanged(
-                                    tempFees,
-                                    refreshedLSP.cheapestOpeningFeeParams,
-                                  ),
-                                  () => _createInvoice(
-                                    context,
-                                    accountBloc,
-                                    account,
-                                    refreshedLSP.raw,
-                                  ),
-                                ).then((_) {
-                                  setState(() {
-                                    _isInProgress = false;
-                                  });
-                                });
-                              },
-                              onError: (e) {
-                                setState(() {
-                                  _isInProgress = false;
-                                });
-                                if (loaderRoute.isActive) {
-                                  navigator.removeRoute(loaderRoute);
-                                }
-                                showFlushbar(
-                                  context,
-                                  message:
-                                      texts.qr_code_dialog_error(e.toString()),
-                                );
-                              },
-                            );
+                      final tempFees =
+                          lspStatus.currentLSP.cheapestOpeningFeeParams;
+                      fetchLSPList(lspBloc).then(
+                        (lspList) {
+                          if (loaderRoute.isActive) {
+                            navigator.removeRoute(loaderRoute);
                           }
+                          var refreshedLSP = lspList.firstWhere(
+                            (lsp) => lsp.lspID == lspStatus.currentLSP.lspID,
+                          );
+                          // Show fee dialog if necessary and create invoice dialog
+                          showSetupFeesDialog(
+                            context,
+                            hasFeesChanged(
+                              tempFees,
+                              refreshedLSP.cheapestOpeningFeeParams,
+                            ),
+                            () => _createInvoice(
+                              context,
+                              accountBloc,
+                              account,
+                              refreshedLSP.raw,
+                            ),
+                          );
                         },
+                        onError: (e) {
+                          if (loaderRoute.isActive) {
+                            navigator.removeRoute(loaderRoute);
+                          }
+                          showFlushbar(
+                            context,
+                            message: texts.qr_code_dialog_error(e.toString()),
+                          );
+                        },
+                      );
+                    }
+                  },
                 ),
               );
             },

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -152,6 +152,7 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
                             var loaderRoute = createLoaderRoute(context);
                             try {
                               navigator.push(loaderRoute);
+
                               final tempFees =
                                   lspStatus.currentLSP.cheapestOpeningFeeParams;
                               fetchLSPList(lspBloc).then(

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -152,10 +152,17 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
                             setState(() {
                               _isInProgress = true;
                             });
+                            final navigator = Navigator.of(context);
+                            var loaderRoute = createLoaderRoute(context);
+                            navigator.push(loaderRoute);
+
                             final tempFees =
                                 lspStatus.currentLSP.cheapestOpeningFeeParams;
                             fetchLSPList(lspBloc).then(
                               (lspList) {
+                                if (loaderRoute.isActive) {
+                                  navigator.removeRoute(loaderRoute);
+                                }
                                 var refreshedLSP = lspList.firstWhere(
                                   (lsp) =>
                                       lsp.lspID == lspStatus.currentLSP.lspID,
@@ -183,6 +190,9 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
                                 setState(() {
                                   _isInProgress = false;
                                 });
+                                if (loaderRoute.isActive) {
+                                  navigator.removeRoute(loaderRoute);
+                                }
                                 showFlushbar(
                                   context,
                                   message:

--- a/lib/routes/home/bottom_actions_bar.dart
+++ b/lib/routes/home/bottom_actions_bar.dart
@@ -358,34 +358,40 @@ Future showReceiveOptions(
                             if (v.refreshLSP || v.showLSPFee) {
                               final navigator = Navigator.of(context);
                               var loaderRoute = createLoaderRoute(context);
-                              navigator.push(loaderRoute);
+                              try {
+                                navigator.push(loaderRoute);
 
-                              final currentLSP = lspSnapshot.data.currentLSP;
-                              fetchLSPList(lspBloc).then(
-                                (lspList) {
-                                  if (loaderRoute.isActive) {
-                                    navigator.removeRoute(loaderRoute);
-                                  }
-                                  var refreshedLSP = lspList.firstWhere(
-                                    (lsp) => lsp.lspID == currentLSP.lspID,
-                                  );
-                                  (v.showLSPFee)
-                                      ? promptLSPFeeAndNavigate(
-                                          parentContext,
-                                          account,
-                                          refreshedLSP
-                                              .longestValidOpeningFeeParams,
-                                          v.route,
-                                        )
-                                      : Navigator.of(context)
-                                          .pushNamed(v.route);
-                                },
-                                onError: (_) {
-                                  if (loaderRoute.isActive) {
-                                    navigator.removeRoute(loaderRoute);
-                                  }
-                                },
-                              );
+                                final currentLSP = lspSnapshot.data.currentLSP;
+                                fetchLSPList(lspBloc).then(
+                                  (lspList) {
+                                    if (loaderRoute.isActive) {
+                                      navigator.removeRoute(loaderRoute);
+                                    }
+                                    var refreshedLSP = lspList.firstWhere(
+                                      (lsp) => lsp.lspID == currentLSP.lspID,
+                                    );
+                                    (v.showLSPFee)
+                                        ? promptLSPFeeAndNavigate(
+                                            parentContext,
+                                            account,
+                                            refreshedLSP
+                                                .longestValidOpeningFeeParams,
+                                            v.route,
+                                          )
+                                        : Navigator.of(context)
+                                            .pushNamed(v.route);
+                                  },
+                                  onError: (_) {
+                                    if (loaderRoute.isActive) {
+                                      navigator.removeRoute(loaderRoute);
+                                    }
+                                  },
+                                );
+                              } catch (e) {
+                                if (loaderRoute.isActive) {
+                                  navigator.removeRoute(loaderRoute);
+                                }
+                              }
                             } else {
                               Navigator.of(context).pushNamed(v.route);
                             }

--- a/lib/routes/home/bottom_actions_bar.dart
+++ b/lib/routes/home/bottom_actions_bar.dart
@@ -18,6 +18,7 @@ import 'package:breez/utils/dynamic_fees.dart';
 import 'package:breez/utils/stream_builder_extensions.dart';
 import 'package:breez/widgets/enter_payment_info_dialog.dart';
 import 'package:breez/widgets/escher_dialog.dart';
+import 'package:breez/widgets/loader.dart';
 import 'package:breez/widgets/lsp_fee.dart';
 import 'package:breez/widgets/route.dart';
 import 'package:breez/widgets/warning_box.dart';
@@ -355,9 +356,16 @@ Future showReceiveOptions(
                           onTap: () {
                             Navigator.of(context).pop();
                             if (v.refreshLSP || v.showLSPFee) {
+                              final navigator = Navigator.of(context);
+                              var loaderRoute = createLoaderRoute(context);
+                              navigator.push(loaderRoute);
+
                               final currentLSP = lspSnapshot.data.currentLSP;
                               fetchLSPList(lspBloc).then(
                                 (lspList) {
+                                  if (loaderRoute.isActive) {
+                                    navigator.removeRoute(loaderRoute);
+                                  }
                                   var refreshedLSP = lspList.firstWhere(
                                     (lsp) => lsp.lspID == currentLSP.lspID,
                                   );
@@ -371,6 +379,11 @@ Future showReceiveOptions(
                                         )
                                       : Navigator.of(context)
                                           .pushNamed(v.route);
+                                },
+                                onError: (_) {
+                                  if (loaderRoute.isActive) {
+                                    navigator.removeRoute(loaderRoute);
+                                  }
                                 },
                               );
                             } else {

--- a/lib/widgets/single_button_bottom_bar.dart
+++ b/lib/widgets/single_button_bottom_bar.dart
@@ -59,7 +59,7 @@ class SubmitButton extends StatelessWidget {
       child: ActionButton(
         text: text,
         onPressed: onPressed,
-        enabled: true,
+        enabled: onPressed != null ?? true,
         fill: true,
         variant: Variant.fab,
       ),


### PR DESCRIPTION
This PR adds a loader indicator when LSP's are being refreshed, mainly for users with very slow networks.

- Push a loader route when lsp's are being refreshed
  - Remove loader route on errors
- No longer disable create invoice button(as loader route will prevent clicks)
  - Disable create invoice button when LSP isn't connected yet 