### PR TITLE
check that nodeID can be parsed to hex

### DIFF
--- a/lib/utils/node_id.dart
+++ b/lib/utils/node_id.dart
@@ -1,3 +1,6 @@
+import 'package:convert/convert.dart';
+import 'package:hex/hex.dart';
+
 const NODE_URI_SEPARATOR = "@";
 const NODE_ID_LENGTH = 66;
 
@@ -5,15 +8,28 @@ String parseNodeId(String nodeID) {
   if (nodeID == null) {
     return null;
   }
-  if (nodeID.length == NODE_ID_LENGTH) {
+  nodeID = nodeID.trim();
+
+  if (nodeID.length == NODE_ID_LENGTH && _isParsable(nodeID)) {
     return nodeID;
   }
 
   if (nodeID.length > NODE_ID_LENGTH &&
       nodeID.substring(NODE_ID_LENGTH, NODE_ID_LENGTH + 1) ==
           NODE_URI_SEPARATOR) {
-    return nodeID.substring(0, 66);
+    nodeID = nodeID.substring(0, NODE_ID_LENGTH);
+    if (_isParsable(nodeID)) {
+      return nodeID;
+    }
   }
-
   return null;
+}
+
+bool _isParsable(String nodeID) {
+  try {
+    HEX.decode(nodeID);
+  } on FormatException catch (_) {
+    return false;
+  }
+  return true;
 }


### PR DESCRIPTION
# About PR


This pr check if we are able to parse the given nodeID to hex in order to avoid parsing lighting addresses which can be the same length as nodeID.
