### PR TITLE
Improve backup prompt logic & fix concurrency bugs

### DIFF
--- a/lib/bloc/backup/backup_bloc.dart
+++ b/lib/bloc/backup/backup_bloc.dart
@@ -91,7 +91,6 @@ class BackupBloc with AsyncActionsHandler {
         promptBackupStream,
         promptBackupDismissedStream,
         (settings, signInNeeded, dismissed) {
-          // If prompt is not dismissed or promptOnError is enabled
           return (settings.promptOnError && !dismissed) ? signInNeeded : false;
         },
       );

--- a/lib/bloc/backup/backup_bloc.dart
+++ b/lib/bloc/backup/backup_bloc.dart
@@ -54,6 +54,8 @@ class BackupBloc with AsyncActionsHandler {
       BehaviorSubject<bool>.seeded(false);
   Stream<bool> get promptBackupDismissedStream =>
       _promptBackupDismissedController.stream;
+  Sink<bool> get promptBackupDismissedSink =>
+      _promptBackupDismissedController.sink;
 
   final StreamController<bool> _backupPromptVisibleController =
       BehaviorSubject<bool>.seeded(false);
@@ -650,10 +652,6 @@ class BackupBloc with AsyncActionsHandler {
       _enableBackupPrompt = false;
       _promptBackupController.add(_backupServiceNeedLogin);
     }
-  }
-
-  void promptDismissed() {
-    _promptBackupDismissedController.add(true);
   }
 
   Future testAuth(BackupProvider provider, RemoteServerAuthData authData) {

--- a/lib/bloc/backup/backup_bloc.dart
+++ b/lib/bloc/backup/backup_bloc.dart
@@ -129,6 +129,8 @@ class BackupBloc with AsyncActionsHandler {
       RestoreBackup: _restoreBackup,
     };
 
+    _listenPaidInvoices();
+
     SharedPreferences.getInstance().then((sp) async {
       _sharedPreferences = sp;
       // Read the backupKey from the secure storage and initialize the breez user model appropriately
@@ -162,6 +164,13 @@ class BackupBloc with AsyncActionsHandler {
         handler(action).catchError((e) => action.resolveError(e));
       }
     });
+  }
+
+  void _listenPaidInvoices() {
+    _breezLib.notificationStream
+        .where((event) =>
+            event.type == NotificationEvent_NotificationType.INVOICE_PAID)
+        .listen((invoice) => _promptBackupDismissedController.add(false));
   }
 
   Future _updateBackupSettings(UpdateBackupSettings action) async {

--- a/lib/bloc/backup/backup_bloc.dart
+++ b/lib/bloc/backup/backup_bloc.dart
@@ -85,18 +85,16 @@ class BackupBloc with AsyncActionsHandler {
   final _backupActionsController = StreamController<AsyncAction>.broadcast();
   Sink<AsyncAction> get backupActionsSink => _backupActionsController.sink;
 
-  Stream<bool> get promptBackupSubscription => Rx.combineLatestList([
+  Stream<bool> get promptBackupSubscription =>
+      Rx.combineLatest3<BackupSettings, bool, bool, bool>(
         backupSettingsStream,
         promptBackupStream,
         promptBackupDismissedStream,
-      ]).where((list) {
-        final settings = list[0] as BackupSettings;
-        final dismissed = list[2] as bool;
-        return settings.promptOnError && !dismissed;
-      }).map((list) {
-        final needSignIn = list[1] as bool;
-        return needSignIn;
-      });
+        (settings, signInNeeded, dismissed) {
+          // If prompt is not dismissed or promptOnError is enabled
+          return (settings.promptOnError && !dismissed) ? signInNeeded : false;
+        },
+      );
 
   BreezBridge _breezLib;
   BackgroundTaskService _tasksService;

--- a/lib/bloc/backup/backup_bloc.dart
+++ b/lib/bloc/backup/backup_bloc.dart
@@ -467,7 +467,7 @@ class BackupBloc with AsyncActionsHandler {
   void _updateLastBackupTime(String modifiedTime) {
     _backupStateController.add(
       _backupStateController.value?.copyWith(
-        lastBackupTime: DateTime.tryParse(modifiedTime),
+        lastBackupTime: DateTime.tryParse(modifiedTime).toLocal(),
       ),
     );
   }

--- a/lib/bloc/backup/backup_model.dart
+++ b/lib/bloc/backup/backup_model.dart
@@ -228,6 +228,7 @@ class BackupState {
       : this(
           json["lastBackupTime"] != null
               ? DateTime.fromMillisecondsSinceEpoch(json["lastBackupTime"])
+                  .toLocal()
               : null,
           false,
           json["lastBackupAccountName"],

--- a/lib/bloc/backup/backup_model.dart
+++ b/lib/bloc/backup/backup_model.dart
@@ -86,21 +86,6 @@ enum BackupKeyType {
 }
 
 class BackupSettings {
-  static BackupProvider icloudBackupProvider() => BackupProvider(
-        "icloud",
-        getSystemAppLocalizations().backup_model_name_apple_icloud,
-      );
-
-  static BackupProvider googleBackupProvider() => BackupProvider(
-        "gdrive",
-        getSystemAppLocalizations().backup_model_name_google_drive,
-      );
-
-  static BackupProvider remoteServerBackupProvider() => BackupProvider(
-        "remoteserver",
-        getSystemAppLocalizations().backup_model_name_remote_server,
-      );
-
   final bool promptOnError;
   final BackupKeyType backupKeyType;
   final BackupProvider backupProvider;
@@ -119,17 +104,6 @@ class BackupSettings {
         _defaultBackupProvider(),
         const RemoteServerAuthData(null, null, null, null),
       );
-
-  static BackupProvider _defaultBackupProvider() {
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.android:
-        return googleBackupProvider();
-      case TargetPlatform.iOS:
-        return icloudBackupProvider();
-      default:
-        return null;
-    }
-  }
 
   BackupSettings copyWith({
     bool promptOnError,
@@ -164,17 +138,6 @@ class BackupSettings {
     };
   }
 
-  static List<BackupProvider> availableBackupProviders() {
-    List<BackupProvider> providers = [
-      googleBackupProvider(),
-      remoteServerBackupProvider()
-    ];
-    if (defaultTargetPlatform == TargetPlatform.iOS) {
-      providers.insert(0, icloudBackupProvider());
-    }
-    return providers;
-  }
-
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -197,6 +160,43 @@ class BackupSettings {
     return 'BackupSettings{promptOnError: $promptOnError, backupKeyType: $backupKeyType, '
         'backupProvider: $backupProvider, remoteServerAuthData: $remoteServerAuthData}';
   }
+
+  static BackupProvider _defaultBackupProvider() {
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return googleBackupProvider();
+      case TargetPlatform.iOS:
+        return icloudBackupProvider();
+      default:
+        return null;
+    }
+  }
+
+  static List<BackupProvider> availableBackupProviders() {
+    List<BackupProvider> providers = [
+      googleBackupProvider(),
+      remoteServerBackupProvider()
+    ];
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      providers.insert(0, icloudBackupProvider());
+    }
+    return providers;
+  }
+
+  static BackupProvider icloudBackupProvider() => BackupProvider(
+        "icloud",
+        getSystemAppLocalizations().backup_model_name_apple_icloud,
+      );
+
+  static BackupProvider googleBackupProvider() => BackupProvider(
+        "gdrive",
+        getSystemAppLocalizations().backup_model_name_google_drive,
+      );
+
+  static BackupProvider remoteServerBackupProvider() => BackupProvider(
+        "remoteserver",
+        getSystemAppLocalizations().backup_model_name_remote_server,
+      );
 }
 
 class BackupState {

--- a/lib/routes/account_required_actions.dart
+++ b/lib/routes/account_required_actions.dart
@@ -36,8 +36,6 @@ class AccountRequiredActionsIndicator extends StatefulWidget {
 class AccountRequiredActionsIndicatorState
     extends State<AccountRequiredActionsIndicator> {
   StreamSubscription<dynamic> _promptBackupSubscription;
-  StreamSubscription<BackupSettings> _backupSettingsSubscription;
-  BackupSettings _backupSettings;
   bool showingBackupDialog = false;
 
   @override
@@ -50,13 +48,6 @@ class AccountRequiredActionsIndicatorState
 
   void _initListeners() {
     final backupBloc = AppBlocsProvider.of<BackupBloc>(context);
-    _backupSettingsSubscription = backupBloc.backupSettingsStream.listen(
-      (backupSettings) {
-        setState(() {
-          _backupSettings = backupSettings;
-        });
-      },
-    );
 
     _promptBackupSubscription?.cancel();
     _promptBackupSubscription = backupBloc.promptBackupSubscription
@@ -79,7 +70,6 @@ class AccountRequiredActionsIndicatorState
         barrierDismissible: false,
         context: context,
         builder: (_) => EnableBackupDialog(
-          backupSettings: _backupSettings,
           signInNeeded: signInNeeded,
         ),
       ).then((_) {
@@ -93,7 +83,6 @@ class AccountRequiredActionsIndicatorState
   @override
   void dispose() {
     _promptBackupSubscription?.cancel();
-    _backupSettingsSubscription?.cancel();
     super.dispose();
   }
 
@@ -250,7 +239,6 @@ class AccountRequiredActionsIndicatorState
               barrierDismissible: false,
               context: context,
               builder: (_) => EnableBackupDialog(
-                backupSettings: _backupSettings,
                 signInNeeded: signInNeeded,
               ),
             );

--- a/lib/routes/account_required_actions.dart
+++ b/lib/routes/account_required_actions.dart
@@ -75,7 +75,7 @@ class AccountRequiredActionsIndicatorState
       ).then((_) {
         showingBackupDialog = false;
         backupBloc.backupPromptVisibleSink.add(false);
-        backupBloc.promptDismissed();
+        backupBloc.promptBackupDismissedSink.add(true);
       });
     }
   }

--- a/lib/routes/account_required_actions.dart
+++ b/lib/routes/account_required_actions.dart
@@ -49,26 +49,29 @@ class AccountRequiredActionsIndicatorState
   StreamSubscription<BackupSettings> _backupSettingsSubscription;
   BackupSettings _backupSettings;
   bool showingBackupDialog = false;
-  bool _init = false;
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (!_init) {
-      _backupSettingsSubscription =
-          widget._backupBloc.backupSettingsStream.listen(
-        (backupSettings) {
-          setState(() {
-            _backupSettings = backupSettings;
-          });
-        },
-      );
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initListeners();
+    });
+  }
 
-      _promptBackupSubscription?.cancel();
-      _promptBackupSubscription = widget._backupBloc.promptBackupSubscription
-          .delay(const Duration(seconds: 4))
-          .listen((signInNeeded) => _promptBackup(signInNeeded));
-    }
+  void _initListeners() {
+    _backupSettingsSubscription =
+        widget._backupBloc.backupSettingsStream.listen(
+      (backupSettings) {
+        setState(() {
+          _backupSettings = backupSettings;
+        });
+      },
+    );
+
+    _promptBackupSubscription?.cancel();
+    _promptBackupSubscription = widget._backupBloc.promptBackupSubscription
+        .delay(const Duration(seconds: 4))
+        .listen((signInNeeded) => _promptBackup(signInNeeded));
   }
 
   void _promptBackup(bool signInNeeded) async {

--- a/lib/routes/account_required_actions.dart
+++ b/lib/routes/account_required_actions.dart
@@ -61,7 +61,7 @@ class AccountRequiredActionsIndicatorState
       "prompt backup: {signInNeeded: $signInNeeded, "
       "showingBackupDialog: $showingBackupDialog}",
     );
-    if (!showingBackupDialog) {
+    if (signInNeeded && !showingBackupDialog) {
       showingBackupDialog = true;
       backupBloc.backupPromptVisibleSink.add(true);
       popFlushbars(context);

--- a/lib/routes/funds_over_limit_dialog.dart
+++ b/lib/routes/funds_over_limit_dialog.dart
@@ -2,6 +2,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez/bloc/account/account_actions.dart';
 import 'package:breez/bloc/account/account_bloc.dart';
 import 'package:breez/bloc/account/account_model.dart';
+import 'package:breez/bloc/blocs_provider.dart';
 import 'package:breez/theme_data.dart' as theme;
 import 'package:breez/widgets/loader.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
@@ -9,11 +10,8 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 class SwapRefundDialog extends StatefulWidget {
-  final AccountBloc accountBloc;
-
   const SwapRefundDialog({
     Key key,
-    this.accountBloc,
   }) : super(key: key);
 
   @override
@@ -28,13 +26,22 @@ class SwapRefundDialogState extends State<SwapRefundDialog> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _fetchSwapFundStatus();
+    });
+  }
+
+  void _fetchSwapFundStatus() {
+    final accountBloc = AppBlocsProvider.of<AccountBloc>(context);
     var fetchAction = FetchSwapFundStatus();
     _fetchFuture = fetchAction.future;
-    widget.accountBloc.userActionsSink.add(fetchAction);
+    accountBloc.userActionsSink.add(fetchAction);
   }
 
   @override
   Widget build(BuildContext context) {
+    final accountBloc = AppBlocsProvider.of<AccountBloc>(context);
+
     final themeData = Theme.of(context);
     final texts = context.texts();
 
@@ -55,7 +62,7 @@ class SwapRefundDialogState extends State<SwapRefundDialog> {
           }
 
           return StreamBuilder<AccountModel>(
-            stream: widget.accountBloc.accountStream,
+            stream: accountBloc.accountStream,
             builder: (ctx, snapshot) {
               final swapStatus = snapshot?.data?.swapFundsStatus;
               if (swapStatus == null) {

--- a/lib/routes/initial_walkthrough/dialogs/widgets/snapshot_info_tile.dart
+++ b/lib/routes/initial_walkthrough/dialogs/widgets/snapshot_info_tile.dart
@@ -38,7 +38,7 @@ class _SnapshotInfoTileState extends State<SnapshotInfoTile> {
         (widget.selectedSnapshot?.nodeID == widget.snapshotInfo.nodeID);
 
     var date = widget.snapshotInfo.modifiedTime;
-    var parsedDate = DateTime.tryParse(widget.snapshotInfo.modifiedTime);
+    var parsedDate = DateTime.tryParse(widget.snapshotInfo.modifiedTime).toLocal();
     if (parsedDate != null) {
       date = BreezDateUtils.formatYearMonthDayHourMinute(parsedDate);
     }

--- a/lib/routes/lsp/select_lsp_page.dart
+++ b/lib/routes/lsp/select_lsp_page.dart
@@ -1,20 +1,17 @@
+import 'package:breez/bloc/blocs_provider.dart';
 import 'package:breez/bloc/lsp/lsp_actions.dart';
 import 'package:breez/bloc/lsp/lsp_bloc.dart';
 import 'package:breez/bloc/lsp/lsp_model.dart';
+import 'package:breez/routes/lsp/lsp_webview.dart';
 import 'package:breez/widgets/loader.dart';
 import 'package:breez/widgets/route.dart';
 import 'package:breez/widgets/single_button_bottom_bar.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
 
-import 'lsp_webview.dart';
-
 class SelectLSPPage extends StatefulWidget {
-  final LSPBloc lstBloc;
-
   const SelectLSPPage({
     Key key,
-    this.lstBloc,
   }) : super(key: key);
 
   @override
@@ -30,12 +27,15 @@ class SelectLSPPageState extends State<SelectLSPPage> {
   @override
   void initState() {
     super.initState();
-    _fetchLSPS();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _fetchLSPS();
+    });
   }
 
   void _fetchLSPS() {
+    final lspBloc = AppBlocsProvider.of<LSPBloc>(context);
     var fetchAction = FetchLSPList();
-    widget.lstBloc.actionsSink.add(fetchAction);
+    lspBloc.actionsSink.add(fetchAction);
     fetchAction.future.then((result) {
       List<LSPInfo> lspList = result as List<LSPInfo>;
       var breezLSP = lspList.firstWhere(
@@ -56,6 +56,8 @@ class SelectLSPPageState extends State<SelectLSPPage> {
 
   @override
   Widget build(BuildContext context) {
+    final lspBloc = AppBlocsProvider.of<LSPBloc>(context);
+
     final themeData = Theme.of(context);
     final texts = context.texts();
 
@@ -75,7 +77,7 @@ class SelectLSPPageState extends State<SelectLSPPage> {
         ],
       ),
       body: StreamBuilder<LSPStatus>(
-        stream: widget.lstBloc.lspStatusStream,
+        stream: lspBloc.lspStatusStream,
         builder: (ctx, snapshot) {
           if (_error != null) {
             return Padding(
@@ -164,6 +166,7 @@ class SelectLSPPageState extends State<SelectLSPPage> {
       return SingleButtonBottomBar(
         text: texts.account_page_activation_action_select,
         onPressed: () async {
+          final lspBloc = AppBlocsProvider.of<LSPBloc>(context);
           final navigator = Navigator.of(context);
           ConnectLSP connectAction;
           if (url?.isNotEmpty == true) {
@@ -183,7 +186,7 @@ class SelectLSPPageState extends State<SelectLSPPage> {
           }
 
           if (connectAction != null) {
-            widget.lstBloc.actionsSink.add(connectAction);
+            lspBloc.actionsSink.add(connectAction);
             navigator.pop();
           }
         },

--- a/lib/user_app.dart
+++ b/lib/user_app.dart
@@ -245,9 +245,7 @@ class UserApp extends StatelessWidget {
                             case '/select_lsp':
                               return MaterialPageRoute(
                                 fullscreenDialog: true,
-                                builder: (_) => SelectLSPPage(
-                                  lstBloc: lspBloc,
-                                ),
+                                builder: (_) => const SelectLSPPage(),
                                 settings: settings,
                               );
                             case '/get_refund':

--- a/lib/widgets/enable_backup_dialog.dart
+++ b/lib/widgets/enable_backup_dialog.dart
@@ -96,7 +96,7 @@ class EnableBackupDialogState extends State<EnableBackupDialog> {
   }
 }
 
-class _DoNotPromptAgainCheckbox extends StatelessWidget {
+class _DoNotPromptAgainCheckbox extends StatefulWidget {
   final BackupSettings backupSettings;
   final AutoSizeGroup autoSizeGroup;
 
@@ -106,6 +106,12 @@ class _DoNotPromptAgainCheckbox extends StatelessWidget {
     @required this.backupSettings,
   }) : super(key: key);
 
+  @override
+  State<_DoNotPromptAgainCheckbox> createState() =>
+      _DoNotPromptAgainCheckboxState();
+}
+
+class _DoNotPromptAgainCheckboxState extends State<_DoNotPromptAgainCheckbox> {
   @override
   Widget build(BuildContext context) {
     final backupBloc = AppBlocsProvider.of<BackupBloc>(context);
@@ -123,18 +129,26 @@ class _DoNotPromptAgainCheckbox extends StatelessWidget {
             data: themeData.copyWith(
               unselectedWidgetColor: themeData.textTheme.labelLarge.color,
             ),
-            child: Checkbox(
-              activeColor: Colors.white,
-              checkColor: themeData.canvasColor,
-              value: !backupSettings.promptOnError,
-              onChanged: (v) {
-                backupBloc.backupSettingsSink.add(
-                  backupSettings.copyWith(
-                    promptOnError: !v,
-                  ),
-                );
-              },
-            ),
+            child: StreamBuilder<BackupSettings>(
+                stream: backupBloc.backupSettingsStream,
+                builder: (context, snapshot) {
+                  if (!snapshot.hasData) {
+                    return Container();
+                  }
+                  final backupSettings = snapshot.data;
+                  return Checkbox(
+                    activeColor: Colors.white,
+                    checkColor: themeData.canvasColor,
+                    value: !backupSettings.promptOnError,
+                    onChanged: (v) {
+                      backupBloc.backupSettingsSink.add(
+                        backupSettings.copyWith(
+                          promptOnError: !v,
+                        ),
+                      );
+                    },
+                  );
+                }),
           ),
           Expanded(
             child: AutoSizeText(
@@ -143,7 +157,7 @@ class _DoNotPromptAgainCheckbox extends StatelessWidget {
               maxLines: 1,
               minFontSize: MinFontSize(context).minFontSize,
               stepGranularity: 0.1,
-              group: autoSizeGroup,
+              group: widget.autoSizeGroup,
             ),
           )
         ],

--- a/lib/widgets/home/home_app_bar.dart
+++ b/lib/widgets/home/home_app_bar.dart
@@ -1,8 +1,5 @@
 import 'package:anytime/ui/widgets/layout_selector.dart';
-import 'package:breez/bloc/account/account_bloc.dart';
-import 'package:breez/bloc/backup/backup_bloc.dart';
 import 'package:breez/bloc/blocs_provider.dart';
-import 'package:breez/bloc/lsp/lsp_bloc.dart';
 import 'package:breez/bloc/user_profile/breez_user_model.dart';
 import 'package:breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:breez/routes/account_required_actions.dart';
@@ -34,7 +31,9 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
         final appMode = userSnapshot.data?.appMode;
 
         return AppBar(
-          systemOverlayStyle: theme.themeId == "BLUE" ? SystemUiOverlayStyle.dark : appBar.systemOverlayStyle,
+          systemOverlayStyle: theme.themeId == "BLUE"
+              ? SystemUiOverlayStyle.dark
+              : appBar.systemOverlayStyle,
           iconTheme: const IconThemeData(
             color: Color.fromARGB(255, 0, 133, 251),
           ),
@@ -74,12 +73,7 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
               padding: appMode == AppMode.podcasts
                   ? const EdgeInsets.all(14)
                   : const EdgeInsets.fromLTRB(14, 14, 0, 14),
-              // TODO make AccountRequiredActionsIndicator reads its own blocs
-              child: AccountRequiredActionsIndicator(
-                AppBlocsProvider.of<BackupBloc>(context),
-                AppBlocsProvider.of<AccountBloc>(context),
-                AppBlocsProvider.of<LSPBloc>(context),
-              ),
+              child: AccountRequiredActionsIndicator(),
             ),
             if (appMode == AppMode.podcasts)
               Padding(


### PR DESCRIPTION
This PR introduces changes in 
- #1121 
to 
- #1189


> Behavior changes:
> - Makes `promptBackupController` a behavior subject fixing https://github.com/breez/breezmobile/issues/1116
> - Add a `promptBackupDismissedStream` to avoid multiple prompts in the same session
> - Add a few logs to help bug reports
> - Makes `pushPrompt` take into account only `_enableBackupPrompt`
> - Makes `AccountRequiredActionsIndicator` reads its own blocs
> - Unify streams on `AccountRequiredActionsIndicator` using `combineLatestList`
> 