### PR TITLE
Use local time for latest backup time

### DIFF
--- a/lib/bloc/backup/backup_bloc.dart
+++ b/lib/bloc/backup/backup_bloc.dart
@@ -467,7 +467,7 @@ class BackupBloc with AsyncActionsHandler {
   void _updateLastBackupTime(String modifiedTime) {
     _backupStateController.add(
       _backupStateController.value?.copyWith(
-        lastBackupTime: DateTime.tryParse(modifiedTime),
+        lastBackupTime: DateTime.tryParse(modifiedTime).toLocal(),
       ),
     );
   }

--- a/lib/bloc/backup/backup_model.dart
+++ b/lib/bloc/backup/backup_model.dart
@@ -228,6 +228,7 @@ class BackupState {
       : this(
           json["lastBackupTime"] != null
               ? DateTime.fromMillisecondsSinceEpoch(json["lastBackupTime"])
+                  .toLocal()
               : null,
           false,
           json["lastBackupAccountName"],

--- a/lib/routes/initial_walkthrough/dialogs/widgets/snapshot_info_tile.dart
+++ b/lib/routes/initial_walkthrough/dialogs/widgets/snapshot_info_tile.dart
@@ -38,7 +38,7 @@ class _SnapshotInfoTileState extends State<SnapshotInfoTile> {
         (widget.selectedSnapshot?.nodeID == widget.snapshotInfo.nodeID);
 
     var date = widget.snapshotInfo.modifiedTime;
-    var parsedDate = DateTime.tryParse(widget.snapshotInfo.modifiedTime);
+    var parsedDate = DateTime.tryParse(widget.snapshotInfo.modifiedTime).toLocal();
     if (parsedDate != null) {
       date = BreezDateUtils.formatYearMonthDayHourMinute(parsedDate);
     }


### PR DESCRIPTION
Latest backup time is stored in UTC and this can be confusing from the users perspective.

Latest backup time is converted to local time
- after restoring snapshot,
- when initializing `BackupState` from persistent data,
- When displaying snapshot list on `RestoreDialog`