### PR TITLE
Allow users to switch Google accounts on restore flow

### DIFF
--- a/lib/bloc/backup/backup_actions.dart
+++ b/lib/bloc/backup/backup_actions.dart
@@ -28,3 +28,7 @@ class RestoreBackup extends AsyncAction {
 
   RestoreBackup(this.restoreRequest);
 }
+
+class SignOut extends AsyncAction {
+  SignOut();
+}

--- a/lib/bloc/backup/backup_bloc.dart
+++ b/lib/bloc/backup/backup_bloc.dart
@@ -126,6 +126,7 @@ class BackupBloc with AsyncActionsHandler {
       DownloadSnapshot: _downloadSnapshot,
       ListSnapshots: _listSnapshots,
       RestoreBackup: _restoreBackup,
+      SignOut: _signOut,
     };
 
     _listenPaidInvoices();
@@ -470,6 +471,10 @@ class BackupBloc with AsyncActionsHandler {
         lastBackupTime: DateTime.tryParse(modifiedTime).toLocal(),
       ),
     );
+  }
+
+  Future _signOut(SignOut action) async {
+    action.resolve(await _breezLib.signOut().catchError((_) => null));
   }
 
   _scheduleBackgroundTasks() {

--- a/lib/routes/initial_walkthrough/initial_walkthrough.dart
+++ b/lib/routes/initial_walkthrough/initial_walkthrough.dart
@@ -253,12 +253,18 @@ class _InitialWalkthroughPageState extends State<InitialWalkthroughPage>
 
   void _restoreFromBackup() async {
     log.info("Restore from Backup");
-
+    await _signOut();
     _showSelectProviderDialog().then((snapshots) {
       _showRestoreDialog(snapshots).then((restoreRequest) {
         _restore(restoreRequest);
       });
     });
+  }
+
+  Future _signOut() {
+    var signOutAction = SignOut();
+    widget.backupBloc.backupActionsSink.add(signOutAction);
+    return signOutAction.future;
   }
 
   Future<List<SnapshotInfo>> _showSelectProviderDialog() {


### PR DESCRIPTION
Previously, users were stuck with the Google account they signed into first on restore flow and it required a fresh install to sign in with another account.

Now we're calling sign out before provider selection dialog is shown*. This change allows users to switch Google accounts on restore. 

*: Only on restore flow, this does not affect provider selection dialog on Security & Backup settings.