### PR TITLE
remove `_backupServiceNeedLogin` in backup_bloc

### DIFF
--- a/lib/routes/account_required_actions.dart
+++ b/lib/routes/account_required_actions.dart
@@ -24,7 +24,6 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:rxdart/rxdart.dart';
 
 class AccountRequiredActionsIndicator extends StatefulWidget {
   @override
@@ -51,7 +50,6 @@ class AccountRequiredActionsIndicatorState
 
     _promptBackupSubscription?.cancel();
     _promptBackupSubscription = backupBloc.promptBackupSubscription
-        .delay(const Duration(seconds: 4))
         .listen((signInNeeded) => _promptBackup(signInNeeded));
   }
 


### PR DESCRIPTION
I think we can simplify the backup_block by removing the `_backupServiceNeedLogin` variable. This solved the issue where the user had to authenticate and accept terms twice on a fresh install. GDrive also seems to upload and sync properly when needed.

Removed the timeout from _prompt_backup.