### PR TITLE
Add debug build config

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -49,10 +49,22 @@ android {
                 println("No storeFile provided, release builds are not possible")
             }
         }
+        debug {
+            String filePath = keystoreProperties['storeFileDebug']
+            if (filePath != null) {
+                keyAlias keystoreProperties['aliasDebug']
+                keyPassword keystoreProperties['passwordDebug']
+                storeFile file(filePath)
+                storePassword keystoreProperties['passwordDebug']
+            } else {
+                println("No storeFile provided, debug builds are using your local debug keystore")
+            }
+        }
     }
 
     buildTypes {
         debug {
+            signingConfig signingConfigs.debug
             applicationIdSuffix '.debug'
             versionNameSuffix '-DEBUG'
             resValue "string", "app_name", "Breez Debug"


### PR DESCRIPTION
Add a debug config section so we can share a debug keystore to test google/firebase integrations functionalities