### PR TITLE
Address backup feedback

### DIFF
--- a/android/app/src/main/java/com/breez/client/plugins/breez/breezlib/GoogleAuthenticator.java
+++ b/android/app/src/main/java/com/breez/client/plugins/breez/breezlib/GoogleAuthenticator.java
@@ -71,6 +71,9 @@ public class GoogleAuthenticator implements PluginRegistry.ActivityResultListene
                     Log.d(TAG, "Google silentSignIn succeed.");
                     return signedInAccount;
                 } else {
+                    if(silent){
+                        throw new Exception("AuthError");
+                    }
                     // There's no immediate result ready
                     return Tasks.await(signIn());
                 }

--- a/android/app/src/main/java/com/breez/client/plugins/breez/breezlib/GoogleAuthenticator.java
+++ b/android/app/src/main/java/com/breez/client/plugins/breez/breezlib/GoogleAuthenticator.java
@@ -94,7 +94,6 @@ public class GoogleAuthenticator implements PluginRegistry.ActivityResultListene
 
     public String getAccessToken() throws Exception {
         Log.d(TAG, "getAccessToken");
-        m_signInClient = createSignInClient();
         GoogleSignInAccount googleAccount = ensureSignedIn(true);
         try {
             GoogleAccountCredential credential = credential();

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -18,10 +18,6 @@
 		<string>sk</string>
 		<string>sv</string>
 	</array>
-	<key>com.apple.developer.icloud-services</key>
-    <array>
-        <string>CloudKit</string>
-    </array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/lib/routes/security_pin/security_and_backup/backup_tiles/backup_provider_tile.dart
+++ b/lib/routes/security_pin/security_and_backup/backup_tiles/backup_provider_tile.dart
@@ -96,8 +96,7 @@ class _BackupProviderTileState extends State<BackupProviderTile> {
     final backupBloc = AppBlocsProvider.of<BackupBloc>(context);
     return await backupBloc.backupStateStream.first.then(
       (backupState) async {
-        if ((backupState != BackupState.start() && previousProvider.isGDrive) ||
-            previousProvider.isGDrive) {
+        if (backupState != BackupState.start() && previousProvider.isGDrive) {
           return await promptAreYouSure(
             context,
             "Logout Warning",


### PR DESCRIPTION
This PR addresses feedback & issues found from the latest review on 
- #1183

### Changelist:
- Don't prompt sign in if request is silent
  - This caused an issue on new accounts on Android where user got bombarded with sign in prompts, that is if they cancelled each one, wherever they were on the app.
### Cleanup changes:
  - Do not recreate sign in client on calling getAccessToken
  - Remove CloudKit from Info.plist [Waiting on TestFlight for confirmation]
  - Remove obsolete OR condition