### PR TITLE
Fix wrong input parse format

### DIFF
--- a/lib/bloc/lnurl/lnurl_model.dart
+++ b/lib/bloc/lnurl/lnurl_model.dart
@@ -1,3 +1,4 @@
+import 'package:breez/bloc/user_profile/currency.dart';
 import 'package:breez/services/breezlib/data/messages.pb.dart';
 import 'package:fixnum/fixnum.dart';
 
@@ -10,6 +11,12 @@ class WithdrawFetchResponse {
   Int64 get minAmount => response.minAmount;
   Int64 get maxAmount => response.maxAmount;
   bool get isFixedAmount => response.minAmount == response.maxAmount;
+
+  @override
+  String toString() {
+    return 'WithdrawFetchResponse{defaultDescription: $defaultDescription, '
+        'minAmount: $minAmount, maxAmount: $maxAmount, isFixedAmount: $isFixedAmount}';
+  }
 }
 
 class ChannelFetchResponse {

--- a/lib/bloc/user_profile/currency.dart
+++ b/lib/bloc/user_profile/currency.dart
@@ -71,6 +71,11 @@ class Currency extends Object {
   }
 
   double get satConversionRate => this == SAT ? 1.0 : 100000000;
+
+  @override
+  String toString() {
+    return 'Currency{tickerSymbol: $tickerSymbol}';
+  }
 }
 
 class _CurrencyFormatter {

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -587,7 +587,10 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
     _withdrawFetchResponse = response;
     _descriptionController.text = response.defaultDescription;
     if (response.isFixedAmount) {
-      _amountController.text = "${response.minAmount}";
+      _amountController.text = account.currency.format(
+        response.minAmount,
+        includeDisplayName: false,
+      );
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/breez/breezmobile/issues/1138
The bug's origin is that we were not using the account model currency to format the amount at `applyWithdrawFetchResponse`, this PR fixes it.
Also adding "toString" for WithdrawFetchResponse and Currency helped 

|Sats|BTC|Hide|
|---|---|---|
|<video src="https://github.com/breez/breezmobile/assets/1225438/c1cc4086-3688-4098-841e-e7bc6db484d7" />|<video src="https://github.com/breez/breezmobile/assets/1225438/a897f3ba-5447-46c7-b872-5ba143cb3404" />|<video src="https://github.com/breez/breezmobile/assets/1225438/446d397c-7d8f-47da-82ef-793050db8198" />|

the debug process.