### PR TITLE
Fix safe area on qr code read page

### DIFF
--- a/lib/routes/qr_scan.dart
+++ b/lib/routes/qr_scan.dart
@@ -62,20 +62,26 @@ class QRScanState extends State<QRScan> {
               ],
             ),
           ),
-          Positioned(
-            right: 10,
-            top: 5,
-            child: ImagePickerButton(cameraController),
-          ),
-          Positioned(
-            bottom: 30.0,
-            right: 0,
-            left: 0,
-            child: defaultTargetPlatform == TargetPlatform.iOS
-                ? const QRScanCancelButton()
-                : const SizedBox(),
-          ),
           const ScanOverlay(),
+          SafeArea(
+            child: Stack(
+              children: [
+                Positioned(
+                  right: 10,
+                  top: 5,
+                  child: ImagePickerButton(cameraController),
+                ),
+                Positioned(
+                  bottom: 30.0,
+                  right: 0,
+                  left: 0,
+                  child: defaultTargetPlatform == TargetPlatform.iOS
+                      ? const QRScanCancelButton()
+                      : const SizedBox(),
+                ),
+              ],
+            ),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
Fix https://github.com/breez/breezmobile/issues/1178
I'm simulating the behavior on Android:

![safe area-min](https://github.com/breez/breezmobile/assets/1225438/66da4eb8-5c2d-4203-8217-f5d98404af57)
