### PR TITLE
Apps: fix broken Azteco link

### DIFF
--- a/src/json/vendors.json
+++ b/src/json/vendors.json
@@ -25,7 +25,7 @@
     "responseID": "lnurl"
   },
   "Azteco": {
-    "url": "https://azte.co/breezmap.php"
+    "url": "https://azte.co/"
   },
   "Boltz": {
     "url": "https://boltz.exchange/swapbox"


### PR DESCRIPTION
current link is not working 
![image](https://github.com/breez/breezmobile/assets/93143998/f6ddab60-ca7a-49e7-a6ac-789a6f5975b3)

let me know if a new referral link should be used, then I'll add it 
Or maybe the problem is at Azteco side