### PR TITLE
[support case]fix null issue

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -33,7 +33,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.16.4</string>
+	<string>0.16.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/lib/routes/security_pin/security_and_backup/security_and_backup_page.dart
+++ b/lib/routes/security_pin/security_and_backup/security_and_backup_page.dart
@@ -169,8 +169,8 @@ class SecurityAndBackupPageState extends State<SecurityAndBackupPage>
                   }
 
                   final backupSettings = backupSnapshot.data;
-                  final isRemoteServer =
-                      backupSettings.backupProvider?.isRemoteServer;
+                  final isRemoteServer = (backupSettings != null &&
+                      backupSettings.backupProvider.isRemoteServer);
 
                   return ListView(
                     children: [

--- a/lib/widgets/enable_backup_dialog.dart
+++ b/lib/widgets/enable_backup_dialog.dart
@@ -48,7 +48,8 @@ class EnableBackupDialogState extends State<EnableBackupDialog> {
           }
 
           final backupSettings = snapshot.data;
-          bool isRemoteServer = backupSettings.backupProvider?.isRemoteServer;
+          bool isRemoteServer = (backupSettings != null &&
+              backupSettings.backupProvider.isRemoteServer);
 
           return AlertDialog(
             titlePadding: const EdgeInsets.fromLTRB(24.0, 22.0, 0.0, 16.0),


### PR DESCRIPTION
Received a support case where user ran into issues when going to the security and backup page with the current iOS app store version.


`BIND: Failed assertion: boolean expression must not be null
#0      SecurityAndBackupPageState.build.<anonymous closure>.<anonymous closure> (package:breez/routes/security_pin/security_and_backup/security_and_backup_page.dart:217)
#1      StreamBuilder.build (package:flutter/src/widgets/async.dart:444)
`
and 

`Failed assertion: boolean expression must not be null
#0      EnableBackupDialogState.build.<anonymous closure> (package:breez/widgets/enable_backup_dialog.dart:69)`