### PR TITLE
Check instalation source on Andriod and open github page instead of google play store if the instalation source is not google play

### DIFF
--- a/lib/handlers/check_version_handler.dart
+++ b/lib/handlers/check_version_handler.dart
@@ -4,80 +4,141 @@ import 'package:breez/bloc/blocs_provider.dart';
 import 'package:breez/bloc/user_profile/user_actions.dart';
 import 'package:breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:breez/theme_data.dart' as theme;
+import 'package:breez/utils/exceptions.dart';
 import 'package:breez/widgets/flushbar.dart';
 import 'package:breez/widgets/no_connection_dialog.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:logging/logging.dart';
+import 'package:store_checker/store_checker.dart';
 import 'package:url_launcher/url_launcher_string.dart';
+
+final _log = Logger("CheckVersionHandler");
 
 void checkVersionDialog(
   BuildContext context,
   UserProfileBloc userProfileBloc,
 ) {
-  final texts = context.texts();
-  final themeData = Theme.of(context);
-  AccountBloc accBloc = AppBlocsProvider.of<AccountBloc>(context);
+  _log.info("checkVersionDialog");
   CheckVersion action = CheckVersion();
   userProfileBloc.userActionsSink.add(action);
-  action.future.catchError((err) {
-    bool upgrading = err.contains('upgrading');
+  action.future.then((value) => _log.info("Done $value"), onError: (error) {
+    _log.info("checkVersionDialog error: $error");
+    bool upgrading = error.contains('upgrading');
     if (upgrading) {
-      accBloc.setNodeUpgrading(true);
-      showFlushbar(
-        context,
-        isDismissible: false,
-        position: FlushbarPosition.TOP,
-        duration: Duration.zero,
-        messageWidget: Text(
-          "Breez is currently upgrading its servers. You won't be able to send or receive funds during the upgrade. Please try again later.",
-          style: theme.snackBarStyle,
-          textAlign: TextAlign.left,
-        ),
-        buttonText: "",
-        icon: SvgPicture.asset(
-          "src/icon/warning.svg",
-          colorFilter: ColorFilter.mode(
-            themeData.colorScheme.error,
-            BlendMode.srcATop,
-          ),
-        ),
-      );
-    }
-    if (err.contains('connection error')) {
-      showNoConnectionDialog(context).then((retry) {
-        if (kDebugMode) {
-          print("-- showNoConnectionDialog --\n$retry");
-        }
-        if (retry == true) {
-          Future.delayed(const Duration(seconds: 1), () {
-            checkVersionDialog(context, userProfileBloc);
-          });
-        }
-      });
-    } else if (!upgrading && err.contains('bad version')) {
-      showFlushbar(
-        context,
-        buttonText: texts.handler_check_version_action_update,
-        onDismiss: () {
-          if (defaultTargetPlatform == TargetPlatform.iOS) {
-            launchUrlString('https://testflight.apple.com/join/wPju2Du7');
-          }
-          if (defaultTargetPlatform == TargetPlatform.android) {
-            launchUrlString(
-                'https://play.google.com/apps/testing/com.breez.client');
-          }
-          return false;
-        },
-        position: FlushbarPosition.TOP,
-        duration: Duration.zero,
-        messageWidget: Text(
-          texts.handler_check_version_message,
-          style: theme.snackBarStyle,
-          textAlign: TextAlign.center,
-        ),
-      );
+      _handleUpgrading(context, userProfileBloc);
+    } else if (error.contains('connection error')) {
+      _handleConnectionError(context, userProfileBloc);
+    } else if (!upgrading && error.contains('bad version')) {
+      _handleBadVersion(context);
+    } else {
+      _log.info("Unhandled error $error");
     }
   });
+}
+
+void _handleUpgrading(
+  BuildContext context,
+  UserProfileBloc userProfileBloc,
+) {
+  _log.info("_handleUpgrading");
+  final texts = context.texts();
+  final themeData = Theme.of(context);
+
+  AccountBloc accBloc = AppBlocsProvider.of<AccountBloc>(context);
+  accBloc.setNodeUpgrading(true);
+
+  showFlushbar(
+    context,
+    isDismissible: false,
+    position: FlushbarPosition.TOP,
+    duration: Duration.zero,
+    messageWidget: Text(
+      texts.handler_check_version_error_upgrading_servers,
+      style: theme.snackBarStyle,
+      textAlign: TextAlign.left,
+    ),
+    buttonText: "",
+    icon: SvgPicture.asset(
+      "src/icon/warning.svg",
+      colorFilter: ColorFilter.mode(
+        themeData.colorScheme.error,
+        BlendMode.srcATop,
+      ),
+    ),
+  );
+}
+
+void _handleConnectionError(
+  BuildContext context,
+  UserProfileBloc userProfileBloc,
+) {
+  _log.info("_handleConnectionError");
+  showNoConnectionDialog(context).then((retry) {
+    _log.info("-- showNoConnectionDialog --\n$retry");
+
+    if (retry == true) {
+      Future.delayed(const Duration(seconds: 1), () {
+        checkVersionDialog(context, userProfileBloc);
+      });
+    }
+  });
+}
+
+void _handleBadVersion(
+  BuildContext context,
+) {
+  _log.info("_handleBadVersion");
+  final texts = context.texts();
+
+  showFlushbar(
+    context,
+    buttonText: texts.handler_check_version_action_update,
+    onDismiss: () {
+      _log.info("onDismiss $defaultTargetPlatform");
+      StoreChecker.getSource.then((installationSource) {
+        _launchStoreForUpdate(installationSource);
+      }, onError: (error) {
+        _log.warning("StoreChecker.getSource error: $error");
+        showFlushbar(
+          context,
+          position: FlushbarPosition.TOP,
+          duration: Duration.zero,
+          messageWidget: Text(
+            extractExceptionMessage(error),
+            style: theme.snackBarStyle,
+            textAlign: TextAlign.center,
+          ),
+        );
+      });
+      return false;
+    },
+    position: FlushbarPosition.TOP,
+    duration: Duration.zero,
+    messageWidget: Text(
+      texts.handler_check_version_message,
+      style: theme.snackBarStyle,
+      textAlign: TextAlign.center,
+    ),
+  );
+}
+
+void _launchStoreForUpdate(Source installationSource) {
+  _log.info("_launchStoreForUpdate $installationSource platform: $defaultTargetPlatform");
+  if (defaultTargetPlatform == TargetPlatform.iOS) {
+    if (installationSource == Source.IS_INSTALLED_FROM_APP_STORE) {
+      launchUrlString('https://apps.apple.com/app/breez-lightning-client-pos/id1463604142');
+    } else {
+      launchUrlString('https://testflight.apple.com/join/wPju2Du7');
+    }
+  } else if (defaultTargetPlatform == TargetPlatform.android) {
+    _log.info("StoreChecker.getSource: $installationSource");
+    if (installationSource == Source.IS_INSTALLED_FROM_PLAY_STORE) {
+      launchUrlString('https://play.google.com/apps/testing/com.breez.client');
+    } else {
+      launchUrlString('https://github.com/breez/breezmobile/releases');
+    }
+  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -190,8 +190,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "5acdc444d8d1715c224ac6be2d266468e22e2658"
-      resolved-ref: "5acdc444d8d1715c224ac6be2d266468e22e2658"
+      ref: db1ed37860d4378316e23ab52c5c21d32b4e7831
+      resolved-ref: db1ed37860d4378316e23ab52c5c21d32b4e7831
       url: "https://github.com/breez/Breez-Translations.git"
     source: git
     version: "1.0.0"
@@ -1819,6 +1819,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.0"
+  store_checker:
+    dependency: "direct main"
+    description:
+      name: store_checker
+      sha256: c9c1a93f11fa756fea23a2a08d7e54e84626a8d3c759cf49fc694a3a5afdc705
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   breez_translations:
     git:
       url: https://github.com/breez/Breez-Translations.git
-      ref: 5acdc444d8d1715c224ac6be2d266468e22e2658
+      ref: db1ed37860d4378316e23ab52c5c21d32b4e7831
   clipboard_watcher: ^0.2.0
   collection: ^1.18.0
   confetti: ^0.7.0
@@ -85,6 +85,7 @@ dependencies:
   shimmer: ^3.0.0
   simple_animations: ^5.0.2
   sqflite: <2.3.0 # Requires Flutter 3.10
+  store_checker: ^1.4.0
   timeago: ^3.5.0
   tutorial_coach_mark: ^1.2.9
   uni_links: ^0.5.1


### PR DESCRIPTION
Related https://github.com/breez/breezmobile/issues/413

If the app is installed from Google Play, it opens Google Play as it is today, if the installation source is somewhere else, it opens the release page on GitHub

Also breaking the method into smaller methods and adding logs

How it looks like:

https://github.com/breez/breezmobile/assets/1225438/788e24cf-33e1-48a9-b535-07a028dfcd5b

