### PR TITLE
Allow two lines for shareable payment row

### DIFF
--- a/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
@@ -37,7 +37,7 @@ class ShareablePaymentRow extends StatelessWidget {
         title: AutoSizeText(
           title,
           style: themeData.primaryTextTheme.headlineMedium,
-          maxLines: 1,
+          maxLines: 2,
           group: labelAutoSizeGroup,
         ),
         children: [


### PR DESCRIPTION
Today the shareable payment row is blocking the text as a single line; Despite being an AutoSizeText that works for English; it will be broken in other languages that need bigger phrases.

In this PR I'm changing the row to allow 2 lines; this change plus the AutoSizeText, is reasonable to assume it will be good for all languages.

# How to test
- Open the payment dialog
- You should see all the text (even if needed two lines)

# Screenshots

|Real example with the Bulgarian language|Before|After|
|---|---|---|
|![image](https://github.com/breez/breezmobile/assets/1225438/1dccbf35-2c8e-411b-a000-5d988e7746fc)|![before](https://github.com/breez/breezmobile/assets/1225438/65f13ca4-b7b6-41b1-9868-6cbc220ae778)|![after](https://github.com/breez/breezmobile/assets/1225438/ae8b8ab0-8433-41d8-9768-b6c09afcd22e)|

