### PR TITLE
ensure valid channel before signin

### DIFF
--- a/lib/services/breez_server/server.dart
+++ b/lib/services/breez_server/server.dart
@@ -19,6 +19,7 @@ class BreezServer {
   ClientChannel _channel;
 
   Future<String> signUrl(String baseUrl, String queryString) async {
+    await _ensureValidChannel();
     var signerClient = SignerClient(_channel);
     var response = await signerClient.signUrl(SignUrlRequest()
       ..baseUrl = baseUrl


### PR DESCRIPTION
Fixes issue where we haven't established an active channel to breez server before attempting to signin. This caused issues for users trying to open moonpay immediately after opening the app.