### PR TITLE
Add value time split

### DIFF
--- a/lib/bloc/podcast_payments/actions.dart
+++ b/lib/bloc/podcast_payments/actions.dart
@@ -4,11 +4,13 @@ class PayBoost extends AsyncAction {
   final int sats;
   final String boostMessage;
   final String senderName;
+  final double time;
 
   PayBoost(
     this.sats, {
     this.boostMessage,
     this.senderName,
+    this.time,
   });
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:breez/bloc/podcast_payments/podcast_payments_bloc.dart';
 import 'package:breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:breez/logger.dart';
 import 'package:breez/routes/initial_walkthrough/loaders/loader_indicator.dart';
+import 'package:breez/routes/podcast/podcast_loader.dart';
 import 'package:breez/routes/podcast/podcast_page.dart';
 import 'package:breez/services/breezlib/breez_bridge.dart';
 import 'package:breez/services/injector.dart';
@@ -56,11 +57,13 @@ void main() async {
               Provider<PodcastPaymentsBloc>(
                 lazy: false,
                 create: (ctx) => PodcastPaymentsBloc(
-                    blocs.userProfileBloc,
-                    blocs.accountBloc,
-                    Provider.of<SettingsBloc>(ctx, listen: false),
-                    Provider.of<AudioBloc>(ctx, listen: false),
-                    repository),
+                  blocs.userProfileBloc,
+                  blocs.accountBloc,
+                  Provider.of<SettingsBloc>(ctx, listen: false),
+                  Provider.of<AudioBloc>(ctx, listen: false),
+                  repository,
+                  PodcastIndexClient(),
+                ),
                 dispose: (_, value) => value.dispose(),
                 child: PlayerControlsBuilder(
                     builder: playerBuilder,

--- a/lib/routes/podcast/payment_adjustment.dart
+++ b/lib/routes/podcast/payment_adjustment.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:anytime/bloc/podcast/audio_bloc.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez/bloc/blocs_provider.dart';
 import 'package:breez/bloc/podcast_payments/actions.dart';
@@ -11,15 +12,17 @@ import 'package:breez/bloc/user_profile/breez_user_model.dart';
 import 'package:breez/bloc/user_profile/user_actions.dart';
 import 'package:breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:breez/routes/podcast/boost.dart';
+import 'package:breez/routes/podcast/confetti.dart';
 import 'package:breez/routes/podcast/payment_adjuster.dart';
 import 'package:breez/routes/podcast/theme.dart';
 import 'package:breez/widgets/loader.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
 import 'package:provider/provider.dart';
 import 'package:tutorial_coach_mark/tutorial_coach_mark.dart';
 
-import 'confetti.dart';
+final _log = Logger("PaymentAdjustment");
 
 class PaymentAdjustment extends StatefulWidget {
   const PaymentAdjustment({
@@ -297,11 +300,17 @@ class PaymentAdjustmentState extends State<PaymentAdjustment> {
             key: boostWidgetKey,
             userModel: userModel,
             onBoost: (int boostAmount, {String boostMessage}) {
-              paymentsBloc.actionsSink.add(PayBoost(
-                boostAmount,
-                boostMessage: boostMessage,
-                senderName: userModel.name,
-              ));
+              _log.info("Boosting $boostAmount sats, message $boostMessage");
+              Provider.of<AudioBloc>(context, listen: false).playPosition.first.then((state) {
+                paymentsBloc.actionsSink.add(PayBoost(
+                  boostAmount,
+                  boostMessage: boostMessage,
+                  senderName: userModel.name,
+                  time: state.position.inSeconds.toDouble(),
+                ));
+              }, onError: (e) {
+                _log.warning("Error getting position", e);
+              });
             },
             onChanged: (int boostAmount) {
               userProfileBloc.userActionsSink.add(SetPaymentOptions(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,8 +37,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: f8eb92fb61165b1eb018d928adcf689f0bc9e554
-      resolved-ref: f8eb92fb61165b1eb018d928adcf689f0bc9e554
+      ref: c30de552580d8e64233c4372a7e438b0550de64e
+      resolved-ref: c30de552580d8e64233c4372a7e438b0550de64e
       url: "https://github.com/breez/anytime_podcast_player.git"
     source: git
     version: "1.2.1+74-breez"
@@ -403,15 +403,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
-  dart_rss:
-    dependency: transitive
-    description:
-      path: "."
-      ref: dc20ec54b484ff2ba4956c86b936ab664a36483c
-      resolved-ref: dc20ec54b484ff2ba4956c86b936ab664a36483c
-      url: "https://github.com/breez/dart-rss"
-    source: git
-    version: "2.0.1-breez"
   dart_style:
     dependency: transitive
     description:
@@ -1512,11 +1503,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "5bd8e96728291b11dbc4b1fbac123681000be07d"
-      resolved-ref: "5bd8e96728291b11dbc4b1fbac123681000be07d"
+      ref: a2dfc441a6ba3c506ef15b1dd881a03d15254ccf
+      resolved-ref: a2dfc441a6ba3c506ef15b1dd881a03d15254ccf
       url: "https://github.com/breez/podcast_search.git"
     source: git
-    version: "0.5.2"
+    version: "0.5.1"
   pointycastle:
     dependency: transitive
     description:
@@ -2099,6 +2090,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  webfeed:
+    dependency: transitive
+    description:
+      path: "."
+      ref: "0586eb3d169d5e84bc467261214262e628a8057e"
+      resolved-ref: "0586eb3d169d5e84bc467261214262e628a8057e"
+      url: "https://github.com/breez/dart-rss"
+    source: git
+    version: "2.0.1-breez"
   webkit_inspection_protocol:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -101,7 +101,7 @@ dependencies:
   anytime:
     git:
       url: https://github.com/breez/anytime_podcast_player.git
-      ref: f8eb92fb61165b1eb018d928adcf689f0bc9e554
+      ref: c30de552580d8e64233c4372a7e438b0550de64e
   flutter_downloader:
     git:
       url: https://github.com/breez/flutter_downloader.git
@@ -113,7 +113,7 @@ dependencies:
   podcast_search:
     git:
       url: https://github.com/breez/podcast_search.git
-      ref: 5bd8e96728291b11dbc4b1fbac123681000be07d
+      ref: a2dfc441a6ba3c506ef15b1dd881a03d15254ccf
   nfc_in_flutter:
     git:
       url: https://github.com/breez/nfc_in_flutter.git
@@ -128,10 +128,6 @@ dependency_overrides:
     git:
       url: https://github.com/breez/flutter_downloader.git
       ref: c9cbc56c6d1c8bb434301757be84ac1e65d046c6
-  podcast_search:
-    git:
-      url: https://github.com/breez/podcast_search.git
-      ref: 5bd8e96728291b11dbc4b1fbac123681000be07d
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# Add value time split support
Reference: https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md#value-time-split
Recommended reading: https://blog.getalby.com/value-time-split-the-latest-innovation-in-podcasting-2-0/#:~:text=Value%204%20Value%20is%20a,and%20cross%20referencing%20of%20content

# How to test
- Search for a podcast episode with support to value time split
  - e.g. https://breez.link/p?feedURL=https%3A%2F%2Fmp3s.nashownotes.com%2Fbballrss.xml
- Boost inside a time-split range
  - The boost should be split according to the podcast receipts and the remote recipts
- Boost outside a time-split range
  - The boost should be sent as a traditional boost

# How it looks like
There is no change in UI so I'm attaching some logs to exemplify how the boost happens

- [outside-split.txt](https://github.com/breez/breezmobile/files/13488635/outside-split.txt)
- [inside-split.txt](https://github.com/breez/breezmobile/files/13488634/inside-split.txt)
- [failed-to-fetch-split-metadata.txt](https://github.com/breez/breezmobile/files/13488633/failed-to-fetch-split-metadata.txt)
- [boost-per-minute.txt](https://github.com/breez/breezmobile/files/13488744/boost-per-minute.txt)


# Related PRs:
- [Web feed (dart-rss)](https://github.com/breez/dart-rss/pull/4)
- [Podcast search](https://github.com/breez/podcast_search/pull/4)
- [Anytime podcast player](https://github.com/breez/anytime_podcast_player/pull/49)
- [Breez mobile](https://github.com/breez/breezmobile/pull/1254)