### PR TITLE
await testAuth result

### DIFF
--- a/lib/bloc/backup/backup_bloc.dart
+++ b/lib/bloc/backup/backup_bloc.dart
@@ -831,8 +831,9 @@ class BackupBloc with AsyncActionsHandler {
     }
   }
 
-  Future testAuth(BackupProvider provider, RemoteServerAuthData authData) {
-    return _breezLib
+  Future testAuth(
+      BackupProvider provider, RemoteServerAuthData authData) async {
+    return await _breezLib
         .testBackupAuth(provider.name, json.encode(authData.toJson()))
         .catchError(
       (error) {


### PR DESCRIPTION
Not awaiting the test backup causes the backup flow to behave weirdly when the remote server is slow to respond.