### PR TITLE
schedule chain sync as unique work

### DIFF
--- a/android/app/src/main/java/com/breez/client/job/JobManager.java
+++ b/android/app/src/main/java/com/breez/client/job/JobManager.java
@@ -2,6 +2,7 @@ package com.breez.client.job;
 
 import com.breez.client.plugins.breez.breezlib.ChainSync;
 import androidx.work.Constraints;
+import androidx.work.ExistingWorkPolicy;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
 
@@ -31,6 +32,6 @@ public class JobManager {
                                 .build())
                 .build();
 
-        WorkManager.getInstance().enqueue(oneTime);        
+        WorkManager.getInstance().enqueueUniqueWork(UNIQUE_WORK_NAME, ExistingWorkPolicy.REPLACE, oneTime);
     }
 }


### PR DESCRIPTION
An attempt to deduplicate sync jobs at the root level, namely where they're scheduled.

Tested with a firebase notification. The job is still triggered at least. I'm not sure whether it will actually be deduplicated.