### PR TITLE
Linter issues

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -18,35 +18,35 @@ PODS:
     - ReachabilitySwift
   - device_info_plus (0.0.1):
     - Flutter
-  - DKImagePickerController/Core (4.3.8):
+  - DKImagePickerController/Core (4.3.9):
     - DKImagePickerController/ImageDataManager
     - DKImagePickerController/Resource
-  - DKImagePickerController/ImageDataManager (4.3.8)
-  - DKImagePickerController/PhotoGallery (4.3.8):
+  - DKImagePickerController/ImageDataManager (4.3.9)
+  - DKImagePickerController/PhotoGallery (4.3.9):
     - DKImagePickerController/Core
     - DKPhotoGallery
-  - DKImagePickerController/Resource (4.3.8)
-  - DKPhotoGallery (0.0.18):
-    - DKPhotoGallery/Core (= 0.0.18)
-    - DKPhotoGallery/Model (= 0.0.18)
-    - DKPhotoGallery/Preview (= 0.0.18)
-    - DKPhotoGallery/Resource (= 0.0.18)
+  - DKImagePickerController/Resource (4.3.9)
+  - DKPhotoGallery (0.0.19):
+    - DKPhotoGallery/Core (= 0.0.19)
+    - DKPhotoGallery/Model (= 0.0.19)
+    - DKPhotoGallery/Preview (= 0.0.19)
+    - DKPhotoGallery/Resource (= 0.0.19)
     - SDWebImage
     - SwiftyGif
-  - DKPhotoGallery/Core (0.0.18):
+  - DKPhotoGallery/Core (0.0.19):
     - DKPhotoGallery/Model
     - DKPhotoGallery/Preview
     - SDWebImage
     - SwiftyGif
-  - DKPhotoGallery/Model (0.0.18):
+  - DKPhotoGallery/Model (0.0.19):
     - SDWebImage
     - SwiftyGif
-  - DKPhotoGallery/Preview (0.0.18):
+  - DKPhotoGallery/Preview (0.0.19):
     - DKPhotoGallery/Model
     - DKPhotoGallery/Resource
     - SDWebImage
     - SwiftyGif
-  - DKPhotoGallery/Resource (0.0.18):
+  - DKPhotoGallery/Resource (0.0.19):
     - SDWebImage
     - SwiftyGif
   - ffmpeg-kit-ios-https-gpl (6.0)
@@ -235,9 +235,9 @@ PODS:
     - Flutter
   - PromisesObjC (2.4.0)
   - ReachabilitySwift (5.2.2)
-  - SDWebImage (5.19.1):
-    - SDWebImage/Core (= 5.19.1)
-  - SDWebImage/Core (5.19.1)
+  - SDWebImage (5.19.2):
+    - SDWebImage/Core (= 5.19.2)
+  - SDWebImage/Core (5.19.2)
   - share_plus (0.0.1):
     - Flutter
   - shared_preferences_foundation (0.0.1):
@@ -418,8 +418,8 @@ SPEC CHECKSUMS:
   clipboard_watcher: 86fb70421aca6f4944e0591a8292605da7784666
   connectivity_plus: 07c49e96d7fc92bc9920617b83238c4d178b446a
   device_info_plus: c6fb39579d0f423935b0c9ce7ee2f44b71b9fce6
-  DKImagePickerController: a7836546cfdfe014171694f643a7d575bc8ace7f
-  DKPhotoGallery: acbd8a3bab19cf6e5fe64a853fc07bfbd247a8f6
+  DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
+  DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
   ffmpeg-kit-ios-https-gpl: 0caef23dca1bdb18fe6f2e1cd43d02d5978c4c2e
   ffmpeg_kit_flutter_https_gpl: 066ec3b6a89759f1ffb84860e75534c3d3a1b172
   file_picker: ce3938a0df3cc1ef404671531facef740d03f920
@@ -470,7 +470,7 @@ SPEC CHECKSUMS:
   printing: 233e1b73bd1f4a05615548e9b5a324c98588640b
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   ReachabilitySwift: 2128f3a8c9107e1ad33574c6e58e8285d460b149
-  SDWebImage: 40b0b4053e36c660a764958bff99eed16610acbb
+  SDWebImage: dfe95b2466a9823cf9f0c6d01217c06550d7b29a
   share_plus: c3fef564749587fc939ef86ffb283ceac0baf9f5
   shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
   sqflite: 31f7eba61e3074736dff8807a9b41581e4f7f15a

--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -50,13 +50,10 @@ class AccountBloc {
   final _reconnectStreamController = StreamController<void>.broadcast();
   Sink<void> get _reconnectSink => _reconnectStreamController.sink;
 
-  final _broadcastRefundRequestController =
-      StreamController<BroadcastRefundRequestModel>.broadcast();
-  Sink<BroadcastRefundRequestModel> get broadcastRefundRequestSink =>
-      _broadcastRefundRequestController.sink;
+  final _broadcastRefundRequestController = StreamController<BroadcastRefundRequestModel>.broadcast();
+  Sink<BroadcastRefundRequestModel> get broadcastRefundRequestSink => _broadcastRefundRequestController.sink;
 
-  final _broadcastRefundResponseController =
-      StreamController<BroadcastRefundResponseModel>.broadcast();
+  final _broadcastRefundResponseController = StreamController<BroadcastRefundResponseModel>.broadcast();
   Stream<BroadcastRefundResponseModel> get broadcastRefundResponseStream =>
       _broadcastRefundResponseController.stream;
 
@@ -67,46 +64,35 @@ class AccountBloc {
   Sink<bool> get accountEnableSink => _accountEnableController.sink;
 
   final _accountSettingsController = BehaviorSubject<AccountSettings>();
-  Stream<AccountSettings> get accountSettingsStream =>
-      _accountSettingsController.stream;
-  Sink<AccountSettings> get accountSettingsSink =>
-      _accountSettingsController.sink;
+  Stream<AccountSettings> get accountSettingsStream => _accountSettingsController.stream;
+  Sink<AccountSettings> get accountSettingsSink => _accountSettingsController.sink;
 
   final _routingNodeConnectionController = BehaviorSubject<bool>();
-  Stream<bool> get routingNodeConnectionStream =>
-      _routingNodeConnectionController.stream;
+  Stream<bool> get routingNodeConnectionStream => _routingNodeConnectionController.stream;
 
   final _paymentsController = BehaviorSubject<PaymentsModel>();
   Stream<PaymentsModel> get paymentsStream => _paymentsController.stream;
 
   final _paymentFilterController = BehaviorSubject<PaymentFilterModel>();
-  Stream<PaymentFilterModel> get paymentFilterStream =>
-      _paymentFilterController.stream;
-  Sink<PaymentFilterModel> get paymentFilterSink =>
-      _paymentFilterController.sink;
+  Stream<PaymentFilterModel> get paymentFilterStream => _paymentFilterController.stream;
+  Sink<PaymentFilterModel> get paymentFilterSink => _paymentFilterController.sink;
 
   final _lspActivityController = BehaviorSubject<LSPActivity>();
   Stream<LSPActivity> get lspActivityStream => _lspActivityController.stream;
 
   final _accountNotificationsController = StreamController<String>.broadcast();
-  Stream<String> get accountNotificationsStream =>
-      _accountNotificationsController.stream;
+  Stream<String> get accountNotificationsStream => _accountNotificationsController.stream;
 
-  final _completedPaymentsController =
-      StreamController<CompletedPayment>.broadcast();
-  Stream<CompletedPayment> get completedPaymentsStream =>
-      _completedPaymentsController.stream;
+  final _completedPaymentsController = StreamController<CompletedPayment>.broadcast();
+  Stream<CompletedPayment> get completedPaymentsStream => _completedPaymentsController.stream;
 
   final Map<String, bool> _ignoredFeedbackPayments = <String, bool>{};
 
   Stream<PaymentInfo> get pendingPaymentStream {
-    var newestPaymentTime =
-        _paymentsController.value.paymentsList.first.creationTimestamp;
+    var newestPaymentTime = _paymentsController.value.paymentsList.first.creationTimestamp;
     return paymentsStream
-        .map((ps) => ps.paymentsList.where((p) =>
-            p.creationTimestamp > newestPaymentTime &&
-            p.pending &&
-            p.type == PaymentType.SENT))
+        .map((ps) => ps.paymentsList
+            .where((p) => p.creationTimestamp > newestPaymentTime && p.pending && p.type == PaymentType.SENT))
         .expand((ps) => ps)
         .distinct((p1, p2) => p1?.paymentHash == p2?.paymentHash);
   }
@@ -118,15 +104,12 @@ class AccountBloc {
   Stream<void> get nodeConflictStream => _nodeConflictController.stream;
 
   final _nodeBackupNotLatestController = BehaviorSubject<void>();
-  Stream<void> get nodeBackupNotLatestStream =>
-      _nodeBackupNotLatestController.stream;
+  Stream<void> get nodeBackupNotLatestStream => _nodeBackupNotLatestController.stream;
 
-  final AccountPermissionsHandler _permissionsHandler =
-      AccountPermissionsHandler();
+  final AccountPermissionsHandler _permissionsHandler = AccountPermissionsHandler();
   Stream<bool> get optimizationWhitelistExplainStream =>
       _permissionsHandler.optimizationWhitelistExplainStream;
-  Sink get optimizationWhitelistRequestSink =>
-      _permissionsHandler.optimizationWhitelistRequestSink;
+  Sink get optimizationWhitelistRequestSink => _permissionsHandler.optimizationWhitelistRequestSink;
 
   BreezUserModel _currentUser;
   bool _startedLightning = false;
@@ -211,25 +194,20 @@ class AccountBloc {
   }
 
   void setNodeUpgrading(bool upgrading) {
-    _accountController
-        .add(_accountController.value.copyWith(nodeUpgrading: upgrading));
+    _accountController.add(_accountController.value.copyWith(nodeUpgrading: upgrading));
   }
 
   Stream<List<PaymentInfo>> get pendingChannelsStream {
-    return _paymentsController.map((paymentModel) => paymentModel
-        .nonFilteredItems
-        .where(
-            (item) => item.type == PaymentType.CLOSED_CHANNEL && item.pending)
+    return _paymentsController.map((paymentModel) => paymentModel.nonFilteredItems
+        .where((item) => item.type == PaymentType.CLOSED_CHANNEL && item.pending)
         .toList());
   }
 
   void _listenEnableAccount() {
     _accountEnableController.stream.listen((enable) {
-      _accountController
-          .add(_accountController.value.copyWith(enableInProgress: true));
+      _accountController.add(_accountController.value.copyWith(enableInProgress: true));
       _breezLib.enableAccount(enable).whenComplete(() {
-        _accountController
-            .add(_accountController.value.copyWith(enableInProgress: false));
+        _accountController.add(_accountController.value.copyWith(enableInProgress: false));
       });
     });
   }
@@ -237,8 +215,7 @@ class AccountBloc {
   Future _handleRegisterDeviceNode() async {
     userProfileStream.listen((user) async {
       if (user.token != null) {
-        var acc =
-            await _accountController.firstWhere((acc) => acc.id?.isNotEmpty);
+        var acc = await _accountController.firstWhere((acc) => acc.id?.isNotEmpty);
         try {
           await _breezServer.registerDevice(user.token, acc.id);
         } catch (e) {
@@ -251,15 +228,13 @@ class AccountBloc {
   //settings persistency
   Future _handleAccountSettings() async {
     var preferences = await ServiceInjector().sharedPreferences;
-    var accountSettings =
-        preferences.getString(ACCOUNT_SETTINGS_PREFERENCES_KEY);
+    var accountSettings = preferences.getString(ACCOUNT_SETTINGS_PREFERENCES_KEY);
     if (accountSettings != null) {
       Map<String, dynamic> settings = json.decode(accountSettings);
       _accountSettingsController.add(AccountSettings.fromJson(settings));
     }
     _accountSettingsController.stream.listen((settings) {
-      preferences.setString(
-          ACCOUNT_SETTINGS_PREFERENCES_KEY, json.encode(settings.toJson()));
+      preferences.setString(ACCOUNT_SETTINGS_PREFERENCES_KEY, json.encode(settings.toJson()));
     });
 
     _accountController.stream.listen((acc) async {
@@ -274,8 +249,7 @@ class AccountBloc {
       var handler = _actionHandlers[action.runtimeType];
       if (handler != null) {
         handler(action).catchError((e) {
-          _log.severe(
-              "AccountAction: ${action.runtimeType.toString()} - Error: ${e.toString()}");
+          _log.severe("AccountAction: ${action.runtimeType.toString()} - Error: ${e.toString()}");
           action.resolveError(e);
         });
       }
@@ -292,17 +266,15 @@ class AccountBloc {
   List<FiatConversion> _sortFiatConversionList({
     List<FiatConversion> fiatConversionList,
   }) {
-    var toSort = List<FiatConversion>.from(
-        (fiatConversionList ?? _accountController.value.fiatConversionList));
+    var toSort =
+        List<FiatConversion>.from((fiatConversionList ?? _accountController.value.fiatConversionList));
 
     // First sort by name
-    toSort.sort((f1, f2) =>
-        f1.currencyData.shortName.compareTo(f2.currencyData.shortName));
+    toSort.sort((f1, f2) => f1.currencyData.shortName.compareTo(f2.currencyData.shortName));
 
     // Then give precedence to the preferred items.
     for (var p in _currentUser.preferredCurrencies.reversed) {
-      var preferred = toSort.firstWhere((e) => e.currencyData.shortName == p,
-          orElse: () => null);
+      var preferred = toSort.firstWhere((e) => e.currencyData.shortName == p, orElse: () => null);
       if (preferred != null) {
         toSort.remove(preferred);
         toSort.insert(0, preferred);
@@ -337,16 +309,12 @@ class AccountBloc {
     action.resolve(await _breezLib.publishTransaction(action.tx));
   }
 
-  Future _checkClosedChannelMismatch(
-      CheckClosedChannelMismatchAction action) async {
-    action.resolve(await _breezLib.checkLSPClosedChannelMismatch(
-        action.lsp, action.channelPoint));
+  Future _checkClosedChannelMismatch(CheckClosedChannelMismatchAction action) async {
+    action.resolve(await _breezLib.checkLSPClosedChannelMismatch(action.lsp, action.channelPoint));
   }
 
-  Future _resetClosedChannelChainInfoAction(
-      ResetClosedChannelChainInfoAction action) async {
-    action.resolve(await _breezLib.resetClosedChannelChainInfo(
-        action.blockHeight, action.channelPoint));
+  Future _resetClosedChannelChainInfoAction(ResetClosedChannelChainInfoAction action) async {
+    action.resolve(await _breezLib.resetClosedChannelChainInfo(action.blockHeight, action.channelPoint));
   }
 
   Future _exportPaymentsAction(ExportPayments action) async {
@@ -379,24 +347,19 @@ class AccountBloc {
     action.resolve(await _fetchFundStatus());
   }
 
-  Future _setNonBlockingUnconfirmedSwaps(
-      SetNonBlockingUnconfirmedSwaps action) async {
+  Future _setNonBlockingUnconfirmedSwaps(SetNonBlockingUnconfirmedSwaps action) async {
     action.resolve(await _breezLib.setNonBlockingUnconfirmedSwaps());
   }
 
   Future _sendSpontaneousPayment(SendSpontaneousPayment action) async {
-    var sendRequest = _breezLib
-        .sendSpontaneousPayment(
-            action.nodeID, action.amount, action.description)
-        .then((response) {
+    var sendRequest =
+        _breezLib.sendSpontaneousPayment(action.nodeID, action.amount, action.description).then((response) {
       if (response.paymentError.isNotEmpty) {
-        var error =
-            PaymentError(null, response.paymentError, response.traceReport);
+        var error = PaymentError(null, response.paymentError, response.traceReport);
         _completedPaymentsController.addError(error);
         return Future.error(error);
       }
-      _completedPaymentsController
-          .add(const CompletedPayment(null, null, null));
+      _completedPaymentsController.add(const CompletedPayment(null, null, null));
       return response;
     });
 
@@ -432,21 +395,18 @@ class AccountBloc {
         return Future.error(error);
       }
 
-      final paymentHash =
-          await _breezLib.getPaymentRequestHash(payRequest.paymentRequest);
+      final paymentHash = await _breezLib.getPaymentRequestHash(payRequest.paymentRequest);
       _log.info(
           '_sendPayment: getPaymentRequestHash found paymentHash  $paymentHash for paymentRequest ${payRequest.paymentRequest}');
 
       PaymentInfo currentPayment;
       if (paymentHash != '') {
         var allPayments = await fetchPayments();
-        currentPayment = allPayments.paymentsList.firstWhere(
-            (element) => element.paymentHash == paymentHash,
-            orElse: () => null);
+        currentPayment = allPayments.paymentsList
+            .firstWhere((element) => element.paymentHash == paymentHash, orElse: () => null);
       }
 
-      _completedPaymentsController.add(CompletedPayment(
-          payRequest, paymentHash, currentPayment,
+      _completedPaymentsController.add(CompletedPayment(payRequest, paymentHash, currentPayment,
           ignoreGlobalFeedback: action.ignoreGlobalFeedback == true));
       return response;
     });
@@ -458,34 +418,26 @@ class AccountBloc {
   }
 
   Future _cancelPaymentRequest(CancelPaymentRequest cancelRequest) async {
-    var paymentHash = await _breezLib
-        .getPaymentRequestHash(cancelRequest.paymentRequest.paymentRequest);
-    _completedPaymentsController.add(CompletedPayment(
-        cancelRequest.paymentRequest, paymentHash, null,
-        cancelled: true));
+    var paymentHash = await _breezLib.getPaymentRequestHash(cancelRequest.paymentRequest.paymentRequest);
+    _completedPaymentsController
+        .add(CompletedPayment(cancelRequest.paymentRequest, paymentHash, null, cancelled: true));
     return Future.value(null);
   }
 
   Future _collapseSyncUI(ChangeSyncUIState stateAction) {
-    _accountController.add(
-        _accountController.value.copyWith(syncUIState: stateAction.nextState));
+    _accountController.add(_accountController.value.copyWith(syncUIState: stateAction.nextState));
     return Future.value(null);
   }
 
   void _trackOnBoardingStatus() {
-    _accountController
-        .where((acc) => !acc.initial && acc.synced)
-        .first
-        .then((_) {
+    _accountController.where((acc) => !acc.initial && acc.synced).first.then((_) {
       _onBoardingCompleter.complete();
     });
   }
 
   void _listenRefundableDeposits() {
     _breezLib.notificationStream
-        .where((n) =>
-            n.type ==
-            NotificationEvent_NotificationType.FUND_ADDRESS_UNSPENT_CHANGED)
+        .where((n) => n.type == NotificationEvent_NotificationType.FUND_ADDRESS_UNSPENT_CHANGED)
         .listen((e) {
       _fetchFundStatus();
     });
@@ -493,11 +445,8 @@ class AccountBloc {
 
   void _listenRefundBroadcasts() {
     _broadcastRefundRequestController.stream.listen((request) {
-      _breezLib
-          .refund(request.fromAddress, request.toAddress, request.feeRate)
-          .then((txID) {
-        _broadcastRefundResponseController
-            .add(BroadcastRefundResponseModel(request, txID));
+      _breezLib.refund(request.fromAddress, request.toAddress, request.feeRate).then((txID) {
+        _broadcastRefundResponseController.add(BroadcastRefundResponseModel(request, txID));
       }).catchError(_broadcastRefundResponseController.addError);
     });
   }
@@ -505,8 +454,7 @@ class AccountBloc {
   void _listenConnectivityChanges() {
     var connectivity = Connectivity();
     connectivity.onConnectivityChanged.skip(1).listen((connectivityResult) {
-      _log.info(
-          "_listenConnectivityChanges: connection changed to: $connectivityResult");
+      _log.info("_listenConnectivityChanges: connection changed to: $connectivityResult");
       if (connectivityResult != ConnectivityResult.none) {
         _reconnectSink.add(null);
       }
@@ -515,16 +463,13 @@ class AccountBloc {
 
   void _listenReconnects() {
     Future connectingFuture = Future.value(null);
-    _reconnectStreamController.stream
-        .debounceTime(const Duration(milliseconds: 500))
-        .listen((_) async {
+    _reconnectStreamController.stream.debounceTime(const Duration(milliseconds: 500)).listen((_) async {
       connectingFuture = connectingFuture.whenComplete(() async {
         var acc = _accountController.value;
         _log.info(
             "Checking if reconnect needed for account: connected=${acc.connected} readyForPayment=${acc.readyForPayments} processingConnection=${acc.processingConnection}");
 
-        if (acc.connected && acc.readyForPayments == false ||
-            acc.processingConnection) {
+        if (acc.connected && acc.readyForPayments == false || acc.processingConnection) {
           _log.info("Reconnecting...");
           await _breezLib.connectAccount();
         }
@@ -535,20 +480,17 @@ class AccountBloc {
   void _listenMempoolTransactions() {
     _notificationsService.notifications
         .where((message) =>
-            message["msg"] == "Unconfirmed transaction" ||
-            message["msg"] == "Confirmed transaction")
+            message["msg"] == "Unconfirmed transaction" || message["msg"] == "Confirmed transaction")
         .listen((message) {
       _log.severe(message.toString());
-      if (message["msg"] == "Unconfirmed transaction" &&
-          message["user_click"] == null) {
+      if (message["msg"] == "Unconfirmed transaction" && message["user_click"] == null) {
         _accountNotificationsController.add(message["body"].toString());
       }
       _fetchFundStatus();
     });
 
     _device.eventStream.where((e) => e == NotificationType.RESUME).listen((e) {
-      _log.info(
-          "App Resumed - flutter resume called, adding reconnect request");
+      _log.info("App Resumed - flutter resume called, adding reconnect request");
       _reconnectSink.add(null);
     });
   }
@@ -577,8 +519,7 @@ class AccountBloc {
   _listenUserChanges(Stream<BreezUserModel> userProfileStream) {
     userProfileStream.listen((user) async {
       if (user.token != null && user.token != _currentUser?.token) {
-        _log.info(
-            "user profile bloc registering for channel open notifications");
+        _log.info("user profile bloc registering for channel open notifications");
         _breezLib.registerChannelOpenedNotification(user.token);
       }
       _currentUser = user;
@@ -589,25 +530,23 @@ class AccountBloc {
         fiatShortName: user.fiatCurrency,
         posCurrencyShortName: user.posCurrencyShortName,
         preferredCurrencies: user.preferredCurrencies,
-        fiatConversionList: _sortFiatConversionList(
-            fiatConversionList: _accountController.value.fiatConversionList),
+        fiatConversionList:
+            _sortFiatConversionList(fiatConversionList: _accountController.value.fiatConversionList),
       ));
 
       var updatedPayments = _paymentsController.value.copyWith(
         nonFilteredItems: _paymentsController.value.nonFilteredItems
             .map((p) => p.copyWith(_accountController.value))
             .toList(),
-        paymentsList: _paymentsController.value.paymentsList
-            .map((p) => p.copyWith(_accountController.value))
-            .toList(),
+        paymentsList:
+            _paymentsController.value.paymentsList.map((p) => p.copyWith(_accountController.value)).toList(),
       );
       _paymentsController.add(updatedPayments);
 
       //start lightning
       if (user.registrationRequested) {
         if (!_startedLightning) {
-          _log.info(
-              "Account bloc got registered user, starting lightning daemon...");
+          _log.info("Account bloc got registered user, starting lightning daemon...");
           _startedLightning = true;
           _pollSyncStatus();
           _backgroundService.runAsTask(_onBoardingCompleter.future, () {
@@ -646,12 +585,10 @@ class AccountBloc {
     bool blockingPrompted = false;
     bool newNode = nodeID == null;
     _accountSynchronizer = AccountSynchronizer(_breezLib,
-        onProgress:
-            (startPollTimestamp, progress, syncedToChain, bootstrap) async {
-          bool moreThan3DaysOff = Duration(
-                  milliseconds: DateTime.now().millisecondsSinceEpoch -
-                      startPollTimestamp) >
-              const Duration(days: 3);
+        onProgress: (startPollTimestamp, progress, syncedToChain, bootstrap) async {
+          bool moreThan3DaysOff =
+              Duration(milliseconds: DateTime.now().millisecondsSinceEpoch - startPollTimestamp) >
+                  const Duration(days: 3);
           var syncUIState = _accountController.value.syncUIState;
           if ((moreThan3DaysOff || newNode) &&
               _accountController.value.syncUIState == SyncUIState.NONE &&
@@ -659,13 +596,11 @@ class AccountBloc {
             blockingPrompted = true;
             syncUIState = SyncUIState.COLLAPSED;
           }
-          _accountController.add(_accountController.value.copyWith(
-              syncUIState: syncUIState,
-              syncProgress: progress,
-              syncedToChain: syncedToChain));
+          _accountController.add(_accountController.value
+              .copyWith(syncUIState: syncUIState, syncProgress: progress, syncedToChain: syncedToChain));
         },
-        onComplete: () => _accountController.add(_accountController.value
-            .copyWith(syncUIState: SyncUIState.NONE, syncProgress: 1.0)));
+        onComplete: () => _accountController
+            .add(_accountController.value.copyWith(syncUIState: SyncUIState.NONE, syncProgress: 1.0)));
   }
 
   Future _fetchFundStatus() {
@@ -675,8 +610,7 @@ class AccountBloc {
 
     return _breezLib.getFundStatus(_currentUser.userID ?? "").then((status) {
       _log.severe("fund status = ${status.writeToJson()}");
-      _accountController
-          .add(_accountController.value.copyWith(addedFundsReply: status));
+      _accountController.add(_accountController.value.copyWith(addedFundsReply: status));
     }).catchError((err) {
       _log.severe("Error in getFundStatus $err");
     });
@@ -754,18 +688,14 @@ class AccountBloc {
 
   _filterPayments(List<PaymentInfo> paymentsList) {
     Set<PaymentInfo> paymentsSet = _groupPayments(paymentsList)
-        .where(
-            (p) => _paymentFilterController.value.paymentType.contains(p.type))
+        .where((p) => _paymentFilterController.value.paymentType.contains(p.type))
         .toSet();
-    if (_paymentFilterController.value.startDate != null &&
-        _paymentFilterController.value.endDate != null) {
+    if (_paymentFilterController.value.startDate != null && _paymentFilterController.value.endDate != null) {
       Set<PaymentInfo> dateFilteredPaymentsSet = paymentsList
           .where((p) => (p.creationTimestamp.toInt() * 1000 >=
-                  _paymentFilterController
-                      .value.startDate.millisecondsSinceEpoch &&
+                  _paymentFilterController.value.startDate.millisecondsSinceEpoch &&
               p.creationTimestamp.toInt() * 1000 <=
-                  _paymentFilterController
-                      .value.endDate.millisecondsSinceEpoch))
+                  _paymentFilterController.value.endDate.millisecondsSinceEpoch))
           .toSet();
       return dateFilteredPaymentsSet.intersection(paymentsSet).toList();
     }
@@ -776,10 +706,8 @@ class AccountBloc {
     StreamSubscription<NotificationEvent> eventSubscription;
     eventSubscription = _breezLib.notificationStream.listen((event) async {
       _log.info('_breezLib.notificationStream received: ${event.type}.');
-      if (event.type ==
-          NotificationEvent_NotificationType.LIGHTNING_SERVICE_DOWN) {
-        _accountController
-            .add(_accountController.value.copyWith(serverReady: false));
+      if (event.type == NotificationEvent_NotificationType.LIGHTNING_SERVICE_DOWN) {
+        _accountController.add(_accountController.value.copyWith(serverReady: false));
         _pollSyncStatus();
         if (!_retryingLightningService) {
           _retryingLightningService = true;
@@ -794,20 +722,17 @@ class AccountBloc {
         _refreshAccountAndPayments();
       }
       if (event.type == NotificationEvent_NotificationType.READY) {
-        _accountController
-            .add(_accountController.value.copyWith(serverReady: true));
+        _accountController.add(_accountController.value.copyWith(serverReady: true));
         _log.info("READY event triggers _refreshAccountAndPayments");
         _refreshAccountAndPayments();
       }
 
-      if (event.type ==
-          NotificationEvent_NotificationType.BACKUP_NODE_CONFLICT) {
+      if (event.type == NotificationEvent_NotificationType.BACKUP_NODE_CONFLICT) {
         eventSubscription.cancel();
         _nodeConflictController.add(null);
       }
 
-      if (event.type ==
-          NotificationEvent_NotificationType.BACKUP_NOT_LATEST_CONFLICT) {
+      if (event.type == NotificationEvent_NotificationType.BACKUP_NOT_LATEST_CONFLICT) {
         _log.info("BACKUP_NOT_LATEST_CONFLICT event triggered");
         eventSubscription.cancel();
         _nodeBackupNotLatestController.add(null);
@@ -816,8 +741,7 @@ class AccountBloc {
       if (event.type == NotificationEvent_NotificationType.PAYMENT_SUCCEEDED) {
         var paymentRequest = event.data[0];
         var paymentHash = event.data[1];
-        _log.info(
-            '_listenAccountChanges: Payment succeeded with paymentHash = $paymentHash');
+        _log.info('_listenAccountChanges: Payment succeeded with paymentHash = $paymentHash');
         PayRequest payRequest;
 
         if (paymentRequest.isNotEmpty) {
@@ -825,11 +749,8 @@ class AccountBloc {
           payRequest = PayRequest(paymentRequest, invoice.amount);
         }
 
-        _completedPaymentsController.add(CompletedPayment(
-            payRequest, paymentHash, null,
-            cancelled: false,
-            ignoreGlobalFeedback:
-                _ignoredFeedbackPayments.containsKey(paymentRequest)));
+        _completedPaymentsController.add(CompletedPayment(payRequest, paymentHash, null,
+            cancelled: false, ignoreGlobalFeedback: _ignoredFeedbackPayments.containsKey(paymentRequest)));
         _ignoredFeedbackPayments.remove(paymentRequest);
       }
 
@@ -845,10 +766,8 @@ class AccountBloc {
           var invoice = await _breezLib.decodePaymentRequest(paymentRequest);
           payRequest = PayRequest(paymentRequest, invoice.amount);
         }
-        _completedPaymentsController.addError(PaymentError(
-            payRequest, error, traceReport,
-            ignoreGlobalFeedback:
-                _ignoredFeedbackPayments.containsKey(paymentRequest)));
+        _completedPaymentsController.addError(PaymentError(payRequest, error, traceReport,
+            ignoreGlobalFeedback: _ignoredFeedbackPayments.containsKey(paymentRequest)));
         _ignoredFeedbackPayments.remove(paymentRequest);
       }
     });
@@ -858,8 +777,7 @@ class AccountBloc {
     return _breezLib.getAccount().then((acc) {
       _log.info("_fetchAccount id: ${acc.id}");
       if (acc.id.isNotEmpty) {
-        _log.info(
-            "ACCOUNT CHANGED BALANCE=${acc.balance} STATUS = ${acc.status}");
+        _log.info("ACCOUNT CHANGED BALANCE=${acc.balance} STATUS = ${acc.status}");
         return _accountController.value.copyWith(
             accountResponse: acc,
             currency: _currentUser?.currency,
@@ -903,9 +821,7 @@ class AccountBloc {
         .distinct((acc1, acc2) {
           return acc1?.readyForPayments == acc2?.readyForPayments;
         })
-        .where((acc) =>
-            !acc.readyForPayments &&
-            (acc.connected || acc.processingConnection))
+        .where((acc) => !acc.readyForPayments && (acc.connected || acc.processingConnection))
         .skip(1)
         .listen((acc) {
           _reconnectSink.add(null);
@@ -918,8 +834,7 @@ class AccountBloc {
   }
 
   Future _updateExchangeRates() {
-    return retry(_getExchangeRate, interval: const Duration(seconds: 5))
-        .whenComplete(() {
+    return retry(_getExchangeRate, interval: const Duration(seconds: 5)).whenComplete(() {
       _startExchangeRateTimer();
       _device.eventStream.listen((e) {
         if (e == NotificationType.RESUME) {
@@ -942,11 +857,9 @@ class AccountBloc {
   Future _getExchangeRate() async {
     _currencyData = await _currencyService.currencies();
     Rates rate = await _breezLib.rate();
-    List<FiatConversion> fiatConversionList = rate.rates
-        .map((rate) => FiatConversion(_currencyData[rate.coin], rate.value))
-        .toList();
-    fiatConversionList =
-        _sortFiatConversionList(fiatConversionList: fiatConversionList);
+    List<FiatConversion> fiatConversionList =
+        rate.rates.map((rate) => FiatConversion(_currencyData[rate.coin], rate.value)).toList();
+    fiatConversionList = _sortFiatConversionList(fiatConversionList: fiatConversionList);
     _accountController.add(_accountController.value.copyWith(
       fiatConversionList: fiatConversionList,
       fiatShortName: _currentUser?.fiatCurrency,

--- a/lib/bloc/account/account_model.dart
+++ b/lib/bloc/account/account_model.dart
@@ -28,10 +28,8 @@ enum SyncUIState {
 Map<String, String> paymentErrorsMapping() {
   final texts = getSystemAppLocalizations();
   return {
-    "FAILURE_REASON_INSUFFICIENT_BALANCE":
-        texts.payment_error_insufficient_balance,
-    "FAILURE_REASON_INCORRECT_PAYMENT_DETAILS":
-        texts.payment_error_incorrect_payment_details,
+    "FAILURE_REASON_INSUFFICIENT_BALANCE": texts.payment_error_insufficient_balance,
+    "FAILURE_REASON_INCORRECT_PAYMENT_DETAILS": texts.payment_error_incorrect_payment_details,
     "FAILURE_REASON_ERROR": texts.payment_error_unexpected_error,
     "FAILURE_REASON_NO_ROUTE": texts.payment_error_no_route,
     "FAILURE_REASON_TIMEOUT": texts.payment_error_payment_timeout_exceeded,
@@ -65,8 +63,7 @@ class AccountSettings {
     return AccountSettings(
       ignoreWalletBalance ?? this.ignoreWalletBalance,
       showConnectProgress: showConnectProgress ?? this.showConnectProgress,
-      failedPaymentBehavior:
-          failedPaymentBehavior ?? this.failedPaymentBehavior,
+      failedPaymentBehavior: failedPaymentBehavior ?? this.failedPaymentBehavior,
       isEscherEnabled: isEscherEnabled ?? this.isEscherEnabled,
     );
   }
@@ -76,8 +73,7 @@ class AccountSettings {
       : this(
           json["ignoreWalletBalance"] ?? false,
           showConnectProgress: json["showConnectProgress"] ?? false,
-          failedPaymentBehavior:
-              BugReportBehavior.values[json["failePaymentBehavior"] ?? 0],
+          failedPaymentBehavior: BugReportBehavior.values[json["failePaymentBehavior"] ?? 0],
           isEscherEnabled: json["isEscherEnabled"] ?? false,
         );
 
@@ -102,9 +98,7 @@ class SwapFundStatus {
     if (_addedFundsReply == null) {
       return null;
     }
-    var nonBlocking = _addedFundsReply.unConfirmedAddresses
-        .where((a) => a.nonBlocking != true)
-        .toList();
+    var nonBlocking = _addedFundsReply.unConfirmedAddresses.where((a) => a.nonBlocking != true).toList();
     if (nonBlocking.isEmpty) {
       return null;
     }
@@ -112,10 +106,8 @@ class SwapFundStatus {
   }
 
   bool get depositConfirmed {
-    var waitingPaymentAddresses = _addedFundsReply?.confirmedAddresses
-        ?.where((a) => a.errorMessage.isEmpty);
-    return waitingPaymentAddresses != null &&
-        waitingPaymentAddresses.isNotEmpty;
+    var waitingPaymentAddresses = _addedFundsReply?.confirmedAddresses?.where((a) => a.errorMessage.isEmpty);
+    return waitingPaymentAddresses != null && waitingPaymentAddresses.isNotEmpty;
   }
 
   // in case of status is error, these fields will be populated.
@@ -125,8 +117,7 @@ class SwapFundStatus {
       return refundAddresses[0].refundableError;
     }
 
-    var errorAddresses = _addedFundsReply?.confirmedAddresses
-        ?.where((a) => a.errorMessage.isNotEmpty);
+    var errorAddresses = _addedFundsReply?.confirmedAddresses?.where((a) => a.errorMessage.isNotEmpty);
     if (errorAddresses == null || errorAddresses.isEmpty) {
       return null;
     }
@@ -135,23 +126,17 @@ class SwapFundStatus {
   }
 
   List<String> get unConfirmedAddresses {
-    var unConfirmedAddresses =
-        _addedFundsReply?.unConfirmedAddresses ?? <SwapAddressInfo>[];
-    return unConfirmedAddresses
-        .where((a) => a.nonBlocking != true)
-        .map((a) => a.address)
-        .toList();
+    var unConfirmedAddresses = _addedFundsReply?.unConfirmedAddresses ?? <SwapAddressInfo>[];
+    return unConfirmedAddresses.where((a) => a.nonBlocking != true).map((a) => a.address).toList();
   }
 
   List<String> get confirmedAddresses {
-    var unConfirmedAddresses =
-        _addedFundsReply?.confirmedAddresses ?? <SwapAddressInfo>[];
+    var unConfirmedAddresses = _addedFundsReply?.confirmedAddresses ?? <SwapAddressInfo>[];
     return unConfirmedAddresses.map((a) => a.address).toList();
   }
 
   List<RefundableAddress> get refundableAddresses {
-    var refundableAddresses =
-        _addedFundsReply?.refundableAddresses ?? <SwapAddressInfo>[];
+    var refundableAddresses = _addedFundsReply?.refundableAddresses ?? <SwapAddressInfo>[];
     return refundableAddresses.map((a) => RefundableAddress(a)).toList();
   }
 
@@ -175,8 +160,7 @@ class RefundableAddress {
 
   Int64 get confirmedAmount => _refundableInfo.confirmedAmount;
 
-  List<String> get confirmedTransactionIds =>
-      _refundableInfo.confirmedTransactionIds;
+  List<String> get confirmedTransactionIds => _refundableInfo.confirmedTransactionIds;
 
   int get lockHeight => _refundableInfo.lockHeight;
 
@@ -298,14 +282,11 @@ class AccountModel {
 
   SwapFundStatus get swapFundsStatus => SwapFundStatus(addedFundsReply);
 
-  bool get disconnected =>
-      _accountResponse.status == Account_AccountStatus.DISCONNECTED;
+  bool get disconnected => _accountResponse.status == Account_AccountStatus.DISCONNECTED;
 
-  bool get processingConnection =>
-      _accountResponse.status == Account_AccountStatus.PROCESSING_CONNECTION;
+  bool get processingConnection => _accountResponse.status == Account_AccountStatus.PROCESSING_CONNECTION;
 
-  bool get connected =>
-      _accountResponse.status == Account_AccountStatus.CONNECTED;
+  bool get connected => _accountResponse.status == Account_AccountStatus.CONNECTED;
 
   Int64 get tipHeight => _accountResponse.tipHeight;
 
@@ -319,23 +300,20 @@ class AccountModel {
 
   Currency get currency => _currency;
 
-  FiatConversion get fiatCurrency => _fiatConversionList.firstWhere(
-      (f) => f.currencyData.shortName == _fiatShortName,
-      orElse: () => null);
+  FiatConversion get fiatCurrency =>
+      _fiatConversionList.firstWhere((f) => f.currencyData.shortName == _fiatShortName, orElse: () => null);
 
   List<FiatConversion> get fiatConversionList => _fiatConversionList;
 
-  List<FiatConversion> get preferredFiatConversionList =>
-      List.from(_fiatConversionList.where((fiatConversion) =>
-          preferredCurrencies.contains(fiatConversion.currencyData.shortName)));
+  List<FiatConversion> get preferredFiatConversionList => List.from(_fiatConversionList
+      .where((fiatConversion) => preferredCurrencies.contains(fiatConversion.currencyData.shortName)));
 
   String get posCurrencyShortName => _posCurrencyShortName;
 
   Int64 get maxAllowedToReceive => _accountResponse.maxAllowedToReceive;
 
-  Int64 get maxAllowedToPay => Int64(min(
-      _accountResponse.maxAllowedToPay.toInt(),
-      _accountResponse.maxPaymentAmount.toInt()));
+  Int64 get maxAllowedToPay =>
+      Int64(min(_accountResponse.maxAllowedToPay.toInt(), _accountResponse.maxPaymentAmount.toInt()));
 
   Int64 get reserveAmount => balance - maxAllowedToPay;
 
@@ -381,12 +359,10 @@ class AccountModel {
     return null;
   }
 
-  bool get transferringOnChainDeposit =>
-      swapFundsStatus.depositConfirmed && connected;
+  bool get transferringOnChainDeposit => swapFundsStatus.depositConfirmed && connected;
 
   FiatConversion getFiatCurrencyByShortName(String fiatShortName) {
-    return _fiatConversionList.firstWhere(
-        (f) => f.currencyData.shortName == fiatShortName,
+    return _fiatConversionList.firstWhere((f) => f.currencyData.shortName == fiatShortName,
         orElse: () => null);
   }
 
@@ -610,9 +586,7 @@ class StreamedPaymentInfo implements PaymentInfo {
 
   @override
   String get description {
-    final group = singlePayments
-        .firstWhere((p) => !p.pending, orElse: () => singlePayments[0])
-        .paymentGroup;
+    final group = singlePayments.firstWhere((p) => !p.pending, orElse: () => singlePayments[0]).paymentGroup;
 
     var desc = group;
     try {
@@ -654,9 +628,8 @@ class StreamedPaymentInfo implements PaymentInfo {
   String get dialogTitle => paymentGroupName;
 
   @override
-  String get title => singlePayments
-      .firstWhere((p) => !p.pending, orElse: () => singlePayments[0])
-      .paymentGroupName;
+  String get title =>
+      singlePayments.firstWhere((p) => !p.pending, orElse: () => singlePayments[0]).paymentGroupName;
 
   @override
   Int64 get pendingExpirationTimestamp {
@@ -741,17 +714,14 @@ class SinglePaymentInfo implements PaymentInfo {
   String get preimage => _paymentResponse.preimage;
 
   @override
-  String get paymentGroup => _paymentResponse.groupKey?.isNotEmpty == true
-      ? _paymentResponse.groupKey
-      : paymentHash;
+  String get paymentGroup =>
+      _paymentResponse.groupKey?.isNotEmpty == true ? _paymentResponse.groupKey : paymentHash;
 
   @override
   String get paymentGroupName => _paymentResponse.groupName;
 
   @override
-  bool get pending =>
-      _paymentResponse.pendingExpirationHeight > 0 ||
-      _paymentResponse.isChannelPending;
+  bool get pending => _paymentResponse.pendingExpirationHeight > 0 || _paymentResponse.isChannelPending;
 
   @override
   bool get fullPending => pending && _paymentResponse.pendingFull == true;
@@ -796,20 +766,14 @@ class SinglePaymentInfo implements PaymentInfo {
   int get pendingExpirationHeight => _paymentResponse.pendingExpirationHeight;
 
   double get hoursToExpire =>
-      max(_paymentResponse.pendingExpirationHeight - _account.tipHeight.toInt(),
-          0) *
-      10 /
-      60;
+      max(_paymentResponse.pendingExpirationHeight - _account.tipHeight.toInt(), 0) * 10 / 60;
 
   @override
-  Int64 get pendingExpirationTimestamp =>
-      _paymentResponse.pendingExpirationTimestamp > 0
-          ? _paymentResponse.pendingExpirationTimestamp
-          : Int64(
-              DateTime.now()
-                  .add(Duration(hours: hoursToExpire.round()))
-                  .millisecondsSinceEpoch,
-            );
+  Int64 get pendingExpirationTimestamp => _paymentResponse.pendingExpirationTimestamp > 0
+      ? _paymentResponse.pendingExpirationTimestamp
+      : Int64(
+          DateTime.now().add(Duration(hours: hoursToExpire.round())).millisecondsSinceEpoch,
+        );
 
   @override
   bool get containsPaymentInfo {
@@ -821,8 +785,7 @@ class SinglePaymentInfo implements PaymentInfo {
   }
 
   @override
-  bool get isTransferRequest =>
-      _paymentResponse?.invoiceMemo?.transferRequest == true;
+  bool get isTransferRequest => _paymentResponse?.invoiceMemo?.transferRequest == true;
 
   @override
   String get description {
@@ -899,8 +862,7 @@ class SinglePaymentInfo implements PaymentInfo {
       return texts.payment_info_title_bitcoin_transfer;
     }
 
-    if (type == PaymentType.WITHDRAWAL &&
-        _paymentResponse.invoiceMemo.description.isEmpty) {
+    if (type == PaymentType.WITHDRAWAL && _paymentResponse.invoiceMemo.description.isEmpty) {
       return texts.payment_info_title_bitcoin_transfer;
     }
 
@@ -916,16 +878,13 @@ class SinglePaymentInfo implements PaymentInfo {
         : _paymentResponse.invoiceMemo?.payerName);
 
     if (result == null || result.isEmpty) {
-      if (_paymentResponse.lnurlPayInfo != null &&
-          _paymentResponse.lnurlPayInfo.host != '') {
+      if (_paymentResponse.lnurlPayInfo != null && _paymentResponse.lnurlPayInfo.host != '') {
         result = _paymentResponse.lnurlPayInfo.host;
       } else {
         result = _paymentResponse.invoiceMemo.description;
       }
     }
-    return (result == null || result.isEmpty)
-        ? texts.payment_info_title_unknown
-        : result;
+    return (result == null || result.isEmpty) ? texts.payment_info_title_unknown : result;
   }
 
   @override
@@ -959,8 +918,7 @@ class SinglePaymentInfo implements PaymentInfo {
     final memo = _paymentResponse.invoiceMemo;
     final info = _paymentResponse.lnurlPayInfo;
 
-    if (memo.description.startsWith("Bitrefill") ||
-        info?.host == 'api-bitrefill.com') {
+    if (memo.description.startsWith("Bitrefill") || info?.host == 'api-bitrefill.com') {
       return PaymentVendor.BITREFILL;
     }
 
@@ -968,8 +926,7 @@ class SinglePaymentInfo implements PaymentInfo {
       return PaymentVendor.LN_PIZZA;
     }
 
-    if (memo.description.startsWith('lightning.gifts') ||
-        info?.host == 'api.lightning.gifts') {
+    if (memo.description.startsWith('lightning.gifts') || info?.host == 'api.lightning.gifts') {
       return PaymentVendor.LIGHTNING_GIFTS;
     }
 
@@ -1033,8 +990,7 @@ class RefundableDepositModel {
 
   Int64 get confirmedAmount => _address.confirmedAmount;
 
-  bool get refundBroadcasted =>
-      _address.lastRefundTxID != null && _address.lastRefundTxID.isNotEmpty;
+  bool get refundBroadcasted => _address.lastRefundTxID != null && _address.lastRefundTxID.isNotEmpty;
 }
 
 class BroadcastRefundRequestModel {
@@ -1092,9 +1048,7 @@ class PaymentError implements Exception {
   final bool ignoreGlobalFeedback;
 
   bool get validationError =>
-      error.toString().contains("rpc error") ||
-      traceReport == null ||
-      traceReport.isEmpty;
+      error.toString().contains("rpc error") || traceReport == null || traceReport.isEmpty;
 
   PaymentError(
     this.request,
@@ -1155,7 +1109,6 @@ class SweepAllCoinsTxs {
   Int64 get amount => _sweepTxs.amt;
 
   Map<int, TxDetail> get transactions {
-    return _sweepTxs.transactions
-        .map((key, value) => MapEntry(key, TxDetail(value)));
+    return _sweepTxs.transactions.map((key, value) => MapEntry(key, TxDetail(value)));
   }
 }

--- a/lib/bloc/account/account_model.dart
+++ b/lib/bloc/account/account_model.dart
@@ -373,7 +373,9 @@ class AccountModel {
     }
 
     if (swapStatus.error?.isNotEmpty == true) {
-      return texts.status_failed_to_add_funds(extractExceptionMessage(swapStatus.error));
+      return texts.status_failed_to_add_funds(
+        extractExceptionMessage(swapStatus.error),
+      );
     }
 
     return null;

--- a/lib/bloc/account/account_permissions_handler.dart
+++ b/lib/bloc/account/account_permissions_handler.dart
@@ -8,19 +8,14 @@ import 'package:rxdart/rxdart.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class AccountPermissionsHandler {
-  static const String PERMISSION_DIALOG_SHOWN_KEY =
-      "PERMISSION_DIALOG_SHOWN_KEY";
+  static const String PERMISSION_DIALOG_SHOWN_KEY = "PERMISSION_DIALOG_SHOWN_KEY";
 
-  final _optimizationWhitelistRequestController =
-      StreamController<void>.broadcast();
-  Stream<void> get optimizationWhitelistRequestStream =>
-      _optimizationWhitelistRequestController.stream;
-  Sink<void> get optimizationWhitelistRequestSink =>
-      _optimizationWhitelistRequestController.sink;
+  final _optimizationWhitelistRequestController = StreamController<void>.broadcast();
+  Stream<void> get optimizationWhitelistRequestStream => _optimizationWhitelistRequestController.stream;
+  Sink<void> get optimizationWhitelistRequestSink => _optimizationWhitelistRequestController.sink;
 
   final _optimizationWhitelistExplainController = BehaviorSubject<bool>();
-  Stream<bool> get optimizationWhitelistExplainStream =>
-      _optimizationWhitelistExplainController.stream;
+  Stream<bool> get optimizationWhitelistExplainStream => _optimizationWhitelistExplainController.stream;
 
   Permissions _permissionsService;
   Future<SharedPreferences> _preferences;

--- a/lib/bloc/account/account_synchronizer.dart
+++ b/lib/bloc/account/account_synchronizer.dart
@@ -14,8 +14,7 @@ class AccountSynchronizer {
   bool _dismissed = false;
   bool bootstrap = false;
 
-  final Function(int startTimestamp, double progress, bool syncedToChain,
-      bool isBootstrap) onProgress;
+  final Function(int startTimestamp, double progress, bool syncedToChain, bool isBootstrap) onProgress;
   final Function onComplete;
 
   AccountSynchronizer(this._breezLib, {this.onProgress, this.onComplete}) {
@@ -55,12 +54,10 @@ class AccountSynchronizer {
       }
       _breezLib.sendCommand("getinfo").then((info) {
         Map replyJson = json.decode(info);
-        var syncedToTimestamp =
-            int.parse(replyJson["bestHeaderTimestamp"].toString()) * 1000;
+        var syncedToTimestamp = int.parse(replyJson["bestHeaderTimestamp"].toString()) * 1000;
         var syncedToChain = replyJson["syncedToChain"].toString() == "true";
 
-        if (_startPollTimestamp == 0 &&
-            DateTime.now().millisecondsSinceEpoch - syncedToTimestamp > 0) {
+        if (_startPollTimestamp == 0 && DateTime.now().millisecondsSinceEpoch - syncedToTimestamp > 0) {
           _startPollTimestamp = syncedToTimestamp;
         }
         if (_startPollTimestamp > syncedToTimestamp) {
@@ -98,9 +95,7 @@ class AccountSynchronizer {
   void _emitProgress() {
     double progress = _chainProgress;
     if (bootstrap) {
-      progress = _bootstrapProgress * 0.7 +
-          _chainProgress * 0.2 +
-          _openChannelProgress * 0.1;
+      progress = _bootstrapProgress * 0.7 + _chainProgress * 0.2 + _openChannelProgress * 0.1;
     }
     onProgress(_startPollTimestamp, progress, _chainProgress == 1.0, bootstrap);
   }

--- a/lib/bloc/account/add_funds_model.dart
+++ b/lib/bloc/account/add_funds_model.dart
@@ -13,8 +13,7 @@ class AddFundsSettings {
     );
   }
 
-  AddFundsSettings.fromJson(Map<String, dynamic> json)
-      : this(moonpayIpCheck: json["moonpayIpCheck"] ?? true);
+  AddFundsSettings.fromJson(Map<String, dynamic> json) : this(moonpayIpCheck: json["moonpayIpCheck"] ?? true);
 
   Map<String, dynamic> toJson() => {
         "moonpayIpCheck": moonpayIpCheck,

--- a/lib/bloc/account/fiat_conversion.dart
+++ b/lib/bloc/account/fiat_conversion.dart
@@ -55,9 +55,8 @@ class FiatConversion {
 
     String formattedAmount = "";
     String spacing = " " * currencyData.spacing;
-    String symbol = currencyData.rightSideSymbol
-        ? '$spacing${currencyData.symbol}'
-        : '${currencyData.symbol}$spacing';
+    String symbol =
+        currencyData.rightSideSymbol ? '$spacing${currencyData.symbol}' : '${currencyData.symbol}$spacing';
     // if conversion result is less than the minimum it doesn't make sense to display
     // it.
     if (!allowBelowMin && fiatAmount < minimumAmount) {
@@ -70,9 +69,7 @@ class FiatConversion {
       formattedAmount = formatter.format(fiatAmount);
     }
     if (addCurrencySymbol) {
-      formattedAmount = currencyData.rightSideSymbol
-          ? formattedAmount + symbol
-          : symbol + formattedAmount;
+      formattedAmount = currencyData.rightSideSymbol ? formattedAmount + symbol : symbol + formattedAmount;
     } else if (includeDisplayName) {
       formattedAmount += currencyData.shortName;
     }

--- a/lib/bloc/app_blocs.dart
+++ b/lib/bloc/app_blocs.dart
@@ -50,11 +50,9 @@ class AppBlocs {
   factory AppBlocs(Stream<bool> backupAnytimeDBStream) {
     var blocsByType = <Type, Object>{};
     final sqliteRepository = SqliteRepository();
-    UserProfileBloc userProfileBloc =
-        _registerBloc(UserProfileBloc(), blocsByType);
-    BackupBloc backupBloc = _registerBloc(
-        BackupBloc(userProfileBloc.userStream, backupAnytimeDBStream),
-        blocsByType);
+    UserProfileBloc userProfileBloc = _registerBloc(UserProfileBloc(), blocsByType);
+    BackupBloc backupBloc =
+        _registerBloc(BackupBloc(userProfileBloc.userStream, backupAnytimeDBStream), blocsByType);
     PaymentOptionsBloc paymentOptionsBloc = _registerBloc(
       PaymentOptionsBloc(backupBloc.restoreLightningFeesStream),
       blocsByType,
@@ -69,13 +67,10 @@ class AppBlocs {
     TorBloc torBloc = _registerBloc(accountBloc.torBloc, blocsByType);
     InvoiceBloc invoicesBloc = _registerBloc(InvoiceBloc(), blocsByType);
     ConnectPayBloc connectPayBloc = _registerBloc(
-        ConnectPayBloc(userProfileBloc.userStream, accountBloc.accountStream,
-            accountBloc.userActionsSink),
+        ConnectPayBloc(userProfileBloc.userStream, accountBloc.accountStream, accountBloc.userActionsSink),
         blocsByType);
-    MarketplaceBloc marketplaceBloc =
-        _registerBloc(MarketplaceBloc(), blocsByType);
-    LSPBloc lspBloc =
-        _registerBloc(LSPBloc(accountBloc.accountStream), blocsByType);
+    MarketplaceBloc marketplaceBloc = _registerBloc(MarketplaceBloc(), blocsByType);
+    LSPBloc lspBloc = _registerBloc(LSPBloc(accountBloc.accountStream), blocsByType);
     LNUrlBloc lnurlBloc = _registerBloc(LNUrlBloc(), blocsByType);
     ReverseSwapBloc reverseSwapBloc = _registerBloc(
         ReverseSwapBloc(
@@ -92,8 +87,7 @@ class AppBlocs {
           sqliteRepository,
         ),
         blocsByType);
-    FastbitcoinsBloc fastbitcoinsBloc =
-        _registerBloc(FastbitcoinsBloc(), blocsByType);
+    FastbitcoinsBloc fastbitcoinsBloc = _registerBloc(FastbitcoinsBloc(), blocsByType);
     PodcastHistoryBloc podCastHistoryBloc = _registerBloc(
       PodcastHistoryBloc(),
       blocsByType,

--- a/lib/bloc/backup/backup_bloc.dart
+++ b/lib/bloc/backup/backup_bloc.dart
@@ -43,45 +43,33 @@ class BackupBloc with AsyncActionsHandler {
 
   static const _kPaymentOptionOverrideFee = "PAYMENT_OPTIONS_OVERRIDE_FEE";
   static const _kPaymentOptionBaseFee = "PAYMENT_OPTIONS_BASE_FEE";
-  static const _kPaymentOptionProportionalFee =
-      "PAYMENT_OPTIONS_PROPORTIONAL_FEE";
+  static const _kPaymentOptionProportionalFee = "PAYMENT_OPTIONS_PROPORTIONAL_FEE";
 
-  final BehaviorSubject<BackupState> _backupStateController =
-      BehaviorSubject<BackupState>();
+  final BehaviorSubject<BackupState> _backupStateController = BehaviorSubject<BackupState>();
   Stream<BackupState> get backupStateStream => _backupStateController.stream;
 
-  final StreamController<bool> _promptBackupController =
-      BehaviorSubject<bool>.seeded(false);
+  final StreamController<bool> _promptBackupController = BehaviorSubject<bool>.seeded(false);
   Stream<bool> get promptBackupStream => _promptBackupController.stream;
 
-  final StreamController<bool> _backupPromptVisibleController =
-      BehaviorSubject<bool>.seeded(false);
-  Stream<bool> get backupPromptVisibleStream =>
-      _backupPromptVisibleController.stream;
+  final StreamController<bool> _backupPromptVisibleController = BehaviorSubject<bool>.seeded(false);
+  Stream<bool> get backupPromptVisibleStream => _backupPromptVisibleController.stream;
   Sink<bool> get backupPromptVisibleSink => _backupPromptVisibleController.sink;
 
-  final StreamController<bool> _promptBackupDismissedController =
-      BehaviorSubject<bool>.seeded(false);
-  Stream<bool> get promptBackupDismissedStream =>
-      _promptBackupDismissedController.stream;
-  Sink<bool> get promptBackupDismissedSink =>
-      _promptBackupDismissedController.sink;
+  final StreamController<bool> _promptBackupDismissedController = BehaviorSubject<bool>.seeded(false);
+  Stream<bool> get promptBackupDismissedStream => _promptBackupDismissedController.stream;
+  Sink<bool> get promptBackupDismissedSink => _promptBackupDismissedController.sink;
 
   final BehaviorSubject<BackupSettings> _backupSettingsController =
       BehaviorSubject<BackupSettings>.seeded(BackupSettings.initial());
-  Stream<BackupSettings> get backupSettingsStream =>
-      _backupSettingsController.stream;
+  Stream<BackupSettings> get backupSettingsStream => _backupSettingsController.stream;
   Sink<BackupSettings> get backupSettingsSink => _backupSettingsController.sink;
 
   final _backupAppDataController = StreamController<bool>.broadcast();
   Sink<bool> get backupAppDataSink => _backupAppDataController.sink;
 
-  final _restoreLightningFeesController =
-      StreamController<Map<String, dynamic>>.broadcast();
-  Sink<Map<String, dynamic>> get restoreLightningFeesSink =>
-      _restoreLightningFeesController.sink;
-  Stream<Map<String, dynamic>> get restoreLightningFeesStream =>
-      _restoreLightningFeesController.stream;
+  final _restoreLightningFeesController = StreamController<Map<String, dynamic>>.broadcast();
+  Sink<Map<String, dynamic>> get restoreLightningFeesSink => _restoreLightningFeesController.sink;
+  Stream<Map<String, dynamic>> get restoreLightningFeesStream => _restoreLightningFeesController.stream;
 
   final _backupActionsController = StreamController<AsyncAction>.broadcast();
   Sink<AsyncAction> get backupActionsSink => _backupActionsController.sink;
@@ -94,19 +82,14 @@ class BackupBloc with AsyncActionsHandler {
         backupPromptVisibleStream,
         backupStateStream,
         (settings, signInNeeded, dismissed, isVisible, backupState) {
-          return (!backupState.inProgress &&
-                  settings.promptOnError &&
-                  !dismissed &&
-                  !isVisible)
+          return (!backupState.inProgress && settings.promptOnError && !dismissed && !isVisible)
               ? signInNeeded
               : false;
         },
       );
 
-  final BehaviorSubject<bool> _backupServiceNeedLoginController =
-      BehaviorSubject<bool>.seeded(false);
-  StreamSink<bool> get backupServiceNeedLoginSink =>
-      _backupServiceNeedLoginController.sink;
+  final BehaviorSubject<bool> _backupServiceNeedLoginController = BehaviorSubject<bool>.seeded(false);
+  StreamSink<bool> get backupServiceNeedLoginSink => _backupServiceNeedLoginController.sink;
 
   BreezBridge _breezLib;
   BackgroundTaskService _tasksService;
@@ -164,8 +147,7 @@ class BackupBloc with AsyncActionsHandler {
   void _initAppDataPathAndDir() async {
     var appDir = await getApplicationDocumentsDirectory();
     _appDirPath = appDir.path;
-    _backupAppDataDirPath =
-        '$_appDirPath${Platform.pathSeparator}app_data_backup';
+    _backupAppDataDirPath = '$_appDirPath${Platform.pathSeparator}app_data_backup';
     Directory(_backupAppDataDirPath).createSync(recursive: true);
   }
 
@@ -180,8 +162,7 @@ class BackupBloc with AsyncActionsHandler {
 
   void _listenPaidInvoices() {
     _breezLib.notificationStream
-        .where((event) =>
-            event.type == NotificationEvent_NotificationType.INVOICE_PAID)
+        .where((event) => event.type == NotificationEvent_NotificationType.INVOICE_PAID)
         .listen((invoice) => _promptBackupDismissedController.add(false));
   }
 
@@ -199,8 +180,7 @@ class BackupBloc with AsyncActionsHandler {
           _log.info("backup key type continue to be the same");
         }
         if (newSettings.backupProvider != oldSettings.backupProvider ||
-            !oldSettings.remoteServerAuthData
-                .equal(newSettings.remoteServerAuthData)) {
+            !oldSettings.remoteServerAuthData.equal(newSettings.remoteServerAuthData)) {
           _log.info("update backup provider");
           await _updateBackupProvider(newSettings);
         } else {
@@ -240,8 +220,7 @@ class BackupBloc with AsyncActionsHandler {
 
   Future _initializePersistentData() async {
     //last backup time persistency
-    String backupStateJson =
-        _sharedPreferences.getString(LAST_BACKUP_STATE_PREFERENCE_KEY);
+    String backupStateJson = _sharedPreferences.getString(LAST_BACKUP_STATE_PREFERENCE_KEY);
     BackupState backupState = BackupState.initial();
     if (backupStateJson != null) {
       backupState = BackupState.fromJson(json.decode(backupStateJson));
@@ -249,35 +228,28 @@ class BackupBloc with AsyncActionsHandler {
 
     _backupStateController.add(backupState);
     _backupStateController.stream.listen((state) {
-      _sharedPreferences.setString(
-          LAST_BACKUP_STATE_PREFERENCE_KEY, json.encode(state.toJson()));
+      _sharedPreferences.setString(LAST_BACKUP_STATE_PREFERENCE_KEY, json.encode(state.toJson()));
     }, onError: (e) {
       _pushPromptIfNeeded();
     });
 
     //settings persistency
-    var backupSettings =
-        _sharedPreferences.getString(BACKUP_SETTINGS_PREFERENCES_KEY);
+    var backupSettings = _sharedPreferences.getString(BACKUP_SETTINGS_PREFERENCES_KEY);
     if (backupSettings != null) {
       Map<String, dynamic> settings = json.decode(backupSettings);
       var backupSettingsModel = BackupSettings.fromJson(settings);
       // For backward compatibility migrate backup provider by assigning "Google Drive"
       // in case we had backup and the provider is not set.
-      if (backupSettingsModel.backupProvider == null &&
-          backupState?.lastBackupTime != null) {
+      if (backupSettingsModel.backupProvider == null && backupState?.lastBackupTime != null) {
         backupSettingsModel = backupSettingsModel.copyWith(
           backupProvider: BackupProvider.googleDrive(),
         );
       }
-      if (backupSettingsModel.backupProvider != null &&
-          backupSettingsModel.backupProvider.isRemoteServer) {
-        String authdata =
-            await _secureStorage.read(key: "remoteServerAuthData");
+      if (backupSettingsModel.backupProvider != null && backupSettingsModel.backupProvider.isRemoteServer) {
+        String authdata = await _secureStorage.read(key: "remoteServerAuthData");
         if (authdata != null) {
-          RemoteServerAuthData auth =
-              RemoteServerAuthData.fromJson(json.decode(authdata));
-          backupSettingsModel =
-              backupSettingsModel.copyWith(remoteServerAuthData: auth);
+          RemoteServerAuthData auth = RemoteServerAuthData.fromJson(json.decode(authdata));
+          backupSettingsModel = backupSettingsModel.copyWith(remoteServerAuthData: auth);
         }
       }
 
@@ -285,11 +257,9 @@ class BackupBloc with AsyncActionsHandler {
     }
 
     _backupSettingsController.stream.listen((settings) async {
-      _sharedPreferences.setString(
-          BACKUP_SETTINGS_PREFERENCES_KEY, json.encode(settings.toJson()));
+      _sharedPreferences.setString(BACKUP_SETTINGS_PREFERENCES_KEY, json.encode(settings.toJson()));
       if (settings.remoteServerAuthData != null) {
-        String secureValue =
-            json.encode(settings.remoteServerAuthData.toJson());
+        String secureValue = json.encode(settings.remoteServerAuthData.toJson());
         await _secureStorage.write(
             key: "remoteServerAuthData",
             value: secureValue,
@@ -312,39 +282,30 @@ class BackupBloc with AsyncActionsHandler {
 
   Future<void> _compareUserPreferences(BreezUserModel user) async {
     var appDir = await getApplicationDocumentsDirectory();
-    var backupAppDataDirPath =
-        '${appDir.path}${Platform.pathSeparator}app_data_backup';
-    final backupUserPrefsPath =
-        '$backupAppDataDirPath${Platform.pathSeparator}userPreferences.txt';
+    var backupAppDataDirPath = '${appDir.path}${Platform.pathSeparator}app_data_backup';
+    final backupUserPrefsPath = '$backupAppDataDirPath${Platform.pathSeparator}userPreferences.txt';
     // Check if userPreferences file exists
     if (await File(backupUserPrefsPath).exists()) {
       // Compare updated user preferences against stored user preferences
-      BackupUserPreferences userPreferences =
-          BackupUserPreferences.fromJson(user.toJson());
-      BackupUserPreferences storedUserPreferences =
-          await _getSavedUserPreferences(backupUserPrefsPath);
+      BackupUserPreferences userPreferences = BackupUserPreferences.fromJson(user.toJson());
+      BackupUserPreferences storedUserPreferences = await _getSavedUserPreferences(backupUserPrefsPath);
       // Update and trigger backup if user preferences has changed
-      if (userPreferences.toJson().toString() !=
-          storedUserPreferences.toJson().toString()) {
-        await _updateUserPreferences(user)
-            .then((_) => backupAppDataSink.add(true));
+      if (userPreferences.toJson().toString() != storedUserPreferences.toJson().toString()) {
+        await _updateUserPreferences(user).then((_) => backupAppDataSink.add(true));
       }
     } else {
       await _saveUserPreferences();
     }
   }
 
-  Future<BackupUserPreferences> _getSavedUserPreferences(
-      String backupUserPrefsPath) async {
+  Future<BackupUserPreferences> _getSavedUserPreferences(String backupUserPrefsPath) async {
     final backupUserPrefs = await File(backupUserPrefsPath).readAsString();
     return BackupUserPreferences.fromJson(json.decode(backupUserPrefs));
   }
 
   Future<void> _updateUserPreferences(BreezUserModel userModel) async {
-    final backupUserPrefsPath =
-        '$_backupAppDataDirPath${Platform.pathSeparator}userPreferences.txt';
-    var backupUserPreferences =
-        BackupUserPreferences.fromJson(userModel.toJson());
+    final backupUserPrefsPath = '$_backupAppDataDirPath${Platform.pathSeparator}userPreferences.txt';
+    var backupUserPreferences = BackupUserPreferences.fromJson(userModel.toJson());
     await File(backupUserPrefsPath)
         .writeAsString(jsonEncode(backupUserPreferences.toJson()))
         .catchError((err) {
@@ -354,15 +315,11 @@ class BackupBloc with AsyncActionsHandler {
 
   // Save BreezUserModel json to backup directory
   Future<void> _saveUserPreferences() async {
-    final backupUserPrefsPath =
-        '$_backupAppDataDirPath${Platform.pathSeparator}userPreferences.txt';
+    final backupUserPrefsPath = '$_backupAppDataDirPath${Platform.pathSeparator}userPreferences.txt';
     var preferences = await ServiceInjector().sharedPreferences;
-    var userPreferences =
-        preferences.getString(USER_DETAILS_PREFERENCES_KEY) ?? "{}";
-    BreezUserModel userModel =
-        BreezUserModel.fromJson(json.decode(userPreferences));
-    var backupUserPreferences =
-        BackupUserPreferences.fromJson(userModel.toJson());
+    var userPreferences = preferences.getString(USER_DETAILS_PREFERENCES_KEY) ?? "{}";
+    BreezUserModel userModel = BreezUserModel.fromJson(json.decode(userPreferences));
+    var backupUserPreferences = BackupUserPreferences.fromJson(userModel.toJson());
     await File(backupUserPrefsPath)
         .writeAsString(json.encode(backupUserPreferences.toJson()))
         .catchError((err) {
@@ -450,8 +407,7 @@ class BackupBloc with AsyncActionsHandler {
       // not to confuse the two.
       if (e.message == _googleSignNotAvailable) {
         exception = GoogleSignNotAvailableException();
-      } else if (e.code == _insufficientScope ||
-          exception.contains(_insufficientScope)) {
+      } else if (e.code == _insufficientScope || exception.contains(_insufficientScope)) {
         exception = InsufficientScopeException();
       } else if (exception.contains(_invalidCredentials)) {
         // If user revokes Breez permissions from their GDrive account during a
@@ -462,8 +418,7 @@ class BackupBloc with AsyncActionsHandler {
         exception = InvalidCredentialsException();
       } else if (e.message == _signInCancelledMessage) {
         exception = SignInCancelledException();
-      } else if (e.code == _signInFailedMessage ||
-          e.message == _signInFailedCode) {
+      } else if (e.code == _signInFailedMessage || e.message == _signInFailedCode) {
         exception = SignInFailedException(
           _backupSettingsController.value.backupProvider,
         );
@@ -495,8 +450,7 @@ class BackupBloc with AsyncActionsHandler {
       action.resolve(true);
     } on FileSystemException catch (error) {
       if (error.message.contains("Failed to decode data using encoding")) {
-        _log.warning(
-            "Failed to restore backup. Incorrect mnemonic phrase.", error);
+        _log.warning("Failed to restore backup. Incorrect mnemonic phrase.", error);
         _clearAppData();
         await _resetBackupKey();
         action.resolveError(
@@ -566,8 +520,7 @@ class BackupBloc with AsyncActionsHandler {
       // not to confuse the two.
       if (e.message == _googleSignNotAvailable) {
         exception = GoogleSignNotAvailableException();
-      } else if (e.code == _insufficientScope ||
-          exception.contains(_insufficientScope)) {
+      } else if (e.code == _insufficientScope || exception.contains(_insufficientScope)) {
         exception = InsufficientScopeException();
       } else if (exception.contains(_invalidCredentials)) {
         // If user revokes Breez permissions from their GDrive account during a
@@ -578,8 +531,7 @@ class BackupBloc with AsyncActionsHandler {
         exception = InvalidCredentialsException();
       } else if (e.code == _signInCancelledMessage) {
         exception = SignInCancelledException();
-      } else if (e.code == _signInFailedMessage ||
-          e.message == _signInFailedCode) {
+      } else if (e.code == _signInFailedMessage || e.message == _signInFailedCode) {
         exception = SignInFailedException(
           _backupSettingsController.value.backupProvider,
         );
@@ -603,8 +555,7 @@ class BackupBloc with AsyncActionsHandler {
     Completer taskCompleter;
 
     _breezLib.notificationStream.listen((event) {
-      if (taskCompleter == null &&
-          event.type == NotificationEvent_NotificationType.BACKUP_REQUEST) {
+      if (taskCompleter == null && event.type == NotificationEvent_NotificationType.BACKUP_REQUEST) {
         taskCompleter = Completer();
         _tasksService.runAsTask(taskCompleter.future, () {
           taskCompleter?.complete();
@@ -625,8 +576,7 @@ class BackupBloc with AsyncActionsHandler {
     try {
       _log.info("Backup Now requested: $action");
       bool signInNeeded = _backupServiceNeedLoginController.value;
-      final backupProviderName =
-          action.updateBackupSettings.settings.backupProvider?.displayName;
+      final backupProviderName = action.updateBackupSettings.settings.backupProvider?.displayName;
 
       await _updateBackupSettings(action.updateBackupSettings);
       _log.info("Does backup service need relogin $signInNeeded");
@@ -657,8 +607,7 @@ class BackupBloc with AsyncActionsHandler {
       // not to confuse the two.
       if (e.message == _googleSignNotAvailable) {
         exception = GoogleSignNotAvailableException();
-      } else if (e.code == _insufficientScope ||
-          exception.contains(_insufficientScope)) {
+      } else if (e.code == _insufficientScope || exception.contains(_insufficientScope)) {
         exception = InsufficientScopeException();
       } else if (exception.contains(_invalidCredentials)) {
         // If user revokes Breez permissions from their GDrive account during a
@@ -670,8 +619,7 @@ class BackupBloc with AsyncActionsHandler {
         _promptBackupController.add(true);
       } else if (e.code == _signInCancelledMessage) {
         exception = SignInCancelledException();
-      } else if (e.code == _signInFailedMessage ||
-          e.message == _signInFailedCode) {
+      } else if (e.code == _signInFailedMessage || e.message == _signInFailedCode) {
         exception = SignInFailedException(
           _backupSettingsController.value.backupProvider,
         );
@@ -691,8 +639,7 @@ class BackupBloc with AsyncActionsHandler {
   }
 
   void _listenAppDataBackupRequests(Stream backupAnytimeDBStream) {
-    Rx.merge([backupAnytimeDBStream, _backupAppDataController.stream])
-        .listen((_) => _backupAppData());
+    Rx.merge([backupAnytimeDBStream, _backupAppDataController.stream]).listen((_) => _backupAppData());
   }
 
   Future _backupAppData() async {
@@ -711,12 +658,9 @@ class BackupBloc with AsyncActionsHandler {
   }
 
   Future<void> _saveLightningFees() async {
-    final lightningFeesPath =
-        '$_backupAppDataDirPath${Platform.pathSeparator}lightningFees.txt';
+    final lightningFeesPath = '$_backupAppDataDirPath${Platform.pathSeparator}lightningFees.txt';
     final lightningFeesPreferences = await _getLightningFeesPreferences();
-    await File(lightningFeesPath)
-        .writeAsString(json.encode(lightningFeesPreferences))
-        .catchError((err) {
+    await File(lightningFeesPath).writeAsString(json.encode(lightningFeesPreferences)).catchError((err) {
       throw Exception("Failed to save lightning fees.");
     });
   }
@@ -729,10 +673,9 @@ class BackupBloc with AsyncActionsHandler {
     int baseFee = preferences.containsKey(_kPaymentOptionBaseFee)
         ? preferences.getInt(_kPaymentOptionBaseFee)
         : _kDefaultBaseFee;
-    double proportionalFee =
-        preferences.containsKey(_kPaymentOptionProportionalFee)
-            ? preferences.getDouble(_kPaymentOptionProportionalFee)
-            : _kDefaultProportionalFee;
+    double proportionalFee = preferences.containsKey(_kPaymentOptionProportionalFee)
+        ? preferences.getDouble(_kPaymentOptionProportionalFee)
+        : _kDefaultProportionalFee;
     return {
       _kPaymentOptionOverrideFee: paymentFeeEnabled,
       _kPaymentOptionBaseFee: baseFee,
@@ -746,8 +689,7 @@ class BackupBloc with AsyncActionsHandler {
         '${await databaseFactory.getDatabasesPath()}${Platform.pathSeparator}product-catalog.db';
     if (await databaseExists(posDbPath)) {
       File(posDbPath)
-          .copy(
-              '$_backupAppDataDirPath${Platform.pathSeparator}product-catalog.db')
+          .copy('$_backupAppDataDirPath${Platform.pathSeparator}product-catalog.db')
           .catchError((err) {
         throw Exception("Failed to copy pos items.");
       });
@@ -758,9 +700,7 @@ class BackupBloc with AsyncActionsHandler {
     // Copy Podcasts library to backup directory
     final anytimeDbPath = '$_appDirPath${Platform.pathSeparator}anytime.db';
     if (await databaseExists(anytimeDbPath)) {
-      File(anytimeDbPath)
-          .copy('$_backupAppDataDirPath${Platform.pathSeparator}anytime.db')
-          .catchError((err) {
+      File(anytimeDbPath).copy('$_backupAppDataDirPath${Platform.pathSeparator}anytime.db').catchError((err) {
         throw Exception("Failed to copy podcast library.");
       });
     }
@@ -831,11 +771,8 @@ class BackupBloc with AsyncActionsHandler {
     }
   }
 
-  Future testAuth(
-      BackupProvider provider, RemoteServerAuthData authData) async {
-    return await _breezLib
-        .testBackupAuth(provider.name, json.encode(authData.toJson()))
-        .catchError(
+  Future testAuth(BackupProvider provider, RemoteServerAuthData authData) async {
+    return await _breezLib.testBackupAuth(provider.name, json.encode(authData.toJson())).catchError(
       (error) {
         _log.info('backupBloc.testAuth caught error: $error');
 
@@ -874,20 +811,16 @@ class BackupBloc with AsyncActionsHandler {
   }
 
   Future<void> _restoreLightningFees() async {
-    final lightningFeesPath =
-        '$_backupAppDataDirPath${Platform.pathSeparator}lightningFees.txt';
+    final lightningFeesPath = '$_backupAppDataDirPath${Platform.pathSeparator}lightningFees.txt';
     if (await File(lightningFeesPath).exists()) {
-      final backupLightningFeesPrefs =
-          await File(lightningFeesPath).readAsString();
-      Map<String, dynamic> lightningFeesPrefs =
-          json.decode(backupLightningFeesPrefs);
+      final backupLightningFeesPrefs = await File(lightningFeesPath).readAsString();
+      Map<String, dynamic> lightningFeesPrefs = json.decode(backupLightningFeesPrefs);
       restoreLightningFeesSink.add(lightningFeesPrefs);
     }
   }
 
   Future<void> _restorePosDB() async {
-    final backupPosDbPath =
-        '$_backupAppDataDirPath${Platform.pathSeparator}product-catalog.db';
+    final backupPosDbPath = '$_backupAppDataDirPath${Platform.pathSeparator}product-catalog.db';
     final posDbPath =
         '${await databaseFactory.getDatabasesPath()}${Platform.pathSeparator}product-catalog.db';
     if (await File(backupPosDbPath).exists()) {
@@ -898,8 +831,7 @@ class BackupBloc with AsyncActionsHandler {
   }
 
   Future<void> _restorePodcastsDB() async {
-    final backupAnytimeDbPath =
-        '$_backupAppDataDirPath${Platform.pathSeparator}anytime.db';
+    final backupAnytimeDbPath = '$_backupAppDataDirPath${Platform.pathSeparator}anytime.db';
     final anytimeDbPath = '$_appDirPath${Platform.pathSeparator}anytime.db';
     if (await File(backupAnytimeDbPath).exists()) {
       await File(backupAnytimeDbPath).copy(anytimeDbPath).catchError((err) {

--- a/lib/bloc/backup/backup_model.dart
+++ b/lib/bloc/backup/backup_model.dart
@@ -31,12 +31,7 @@ class RemoteServerAuthData {
         );
 
   Map<String, dynamic> toJson() {
-    return {
-      "url": url,
-      "user": user,
-      "password": password,
-      "breezDir": breezDir
-    };
+    return {"url": url, "user": user, "password": password, "breezDir": breezDir};
   }
 
   bool equal(RemoteServerAuthData other) {
@@ -150,9 +145,8 @@ class BackupSettings {
       : this(
           json["promptOnError"] ?? false,
           BackupKeyType.values[json["backupKeyType"] ?? 0],
-          BackupSettings.availableBackupProviders().firstWhere(
-              (p) => p.name == json["backupProvider"],
-              orElse: () => null),
+          BackupSettings.availableBackupProviders()
+              .firstWhere((p) => p.name == json["backupProvider"], orElse: () => null),
           RemoteServerAuthData.fromJson(json["remoteServerAuthData"] ?? {}),
         );
 
@@ -200,10 +194,7 @@ class BackupSettings {
   }
 
   static List<BackupProvider> availableBackupProviders() {
-    List<BackupProvider> providers = [
-      BackupProvider.googleDrive(),
-      BackupProvider.remoteServer()
-    ];
+    List<BackupProvider> providers = [BackupProvider.googleDrive(), BackupProvider.remoteServer()];
     if (defaultTargetPlatform == TargetPlatform.iOS) {
       providers.insert(0, BackupProvider.iCloud());
     }
@@ -239,8 +230,7 @@ class BackupState {
   BackupState.fromJson(Map<String, dynamic> json)
       : this(
           json["lastBackupTime"] != null
-              ? DateTime.fromMillisecondsSinceEpoch(json["lastBackupTime"])
-                  .toLocal()
+              ? DateTime.fromMillisecondsSinceEpoch(json["lastBackupTime"]).toLocal()
               : null,
           false,
           json["lastBackupAccountName"],
@@ -398,10 +388,8 @@ class BreezLibBackupKey {
     if (key != null) {
       switch (backupKeyType) {
         case BackupKeyType.PHRASE:
-          assert(entropy.length == ENTROPY_LENGTH ||
-              entropy.length == ENTROPY_LENGTH * 2);
-          result =
-              entropy.length == ENTROPY_LENGTH ? 'Mnemonics12' : 'Mnemonics';
+          assert(entropy.length == ENTROPY_LENGTH || entropy.length == ENTROPY_LENGTH * 2);
+          result = entropy.length == ENTROPY_LENGTH ? 'Mnemonics12' : 'Mnemonics';
           break;
         case BackupKeyType.PIN:
 
@@ -459,8 +447,7 @@ class RestoreRequest {
           "Node ID mustn't be empty for restore request.",
         ),
         assert(
-          !(encryptionKey != null && encryptionKey.key != null) ||
-              encryptionKey.key.isNotEmpty,
+          !(encryptionKey != null && encryptionKey.key != null) || encryptionKey.key.isNotEmpty,
           "Encryption key mustn't be empty for encrypted backup.",
         );
 }

--- a/lib/bloc/blocs_provider.dart
+++ b/lib/bloc/blocs_provider.dart
@@ -4,8 +4,7 @@ import 'package:flutter/material.dart';
 class AppBlocsProvider extends InheritedWidget {
   final AppBlocs appBlocs;
 
-  const AppBlocsProvider({Key key, Widget child, this.appBlocs})
-      : super(key: key, child: child);
+  const AppBlocsProvider({Key key, Widget child, this.appBlocs}) : super(key: key, child: child);
 
   @override
   bool updateShouldNotify(InheritedWidget oldWidget) {
@@ -13,8 +12,7 @@ class AppBlocsProvider extends InheritedWidget {
   }
 
   static T of<T>(BuildContext context) {
-    AppBlocsProvider widget =
-        context.dependOnInheritedWidgetOfExactType<AppBlocsProvider>();
+    AppBlocsProvider widget = context.dependOnInheritedWidgetOfExactType<AppBlocsProvider>();
     if (widget == null) {
       return null;
     }
@@ -66,8 +64,7 @@ class _BlocProviderState<T extends Bloc> extends State<BlocProvider<T>> {
 class _Inherited<T> extends InheritedWidget {
   final T bloc;
 
-  const _Inherited({Key key, Widget child, this.bloc})
-      : super(key: key, child: child);
+  const _Inherited({Key key, Widget child, this.bloc}) : super(key: key, child: child);
 
   @override
   bool updateShouldNotify(InheritedWidget oldWidget) {
@@ -75,8 +72,7 @@ class _Inherited<T> extends InheritedWidget {
   }
 
   static T of<T>(BuildContext context) {
-    _Inherited widget =
-        context.dependOnInheritedWidgetOfExactType<_Inherited<T>>();
+    _Inherited widget = context.dependOnInheritedWidgetOfExactType<_Inherited<T>>();
     if (widget == null) {
       return null;
     }

--- a/lib/bloc/connect_pay/connect_pay_model.dart
+++ b/lib/bloc/connect_pay/connect_pay_model.dart
@@ -4,8 +4,7 @@ This model represents the state of the payment session for both sides.
 import 'package:fixnum/fixnum.dart';
 
 class PaymentSessionState {
-  static const Duration connectionEmulationDuration =
-      Duration(milliseconds: 1500);
+  static const Duration connectionEmulationDuration = Duration(milliseconds: 1500);
   final bool payer;
   final String sessionSecret;
   final PayerSessionData payerData;
@@ -15,8 +14,7 @@ class PaymentSessionState {
   final bool paymentFulfilled;
   final int settledAmount;
 
-  bool get remotePartyCancelled =>
-      payer ? payeeData.cancelled : payerData.cancelled;
+  bool get remotePartyCancelled => payer ? payeeData.cancelled : payerData.cancelled;
 
   PaymentSessionState(
     this.payer,
@@ -49,8 +47,7 @@ class PaymentSessionState {
     );
   }
 
-  PaymentSessionState.payerStart(
-      String sessionSecret, String userName, String imageURL)
+  PaymentSessionState.payerStart(String sessionSecret, String userName, String imageURL)
       : this(
           true,
           sessionSecret,
@@ -61,14 +58,12 @@ class PaymentSessionState {
           false,
           0,
         );
-  PaymentSessionState.payeeStart(
-      String sessionSecret, String userName, String imageURL)
+  PaymentSessionState.payeeStart(String sessionSecret, String userName, String imageURL)
       : this(
           false,
           sessionSecret,
           PayerSessionData(null, null, PeerStatus.initial(), null, null),
-          PayeeSessionData(
-              userName, imageURL, PeerStatus.initial(), null, null, false),
+          PayeeSessionData(userName, imageURL, PeerStatus.initial(), null, null, false),
           true,
           true,
           false,
@@ -87,18 +82,11 @@ class PayerSessionData {
   final bool paymentFulfilled;
   final double unconfirmedChannelsProgress;
 
-  PayerSessionData(
-      this.userName, this.imageURL, this.status, this.amount, this.description,
-      {this.error,
-      this.paymentFulfilled = false,
-      this.cancelled = false,
-      this.unconfirmedChannelsProgress});
+  PayerSessionData(this.userName, this.imageURL, this.status, this.amount, this.description,
+      {this.error, this.paymentFulfilled = false, this.cancelled = false, this.unconfirmedChannelsProgress});
   PayerSessionData.fromJson(Map<dynamic, dynamic> json)
-      : status =
-            json['status'] == null ? null : PeerStatus.fromJson(json['status']),
-        amount = json['amount'] != null
-            ? int.parse(json['amount'].toString())
-            : null,
+      : status = json['status'] == null ? null : PeerStatus.fromJson(json['status']),
+        amount = json['amount'] != null ? int.parse(json['amount'].toString()) : null,
         description = json['description'],
         userName = json["userName"],
         imageURL = json["imageURL"],
@@ -126,8 +114,7 @@ class PayerSessionData {
       error: error ?? this.error,
       paymentFulfilled: paymentFulfilled ?? this.paymentFulfilled,
       cancelled: cancelled ?? cancelled,
-      unconfirmedChannelsProgress:
-          unconfirmedChannelsProgress ?? this.unconfirmedChannelsProgress,
+      unconfirmedChannelsProgress: unconfirmedChannelsProgress ?? this.unconfirmedChannelsProgress,
     );
   }
 }
@@ -141,12 +128,11 @@ class PayeeSessionData {
   final bool cancelled;
   bool get invitationAccepted => status.lastChanged != 0;
 
-  PayeeSessionData(this.userName, this.imageURL, this.status,
-      this.paymentRequest, this.error, this.cancelled);
+  PayeeSessionData(
+      this.userName, this.imageURL, this.status, this.paymentRequest, this.error, this.cancelled);
 
   PayeeSessionData.fromJson(Map<dynamic, dynamic> json)
-      : status =
-            json['status'] == null ? null : PeerStatus.fromJson(json['status']),
+      : status = json['status'] == null ? null : PeerStatus.fromJson(json['status']),
         paymentRequest = json['paymentRequest'],
         userName = json["userName"],
         error = json["error"],
@@ -199,8 +185,7 @@ class PaymentSessionError {
   final PaymentSessionErrorType type;
   final String description;
 
-  PaymentSessionError.unknown(this.description)
-      : type = PaymentSessionErrorType.UNKNOWN;
+  PaymentSessionError.unknown(this.description) : type = PaymentSessionErrorType.UNKNOWN;
 
   PaymentSessionError(this.type, this.description);
 }

--- a/lib/bloc/connect_pay/firebase_session_channel.dart
+++ b/lib/bloc/connect_pay/firebase_session_channel.dart
@@ -14,15 +14,12 @@ class PaymentSessionChannel {
 
   final StreamController<Map<dynamic, dynamic>> _incomingMessagesController =
       StreamController<Map<dynamic, dynamic>>.broadcast();
-  Stream<Map<dynamic, dynamic>> get incomingMessagesStream =>
-      _incomingMessagesController.stream;
+  Stream<Map<dynamic, dynamic>> get incomingMessagesStream => _incomingMessagesController.stream;
 
-  final StreamController<void> _peerTerminatedController =
-      StreamController<void>();
+  final StreamController<void> _peerTerminatedController = StreamController<void>();
   Stream<void> get peerTerminatedStream => _peerTerminatedController.stream;
 
-  final StreamController<void> peerResetStreamController =
-      StreamController<void>();
+  final StreamController<void> peerResetStreamController = StreamController<void>();
   Stream<void> get peerResetStream => peerResetStreamController.stream;
 
   final String _sessionID;
@@ -84,10 +81,7 @@ class PaymentSessionChannel {
       await peerResetStreamController.close();
       await _peerTerminatedController.close();
       if (destroyHistory) {
-        await FirebaseDatabase.instance
-            .ref()
-            .child('remote-payments/$_sessionID')
-            .remove();
+        await FirebaseDatabase.instance.ref().child('remote-payments/$_sessionID').remove();
       }
       await _incomingMessagesController.close();
       _activeChannels--;
@@ -100,9 +94,7 @@ class PaymentSessionChannel {
   bool get terminated => _terminated;
 
   void _listenIncomingMessages() async {
-    var theirData = FirebaseDatabase.instance
-        .ref()
-        .child('remote-payments/$_sessionID/$_theirKey/state');
+    var theirData = FirebaseDatabase.instance.ref().child('remote-payments/$_sessionID/$_theirKey/state');
     _theirDataListener = theirData.onValue.listen((event) async {
       var stateMessage = event.snapshot.value;
       if (stateMessage == null) {
@@ -112,8 +104,7 @@ class PaymentSessionChannel {
 
       if (stateMessage != null && stateMessage.runtimeType == String) {
         if (interceptor != null) {
-          stateMessage =
-              await interceptor.transformIncomingMessage(stateMessage);
+          stateMessage = await interceptor.transformIncomingMessage(stateMessage);
         }
         Map<String, dynamic> decodedState = json.decode(stateMessage);
         _incomingMessagesController.add(decodedState);
@@ -122,8 +113,7 @@ class PaymentSessionChannel {
   }
 
   void _watchSessionTermination() {
-    var sessionRoot =
-        FirebaseDatabase.instance.ref().child('remote-payments/$_sessionID');
+    var sessionRoot = FirebaseDatabase.instance.ref().child('remote-payments/$_sessionID');
     _sessionRootListener = sessionRoot.onValue.listen((event) {
       if (event.snapshot.value == null) {
         _peerTerminatedController.add(null);
@@ -133,12 +123,8 @@ class PaymentSessionChannel {
 
   void _watchPeerReset() {
     var terminationPath = _payer ? '$_sessionID/payer' : '$_sessionID/payee';
-    var terminationRef = FirebaseDatabase.instance
-        .ref()
-        .child('remote-payments/$terminationPath');
-    _peerResetListener = terminationRef.onValue
-        .delay(const Duration(milliseconds: 500))
-        .listen((event) {
+    var terminationRef = FirebaseDatabase.instance.ref().child('remote-payments/$terminationPath');
+    _peerResetListener = terminationRef.onValue.delay(const Duration(milliseconds: 500)).listen((event) {
       if (event.snapshot.value == null) {
         peerResetStreamController.add(null);
       }

--- a/lib/bloc/connect_pay/online_status_updater.dart
+++ b/lib/bloc/connect_pay/online_status_updater.dart
@@ -9,38 +9,25 @@ class OnlineStatusUpdater {
   StreamSubscription _onRemoteConnectSubscription;
   DatabaseReference _userStatusPath;
 
-  void startStatusUpdates(
-      String localKey,
-      Function(PeerStatus) onLocalStatusChanged,
-      String remoteKey,
+  void startStatusUpdates(String localKey, Function(PeerStatus) onLocalStatusChanged, String remoteKey,
       Function(PeerStatus) onRemoteStatusChanged) {
     if (_onLocalConnectSubscription != null) {
       final texts = getSystemAppLocalizations();
-      throw Exception(
-          texts.connect_to_pay_error_status_tracking_already_started);
+      throw Exception(texts.connect_to_pay_error_status_tracking_already_started);
     }
     _userStatusPath = FirebaseDatabase.instance.ref().child(localKey);
 
-    _onLocalConnectSubscription = FirebaseDatabase.instance
-        .ref()
-        .child('.info/connected')
-        .onValue
-        .listen((event) {
-      onLocalStatusChanged(PeerStatus(
-          event.snapshot.value, DateTime.now().millisecondsSinceEpoch));
+    _onLocalConnectSubscription =
+        FirebaseDatabase.instance.ref().child('.info/connected').onValue.listen((event) {
+      onLocalStatusChanged(PeerStatus(event.snapshot.value, DateTime.now().millisecondsSinceEpoch));
       if (event.snapshot.value) {
         pushOnline();
       }
     });
 
-    _onRemoteConnectSubscription = FirebaseDatabase.instance
-        .ref()
-        .child(remoteKey)
-        .onValue
-        .listen((event) {
+    _onRemoteConnectSubscription = FirebaseDatabase.instance.ref().child(remoteKey).onValue.listen((event) {
       var connected = (event.snapshot.value as Map)["online"] ?? false;
-      onRemoteStatusChanged(
-          PeerStatus(connected, DateTime.now().millisecondsSinceEpoch));
+      onRemoteStatusChanged(PeerStatus(connected, DateTime.now().millisecondsSinceEpoch));
     });
   }
 
@@ -56,10 +43,8 @@ class OnlineStatusUpdater {
       return Future.value(null);
     }
     _userStatusPath.onDisconnect().remove();
-    return Future.wait([
-      _onRemoteConnectSubscription.cancel(),
-      _onLocalConnectSubscription.cancel()
-    ]).then((_) {
+    return Future.wait([_onRemoteConnectSubscription.cancel(), _onLocalConnectSubscription.cancel()])
+        .then((_) {
       _onLocalConnectSubscription = null;
       _onRemoteConnectSubscription = null;
     });

--- a/lib/bloc/csv_exporter.dart
+++ b/lib/bloc/csv_exporter.dart
@@ -25,8 +25,7 @@ class CsvExporter {
 
   Future export() async {
     _log.info("export payments started");
-    String tmpFilePath =
-        await _saveCsvFile(const ListToCsvConverter().convert(_generateList()));
+    String tmpFilePath = await _saveCsvFile(const ListToCsvConverter().convert(_generateList()));
     _log.info("export payments finished");
     return tmpFilePath;
   }
@@ -108,11 +107,9 @@ class CsvExporter {
 
   String _appendFilterInformation(String filePath) {
     _log.info("add filter information to path started");
-    if (listEquals(
-        filter.paymentType, [PaymentType.SENT, PaymentType.WITHDRAWAL])) {
+    if (listEquals(filter.paymentType, [PaymentType.SENT, PaymentType.WITHDRAWAL])) {
       filePath += "_sent";
-    } else if (listEquals(
-        filter.paymentType, [PaymentType.RECEIVED, PaymentType.DEPOSIT])) {
+    } else if (listEquals(filter.paymentType, [PaymentType.RECEIVED, PaymentType.DEPOSIT])) {
       filePath += "_received";
     }
     if (filter.startDate != null && filter.endDate != null) {

--- a/lib/bloc/fastbitcoins/fastbitcoins_bloc.dart
+++ b/lib/bloc/fastbitcoins/fastbitcoins_bloc.dart
@@ -16,25 +16,17 @@ class FastbitcoinsBloc {
   static const PRODUCTION_URL = "wallet-api.fastbitcoins.com";
   static const TESTING_URL = "wallet-api-test.aao-tech.com";
 
-  final _validateRequestController =
-      StreamController<ValidateRequestModel>.broadcast();
-  Sink<ValidateRequestModel> get validateRequestSink =>
-      _validateRequestController.sink;
+  final _validateRequestController = StreamController<ValidateRequestModel>.broadcast();
+  Sink<ValidateRequestModel> get validateRequestSink => _validateRequestController.sink;
 
-  final _validateResponseController =
-      StreamController<ValidateResponseModel>.broadcast();
-  Stream<ValidateResponseModel> get validateResponseStream =>
-      _validateResponseController.stream;
+  final _validateResponseController = StreamController<ValidateResponseModel>.broadcast();
+  Stream<ValidateResponseModel> get validateResponseStream => _validateResponseController.stream;
 
-  final _redeemRequestController =
-      StreamController<RedeemRequestModel>.broadcast();
-  Sink<RedeemRequestModel> get redeemRequestSink =>
-      _redeemRequestController.sink;
+  final _redeemRequestController = StreamController<RedeemRequestModel>.broadcast();
+  Sink<RedeemRequestModel> get redeemRequestSink => _redeemRequestController.sink;
 
-  final _redeemResponseController =
-      StreamController<RedeemResponseModel>.broadcast();
-  Stream<RedeemResponseModel> get redeemResponseStream =>
-      _redeemResponseController.stream;
+  final _redeemResponseController = StreamController<RedeemResponseModel>.broadcast();
+  Stream<RedeemResponseModel> get redeemResponseStream => _redeemResponseController.stream;
 
   final String baseURL;
   BreezBridge _breezLib;
@@ -59,8 +51,7 @@ class FastbitcoinsBloc {
           body: jsonEncode(request.toJson()),
         );
         _validateResponse(response);
-        ValidateResponseModel res =
-            ValidateResponseModel.fromJson(jsonDecode(response.body));
+        ValidateResponseModel res = ValidateResponseModel.fromJson(jsonDecode(response.body));
         if (res.error == 1 && res.kycRequired != 1) {
           throw res.errorMessage;
         }
@@ -87,8 +78,7 @@ class FastbitcoinsBloc {
           body: jsonEncode(request.toJson()),
         );
         _validateResponse(response);
-        RedeemResponseModel res =
-            RedeemResponseModel.fromJson(jsonDecode(response.body));
+        RedeemResponseModel res = RedeemResponseModel.fromJson(jsonDecode(response.body));
         if (res.error == 1) {
           throw res.errorMessage;
         }

--- a/lib/bloc/fastbitcoins/fastbitcoins_model.dart
+++ b/lib/bloc/fastbitcoins/fastbitcoins_model.dart
@@ -12,8 +12,7 @@ class ValidateRequestModel {
 
   ValidateRequestModel(this.emailAddress, this.code, this.value, this.currency);
 
-  factory ValidateRequestModel.fromJson(Map<String, dynamic> json) =>
-      _$ValidateRequestModelFromJson(json);
+  factory ValidateRequestModel.fromJson(Map<String, dynamic> json) => _$ValidateRequestModelFromJson(json);
   Map<String, dynamic> toJson() => _$ValidateRequestModelToJson(this);
 }
 
@@ -52,8 +51,7 @@ class ValidateResponseModel {
       this.commissionTotal,
       this.bitcoinAmount,
       this.satoshiAmount);
-  factory ValidateResponseModel.fromJson(Map<String, dynamic> json) =>
-      _$ValidateResponseModelFromJson(json);
+  factory ValidateResponseModel.fromJson(Map<String, dynamic> json) => _$ValidateResponseModelFromJson(json);
   Map<String, dynamic> toJson() => _$ValidateResponseModelToJson(this);
 }
 
@@ -74,11 +72,10 @@ class RedeemRequestModel {
   @JsonKey(name: 'lightning_invoice')
   String lightningInvoice;
 
-  RedeemRequestModel(this.emailAddress, this.code, this.value, this.currency,
-      this.quotationId, this.quotationSecret);
+  RedeemRequestModel(
+      this.emailAddress, this.code, this.value, this.currency, this.quotationId, this.quotationSecret);
 
-  factory RedeemRequestModel.fromJson(Map<String, dynamic> json) =>
-      _$RedeemRequestModelFromJson(json);
+  factory RedeemRequestModel.fromJson(Map<String, dynamic> json) => _$RedeemRequestModelFromJson(json);
   Map<String, dynamic> toJson() => _$RedeemRequestModelToJson(this);
 }
 
@@ -91,7 +88,6 @@ class RedeemResponseModel {
 
   RedeemResponseModel(this.error, this.errorMessage);
 
-  factory RedeemResponseModel.fromJson(Map<String, dynamic> json) =>
-      _$RedeemResponseModelFromJson(json);
+  factory RedeemResponseModel.fromJson(Map<String, dynamic> json) => _$RedeemResponseModelFromJson(json);
   Map<String, dynamic> toJson() => _$RedeemResponseModelToJson(this);
 }

--- a/lib/bloc/fastbitcoins/fastbitcoins_model.g.dart
+++ b/lib/bloc/fastbitcoins/fastbitcoins_model.g.dart
@@ -7,24 +7,18 @@ part of 'fastbitcoins_model.dart';
 // **************************************************************************
 
 ValidateRequestModel _$ValidateRequestModelFromJson(Map<String, dynamic> json) {
-  return ValidateRequestModel(
-      json['email_address'] as String,
-      json['code'] as String,
-      (json['value'] as num)?.toDouble(),
-      json['currency'] as String);
+  return ValidateRequestModel(json['email_address'] as String, json['code'] as String,
+      (json['value'] as num)?.toDouble(), json['currency'] as String);
 }
 
-Map<String, dynamic> _$ValidateRequestModelToJson(
-        ValidateRequestModel instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$ValidateRequestModelToJson(ValidateRequestModel instance) => <String, dynamic>{
       'email_address': instance.emailAddress,
       'code': instance.code,
       'value': instance.value,
       'currency': instance.currency
     };
 
-ValidateResponseModel _$ValidateResponseModelFromJson(
-    Map<String, dynamic> json) {
+ValidateResponseModel _$ValidateResponseModelFromJson(Map<String, dynamic> json) {
   return ValidateResponseModel(
       json['error'] as int,
       json['error_message'] as String,
@@ -39,9 +33,7 @@ ValidateResponseModel _$ValidateResponseModelFromJson(
       json['satoshi_amount'] as int);
 }
 
-Map<String, dynamic> _$ValidateResponseModelToJson(
-        ValidateResponseModel instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$ValidateResponseModelToJson(ValidateResponseModel instance) => <String, dynamic>{
       'error': instance.error,
       'error_message': instance.errorMessage,
       'kyc_required': instance.kycRequired,
@@ -66,8 +58,7 @@ RedeemRequestModel _$RedeemRequestModelFromJson(Map<String, dynamic> json) {
     ..lightningInvoice = json['lightning_invoice'] as String;
 }
 
-Map<String, dynamic> _$RedeemRequestModelToJson(RedeemRequestModel instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$RedeemRequestModelToJson(RedeemRequestModel instance) => <String, dynamic>{
       'email_address': instance.emailAddress,
       'code': instance.code,
       'value': instance.value,
@@ -78,13 +69,8 @@ Map<String, dynamic> _$RedeemRequestModelToJson(RedeemRequestModel instance) =>
     };
 
 RedeemResponseModel _$RedeemResponseModelFromJson(Map<String, dynamic> json) {
-  return RedeemResponseModel(
-      json['error'] as int, json['error_message'] as String);
+  return RedeemResponseModel(json['error'] as int, json['error_message'] as String);
 }
 
-Map<String, dynamic> _$RedeemResponseModelToJson(
-        RedeemResponseModel instance) =>
-    <String, dynamic>{
-      'error': instance.error,
-      'error_message': instance.errorMessage
-    };
+Map<String, dynamic> _$RedeemResponseModelToJson(RedeemResponseModel instance) =>
+    <String, dynamic>{'error': instance.error, 'error_message': instance.errorMessage};

--- a/lib/bloc/invoice/invoice_model.dart
+++ b/lib/bloc/invoice/invoice_model.dart
@@ -19,8 +19,7 @@ class PaymentRequestModel {
   final String _paymentHash;
   final Int64 _lspFee;
 
-  PaymentRequestModel(
-      this._invoice, this._rawPayReq, this._paymentHash, this._lspFee);
+  PaymentRequestModel(this._invoice, this._rawPayReq, this._paymentHash, this._lspFee);
 
   String get description => _invoice.description;
   String get payeeImageURL => _invoice.payeeImageURL;

--- a/lib/bloc/lnurl/lnurl_bloc.dart
+++ b/lib/bloc/lnurl/lnurl_bloc.dart
@@ -22,14 +22,12 @@ class LNUrlBloc with AsyncActionsHandler {
 
   StreamController _lnUrlStreamController;
 
-  final StreamController<String> _lnurlInputController =
-      StreamController<String>.broadcast();
+  final StreamController<String> _lnurlInputController = StreamController<String>.broadcast();
   Sink<String> get lnurlInputSink => _lnurlInputController.sink;
 
   final StreamController<NfcWithdrawInvoiceStatus> _nfcWithdrawController =
       StreamController<NfcWithdrawInvoiceStatus>.broadcast();
-  Stream<NfcWithdrawInvoiceStatus> get nfcWithdrawStream =>
-      _nfcWithdrawController.stream;
+  Stream<NfcWithdrawInvoiceStatus> get nfcWithdrawStream => _nfcWithdrawController.stream;
   RegisterNfcSaleRequest _nfcSaleRequest;
 
   LNUrlBloc() {
@@ -67,9 +65,7 @@ class LNUrlBloc with AsyncActionsHandler {
           }
           return result;
         })
-      ])
-          .where((l) => l != null && (isLNURL(l) || isLightningAddress(l)))
-          .asyncMap((l) {
+      ]).where((l) => l != null && (isLNURL(l) || isLightningAddress(l))).asyncMap((l) {
         var v = parseLightningAddress(l);
         v ??= l;
         _lnUrlStreamController.add(FetchLNUrlState.started);
@@ -142,11 +138,8 @@ class LNUrlBloc with AsyncActionsHandler {
   }
 
   Future _openChannel(OpenChannel action) async {
-    var openResult = retry(
-        () => _breezLib.connectDirectToLnurl(
-            action.uri, action.k1, action.callback),
-        tryLimit: 3,
-        interval: const Duration(seconds: 5));
+    var openResult = retry(() => _breezLib.connectDirectToLnurl(action.uri, action.k1, action.callback),
+        tryLimit: 3, interval: const Duration(seconds: 5));
     action.resolve(await openResult);
   }
 
@@ -162,8 +155,7 @@ class LNUrlBloc with AsyncActionsHandler {
     RegisterNfcSaleRequest action,
     WithdrawFetchResponse response,
   ) async {
-    if (response.minAmount > action.amount ||
-        response.maxAmount < action.amount) {
+    if (response.minAmount > action.amount || response.maxAmount < action.amount) {
       _log.info(
           "NFC Payment Request rangeError, requested ${action.amount} but the range is ${response.minAmount} - ${response.maxAmount}");
       _nfcWithdrawController.add(NfcWithdrawInvoiceStatus.rangeError(

--- a/lib/bloc/lnurl/lnurl_bloc.dart
+++ b/lib/bloc/lnurl/lnurl_bloc.dart
@@ -55,16 +55,7 @@ class LNUrlBloc with AsyncActionsHandler {
         injector.nfc.receivedLnLinks(),
         injector.lightningLinks.linksNotifications,
         _lnurlInputController.stream,
-        injector.device.clipboardStream
-            .distinct()
-            .skip(1) // Skip previous session clipboard
-            .where((l) {
-          var result = true;
-          if (isLightningAddress(l)) {
-            result = isLightningAddressURI(l);
-          }
-          return result;
-        })
+        injector.device.clipboardStream.distinct().skip(1) // Skip previous session clipboard
       ]).where((l) => l != null && (isLNURL(l) || isLightningAddress(l))).asyncMap((l) {
         var v = parseLightningAddress(l);
         v ??= l;

--- a/lib/bloc/lnurl/nfc_withdraw_invoice_status.dart
+++ b/lib/bloc/lnurl/nfc_withdraw_invoice_status.dart
@@ -3,17 +3,14 @@ import 'package:fixnum/fixnum.dart';
 abstract class NfcWithdrawInvoiceStatus {
   const NfcWithdrawInvoiceStatus();
 
-  factory NfcWithdrawInvoiceStatus.started() =>
-      const NfcWithdrawInvoiceStatusStarted();
+  factory NfcWithdrawInvoiceStatus.started() => const NfcWithdrawInvoiceStatusStarted();
 
-  factory NfcWithdrawInvoiceStatus.completed() =>
-      const NfcWithdrawInvoiceStatusCompleted();
+  factory NfcWithdrawInvoiceStatus.completed() => const NfcWithdrawInvoiceStatusCompleted();
 
   factory NfcWithdrawInvoiceStatus.rangeError(Int64 min, Int64 max) =>
       NfcWithdrawInvoiceStatusRangeError(min, max);
 
-  factory NfcWithdrawInvoiceStatus.error(String message) =>
-      NfcWithdrawInvoiceStatusError(message);
+  factory NfcWithdrawInvoiceStatus.error(String message) => NfcWithdrawInvoiceStatusError(message);
 }
 
 class NfcWithdrawInvoiceStatusStarted extends NfcWithdrawInvoiceStatus {

--- a/lib/bloc/lsp/lsp_bloc.dart
+++ b/lib/bloc/lsp/lsp_bloc.dart
@@ -17,8 +17,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 final _log = Logger("LSPBloc");
 
 class LSPBloc with AsyncActionsHandler {
-  static const String SELECTED_LSP_PREFERENCES_KEY =
-      "SELECTED_LSP_PREFERENCES_KEY";
+  static const String SELECTED_LSP_PREFERENCES_KEY = "SELECTED_LSP_PREFERENCES_KEY";
 
   final _lspPromptController = StreamController<bool>.broadcast();
   Stream<bool> get lspPromptStream => _lspPromptController.stream;
@@ -47,8 +46,7 @@ class LSPBloc with AsyncActionsHandler {
     ServiceInjector().sharedPreferences.then((sp) async {
       // initial status
       var selectedLSP = sp.getString(SELECTED_LSP_PREFERENCES_KEY);
-      _lspsStatusController
-          .add(LSPStatus.initial().copyWith(selectedLSP: selectedLSP));
+      _lspsStatusController.add(LSPStatus.initial().copyWith(selectedLSP: selectedLSP));
       _breezLib.setSelectedLspID(selectedLSP);
       _listenReconnects();
       _handleAccountChangs(sp);
@@ -61,22 +59,19 @@ class LSPBloc with AsyncActionsHandler {
     try {
       action.resolve(await _ensureLSPSFetched());
     } catch (err) {
-      _lspsStatusController.add(_lspsStatusController.value
-          .copyWith(lastConnectionError: err.toString()));
+      _lspsStatusController.add(_lspsStatusController.value.copyWith(lastConnectionError: err.toString()));
       rethrow;
     }
   }
 
   Future _connectLSP(ConnectLSP action) async {
-    if (_lspsStatusController.value.availableLSPs
-        .where((element) => element.lspID == action.lspID)
-        .isEmpty) {
+    if (_lspsStatusController.value.availableLSPs.where((element) => element.lspID == action.lspID).isEmpty) {
       final texts = getSystemAppLocalizations();
       throw Exception(texts.lsp_error_provider_do_not_exists);
     }
     String selectedLSP = action.lspID;
-    _lspsStatusController.add(_lspsStatusController.value
-        .copyWith(selectedLSP: selectedLSP, lastConnectionError: null));
+    _lspsStatusController
+        .add(_lspsStatusController.value.copyWith(selectedLSP: selectedLSP, lastConnectionError: null));
     _breezLib.setSelectedLspID(selectedLSP);
     await accountStream.where((a) => a.synced).first;
 
@@ -89,8 +84,7 @@ class LSPBloc with AsyncActionsHandler {
       }, tryLimit: 3, interval: const Duration(seconds: 2));
     } catch (err) {
       _log.info("Failed to connect to LSP: $err");
-      _lspsStatusController.add(_lspsStatusController.value
-          .copyWith(lastConnectionError: err.toString()));
+      _lspsStatusController.add(_lspsStatusController.value.copyWith(lastConnectionError: err.toString()));
       rethrow;
     }
   }
@@ -98,10 +92,8 @@ class LSPBloc with AsyncActionsHandler {
   void _handleAccountChangs(SharedPreferences sp) {
     bool breezReady = false;
     _breezLib.notificationStream.listen((event) async {
-      breezReady =
-          breezReady || event.type == NotificationEvent_NotificationType.READY;
-      if (breezReady &&
-          event.type == NotificationEvent_NotificationType.ACCOUNT_CHANGED) {
+      breezReady = breezReady || event.type == NotificationEvent_NotificationType.READY;
+      if (breezReady && event.type == NotificationEvent_NotificationType.ACCOUNT_CHANGED) {
         await _ensureLSPSFetched();
         if (await _selectedLSP == null) {
           var availableLSPs = _lspsStatusController.value.availableLSPs;
@@ -126,9 +118,7 @@ class LSPBloc with AsyncActionsHandler {
   }
 
   void _listenLifecycleEvents() {
-    _device.eventStream
-        .where((e) => e == NotificationType.RESUME)
-        .listen((e) async {
+    _device.eventStream.where((e) => e == NotificationType.RESUME).listen((e) async {
       _log.info("App Resumed - flutter resume called, refreshing LSPs");
       await _ensureLSPSFetched();
     });
@@ -136,9 +126,7 @@ class LSPBloc with AsyncActionsHandler {
 
   void _listenReconnects() {
     Future connectingFuture = Future.value(null);
-    _reconnectStreamController.stream
-        .debounceTime(const Duration(milliseconds: 500))
-        .listen((_) async {
+    _reconnectStreamController.stream.debounceTime(const Duration(milliseconds: 500)).listen((_) async {
       connectingFuture.whenComplete(() {
         connectingFuture = _ensureLSPConnected();
       });
@@ -148,9 +136,8 @@ class LSPBloc with AsyncActionsHandler {
   Future<LSPInfo> get _selectedLSP async {
     var sp = await ServiceInjector().sharedPreferences;
     var selectedLSP = sp.getString(SELECTED_LSP_PREFERENCES_KEY);
-    var lsp = _lspsStatusController.value.availableLSPs.firstWhere(
-        (element) => element.lspID == selectedLSP,
-        orElse: () => null);
+    var lsp = _lspsStatusController.value.availableLSPs
+        .firstWhere((element) => element.lspID == selectedLSP, orElse: () => null);
     return lsp;
   }
 

--- a/lib/bloc/lsp/lsp_model.dart
+++ b/lib/bloc/lsp/lsp_model.dart
@@ -50,13 +50,13 @@ class LSPInfo {
   int get timeLockDelta => _lspInformation.timeLockDelta;
   int get baseFeeMsat => _lspInformation.baseFeeMsat.toInt();
   int get channelCapacity => _lspInformation.channelCapacity.toInt();
+  // ignore: deprecated_member_use_from_same_package
   int get channelFeePermyriad => _lspInformation.channelFeePermyriad.toInt();
+  // ignore: deprecated_member_use_from_same_package
   int get maxInactiveDuration => _lspInformation.maxInactiveDuration.toInt();
-  int get channelMinimumFeeMsat =>
-      _lspInformation.channelMinimumFeeMsat.toInt();
-  OpeningFeeParams get cheapestOpeningFeeParams =>
-      _lspInformation.cheapestOpeningFeeParams;
-  OpeningFeeParams get longestValidOpeningFeeParams =>
-      _lspInformation.longestValidOpeningFeeParams;
+  // ignore: deprecated_member_use_from_same_package
+  int get channelMinimumFeeMsat => _lspInformation.channelMinimumFeeMsat.toInt();
+  OpeningFeeParams get cheapestOpeningFeeParams => _lspInformation.cheapestOpeningFeeParams;
+  OpeningFeeParams get longestValidOpeningFeeParams => _lspInformation.longestValidOpeningFeeParams;
   LSPInformation get raw => _lspInformation;
 }

--- a/lib/bloc/marketplace/marketplace_bloc.dart
+++ b/lib/bloc/marketplace/marketplace_bloc.dart
@@ -15,10 +15,8 @@ class MarketplaceBloc {
   bool _isSnortToggled;
 
   final _nostrSettingsController = BehaviorSubject<NostrSettings>();
-  Stream<NostrSettings> get nostrSettingsStream =>
-      _nostrSettingsController.stream;
-  Sink<NostrSettings> get nostrSettingsSettingsSink =>
-      _nostrSettingsController.sink;
+  Stream<NostrSettings> get nostrSettingsStream => _nostrSettingsController.stream;
+  Sink<NostrSettings> get nostrSettingsSettingsSink => _nostrSettingsController.sink;
 
   MarketplaceBloc() {
     loadVendors();
@@ -35,8 +33,7 @@ class MarketplaceBloc {
     SharedPreferences pref = await SharedPreferences.getInstance();
     nostrSettingsStream.listen((settings) async {
       _isSnortToggled = settings.showSnort;
-      pref.setString(NostrSettings.NOSTR_SETTINGS_PREFERENCES_KEY,
-          json.encode(settings.toJson()));
+      pref.setString(NostrSettings.NOSTR_SETTINGS_PREFERENCES_KEY, json.encode(settings.toJson()));
       await loadVendors();
     });
   }

--- a/lib/bloc/marketplace/nostr_settings.dart
+++ b/lib/bloc/marketplace/nostr_settings.dart
@@ -1,14 +1,9 @@
-
-
 class NostrSettings {
   final bool showSnort;
   final bool isRememberPubKey;
   final bool isRememberSignEvent;
 
-  NostrSettings(
-      {this.showSnort = true,
-      this.isRememberPubKey = false,
-      this.isRememberSignEvent = false});
+  NostrSettings({this.showSnort = true, this.isRememberPubKey = false, this.isRememberSignEvent = false});
 
   static const String NOSTR_SETTINGS_PREFERENCES_KEY = "nostr_settings";
 
@@ -19,8 +14,7 @@ class NostrSettings {
           isRememberSignEvent: false,
         );
 
-  NostrSettings copyWith(
-      {bool showSnort, bool isRememberPubKey, bool isRememberSignEvent}) {
+  NostrSettings copyWith({bool showSnort, bool isRememberPubKey, bool isRememberSignEvent}) {
     return NostrSettings(
       showSnort: showSnort ?? this.showSnort,
       isRememberPubKey: isRememberPubKey ?? this.isRememberPubKey,

--- a/lib/bloc/marketplace/vendor_model.dart
+++ b/lib/bloc/marketplace/vendor_model.dart
@@ -4,8 +4,7 @@ import 'dart:core';
 List<VendorModel> vendorListFromJson(String str) {
   List<VendorModel> vendorList = [];
   Map.from(json.decode(str))
-      .map((k, v) =>
-          MapEntry<String, VendorModel>(k, VendorModel.fromJson(k, v)))
+      .map((k, v) => MapEntry<String, VendorModel>(k, VendorModel.fromJson(k, v)))
       .forEach((k, v) => vendorList.add(v));
   return vendorList;
 }
@@ -36,8 +35,7 @@ class VendorModel {
           json["displayName"] ?? id,
           endpointURI: json["endpointURI"],
           onlyShowLogo: json["onlyShowLogo"] ?? true,
-          responseID: json["endpointURI"] != null && json["responseID"] != null
-              ? json["responseID"]
-              : "lnurl_auth",
+          responseID:
+              json["endpointURI"] != null && json["responseID"] != null ? json["responseID"] : "lnurl_auth",
         );
 }

--- a/lib/bloc/nostr/nostr_bloc.dart
+++ b/lib/bloc/nostr/nostr_bloc.dart
@@ -39,8 +39,7 @@ class NostrBloc with AsyncActionsHandler {
     nostrPrivateKey = await _secureStorage.read(key: "nostrPrivateKey");
   }
 
-  final StreamController<String> _publicKeyController =
-      StreamController<String>.broadcast();
+  final StreamController<String> _publicKeyController = StreamController<String>.broadcast();
   Stream<String> get publicKeyStream => _publicKeyController.stream;
 
   final StreamController<Map<String, dynamic>> _eventController =
@@ -57,8 +56,7 @@ class NostrBloc with AsyncActionsHandler {
 
   Future<void> _handleSignEvent(SignEvent action) async {
     //  to sign the event
-    Map<String, dynamic> signedEvent =
-        await _signEvent(action.eventObject, action.privateKey);
+    Map<String, dynamic> signedEvent = await _signEvent(action.eventObject, action.privateKey);
 
     _eventController.add(signedEvent);
     action.resolve(signedEvent);
@@ -79,8 +77,7 @@ class NostrBloc with AsyncActionsHandler {
 
   Future<void> _handleNip04Decrypt(Nip04Decrypt action) async {
     // to decrypt the data
-    String decryptedData =
-        await _decryptData(action.encryptedData, action.privateKey);
+    String decryptedData = await _decryptData(action.encryptedData, action.privateKey);
     action.resolve(decryptedData);
   }
 
@@ -100,16 +97,14 @@ class NostrBloc with AsyncActionsHandler {
       nostrPublicKey = nostrKeyPair.substring(index + 1);
 
       // Write value
-      await _secureStorage.write(
-          key: 'nostrPrivateKey', value: nostrPrivateKey);
+      await _secureStorage.write(key: 'nostrPrivateKey', value: nostrPrivateKey);
       await _secureStorage.write(key: 'nostrPublicKey', value: nostrPublicKey);
     }
 
     return nostrPublicKey;
   }
 
-  Future<Map<String, dynamic>> _signEvent(
-      Map<String, dynamic> eventObject, String nostrPrivateKey) async {
+  Future<Map<String, dynamic>> _signEvent(Map<String, dynamic> eventObject, String nostrPrivateKey) async {
     final eventApi = EventApi();
 
     if (eventObject['pubkey'] == null) {
@@ -117,8 +112,7 @@ class NostrBloc with AsyncActionsHandler {
     }
 
     List<dynamic> dynamicList = eventObject['tags'];
-    List<List<String>> stringList =
-        dynamicList.map((innerList) => List<String>.from(innerList)).toList();
+    List<List<String>> stringList = dynamicList.map((innerList) => List<String>.from(innerList)).toList();
 
     final event = Event(
       content: eventObject['content'],

--- a/lib/bloc/nostr/nostr_model.dart
+++ b/lib/bloc/nostr/nostr_model.dart
@@ -4,7 +4,7 @@ class Event {
   String pubKey;
   String content;
   List<List<String>> tags;
-  int created_at;
+  int createdAt;
   String sig;
 
   Event({
@@ -13,7 +13,7 @@ class Event {
     this.pubKey,
     this.content,
     this.tags,
-    this.created_at,
+    this.createdAt,
     this.sig,
   });
 }

--- a/lib/bloc/payment_options/payment_options_bloc.dart
+++ b/lib/bloc/payment_options/payment_options_bloc.dart
@@ -19,16 +19,13 @@ class PaymentOptionsBloc with AsyncActionsHandler {
 
   final _paymentOptionsFeeEnabledStreamController = BehaviorSubject<bool>();
 
-  Stream<bool> get paymentOptionsFeeEnabledStream =>
-      _paymentOptionsFeeEnabledStreamController.stream;
+  Stream<bool> get paymentOptionsFeeEnabledStream => _paymentOptionsFeeEnabledStreamController.stream;
 
   final _paymentOptionsBaseFeeStreamController = BehaviorSubject<int>();
 
-  Stream<int> get paymentOptionsBaseFeeStream =>
-      _paymentOptionsBaseFeeStreamController.stream;
+  Stream<int> get paymentOptionsBaseFeeStream => _paymentOptionsBaseFeeStreamController.stream;
 
-  final _paymentOptionsProportionalFeeStreamController =
-      BehaviorSubject<double>();
+  final _paymentOptionsProportionalFeeStreamController = BehaviorSubject<double>();
 
   Stream<double> get paymentOptionsProportionalFeeStream =>
       _paymentOptionsProportionalFeeStreamController.stream;
@@ -145,8 +142,7 @@ class PaymentOptionsBloc with AsyncActionsHandler {
     }
   }
 
-  void _listenRestoreRequests(
-      Stream<Map<String, dynamic>> restoreLightningFeesStream) {
+  void _listenRestoreRequests(Stream<Map<String, dynamic>> restoreLightningFeesStream) {
     restoreLightningFeesStream.listen((lightningFeesPreferences) {
       _restoreLightningFees(lightningFeesPreferences);
     });
@@ -160,8 +156,7 @@ class PaymentOptionsBloc with AsyncActionsHandler {
       UpdatePaymentBaseFee(lightningFeesPreferences[_kPaymentOptionBaseFee]),
     );
     _updatePaymentOptionsProportionalFee(
-      UpdatePaymentProportionalFee(
-          lightningFeesPreferences[_kPaymentOptionProportionalFee]),
+      UpdatePaymentProportionalFee(lightningFeesPreferences[_kPaymentOptionProportionalFee]),
     );
   }
 }

--- a/lib/bloc/podcast_clip/podcast_clip_bloc.dart
+++ b/lib/bloc/podcast_clip/podcast_clip_bloc.dart
@@ -20,18 +20,15 @@ const int _initialSeconds = 10;
 const int _maxClipDuration = 120;
 
 class PodcastClipBloc with AsyncActionsHandler {
-  final BehaviorSubject<PodcastClipDetailsModel> _clipDetailsBehaviourSubject =
-      BehaviorSubject();
+  final BehaviorSubject<PodcastClipDetailsModel> _clipDetailsBehaviourSubject = BehaviorSubject();
 
-  Stream<PodcastClipDetailsModel> get clipDetails =>
-      _clipDetailsBehaviourSubject.stream;
+  Stream<PodcastClipDetailsModel> get clipDetails => _clipDetailsBehaviourSubject.stream;
 
 //Used as a flag to disable sharing since ongoing ffmpeg commands can't be terminated.
   bool enableClipSharing = false;
 
   setPodcastClipDetails({PositionState position}) {
-    Duration endTime =
-        position.position + const Duration(seconds: _initialSeconds);
+    Duration endTime = position.position + const Duration(seconds: _initialSeconds);
 
     PodcastClipDetailsModel podcastClipDetails = PodcastClipDetailsModel(
         startTimeStamp: position.position,
@@ -58,21 +55,18 @@ class PodcastClipBloc with AsyncActionsHandler {
     var clipDetails = getCurrentPodcastClipDetails();
 
     // Check if the duration exceeds the episode length
-    if ((clipDetails.startTimeStamp + Duration(seconds: durationInSeconds)) >
-        clipDetails.episodeLength) {
+    if ((clipDetails.startTimeStamp + Duration(seconds: durationInSeconds)) > clipDetails.episodeLength) {
       return;
     }
     //Return if the incremented duration is >=  _maxClipDuration or if the decremented duration is less <=0
-    if ((_maxClipDuration + _initialSeconds - durationInSeconds <= 0) ||
-        (durationInSeconds <= 0)) {
+    if ((_maxClipDuration + _initialSeconds - durationInSeconds <= 0) || (durationInSeconds <= 0)) {
       return;
     }
 
-    Duration clipEndTime =
-        clipDetails.startTimeStamp + Duration(seconds: durationInSeconds);
+    Duration clipEndTime = clipDetails.startTimeStamp + Duration(seconds: durationInSeconds);
 
-    _clipDetailsBehaviourSubject.add(clipDetails.copy(
-        clipDuration: durationInSeconds, endTimeStamp: clipEndTime));
+    _clipDetailsBehaviourSubject
+        .add(clipDetails.copy(clipDuration: durationInSeconds, endTimeStamp: clipEndTime));
   }
 
   incrementDuration() async {
@@ -81,8 +75,7 @@ class PodcastClipBloc with AsyncActionsHandler {
     int incrementedClipDuration = 0;
 
     if (currentClipDuration % 10 != 0) {
-      incrementedClipDuration =
-          currentClipDuration - currentClipDuration % 10 + _initialSeconds;
+      incrementedClipDuration = currentClipDuration - currentClipDuration % 10 + _initialSeconds;
     } else {
       incrementedClipDuration = currentClipDuration + _initialSeconds;
     }
@@ -116,8 +109,7 @@ class PodcastClipBloc with AsyncActionsHandler {
     String clippedAudioCommand =
         '-i "$episodeUrl" -ss ${clipDetails.startTimeStamp.inSeconds} -to ${clipDetails.endTimeStamp.inSeconds}  -acodec copy $audioClipPath';
 
-    FFmpegSession ffpegSessionDetails =
-        await FFmpegKit.execute(clippedAudioCommand);
+    FFmpegSession ffpegSessionDetails = await FFmpegKit.execute(clippedAudioCommand);
 
     final returnCode = await ffpegSessionDetails.getReturnCode();
 
@@ -148,22 +140,17 @@ class PodcastClipBloc with AsyncActionsHandler {
     // https://ffmpeg.org/ffmpeg-filters.html#showwaves
     const showWaveColor = "colors=0xffffff@0.5";
     const mode = "mode=cline";
-    final size =
-        "size=${_forceEven((width * 0.8).toInt())}x${_forceEven((height * 0.3).toInt())}";
+    final size = "size=${_forceEven((width * 0.8).toInt())}x${_forceEven((height * 0.3).toInt())}";
     const scale = "scale=lin";
-    final scaleValue =
-        "[1:v]scale=${_forceEven(width)}:${_forceEven(height)}[bg]";
+    final scaleValue = "[1:v]scale=${_forceEven(width)}:${_forceEven(height)}[bg]";
     const format = "format=yuva420p[v]";
-    final overlay =
-        "[bg][v]overlay=(main_w-overlay_w)/2:${_forceEven((height * 0.7).toInt())}[outv]";
-    final filterComplex =
-        "[0:a]showwaves=$showWaveColor:$mode:$size:$scale,$format;$scaleValue;$overlay";
+    final overlay = "[bg][v]overlay=(main_w-overlay_w)/2:${_forceEven((height * 0.7).toInt())}[outv]";
+    final filterComplex = "[0:a]showwaves=$showWaveColor:$mode:$size:$scale,$format;$scaleValue;$overlay";
     final clippedVideoCommand =
         '-i  $audioClipPath -i $episodeImagePath -filter_complex $filterComplex -map "[outv]" -map 0:a -c:v libx264 -c:a copy $videoClipPath';
     _log.info("ffmpeg command: $clippedVideoCommand");
 
-    FFmpegSession ffpegSessionDetails =
-        await FFmpegKit.execute(clippedVideoCommand);
+    FFmpegSession ffpegSessionDetails = await FFmpegKit.execute(clippedVideoCommand);
 
     final returnCode = await ffpegSessionDetails.getReturnCode();
     if (ReturnCode.isSuccess(returnCode)) {
@@ -179,8 +166,7 @@ class PodcastClipBloc with AsyncActionsHandler {
     var clipDetails = getCurrentPodcastClipDetails();
 
     // Check if there is time to create a clip of minimum 10 secs
-    if ((clipDetails.endTimeStamp + const Duration(seconds: _initialSeconds)) >
-        clipDetails.episodeLength) {
+    if ((clipDetails.endTimeStamp + const Duration(seconds: _initialSeconds)) > clipDetails.episodeLength) {
       return false;
     }
     return true;
@@ -199,16 +185,15 @@ class PodcastClipBloc with AsyncActionsHandler {
 
       String podcastImageWidgetPath = imageFile.path;
 
-      _clipDetailsBehaviourSubject.add(clipDetails.copy(
-          podcastClipState: PodcastClipState.FETCHING_AUDIO_CLIP));
+      _clipDetailsBehaviourSubject
+          .add(clipDetails.copy(podcastClipState: PodcastClipState.FETCHING_AUDIO_CLIP));
       if (!enableClipSharing) {
         return;
       }
 
       String audioClipPath = await _getAudioClipPath(clipDetails: clipDetails);
 
-      _clipDetailsBehaviourSubject.add(
-          clipDetails.copy(podcastClipState: PodcastClipState.GENERATING_CLIP));
+      _clipDetailsBehaviourSubject.add(clipDetails.copy(podcastClipState: PodcastClipState.GENERATING_CLIP));
       if (!enableClipSharing) {
         return;
       }
@@ -229,15 +214,13 @@ class PodcastClipBloc with AsyncActionsHandler {
       _log.warning(e);
       throw "Failed to clip the episode. More details: ${e.toString()}";
     } finally {
-      _clipDetailsBehaviourSubject
-          .add(clipDetails.copy(podcastClipState: PodcastClipState.IDLE));
+      _clipDetailsBehaviourSubject.add(clipDetails.copy(podcastClipState: PodcastClipState.IDLE));
     }
   }
 
   setPodcastState(PodcastClipState clipState) {
     var clipDetails = getCurrentPodcastClipDetails();
-    _clipDetailsBehaviourSubject
-        .add(clipDetails.copy(podcastClipState: clipState));
+    _clipDetailsBehaviourSubject.add(clipDetails.copy(podcastClipState: clipState));
   }
 
   Future<String> initClipDirectory({
@@ -257,8 +240,7 @@ class PodcastClipBloc with AsyncActionsHandler {
       return null;
     }
 
-    var x = await Directory(tempDirectory.path + tempClipPath)
-        .create(recursive: true);
+    var x = await Directory(tempDirectory.path + tempClipPath).create(recursive: true);
 
     finalPath = x.path;
     return finalPath;

--- a/lib/bloc/podcast_clip/podcast_clip_details_model.dart
+++ b/lib/bloc/podcast_clip/podcast_clip_details_model.dart
@@ -29,9 +29,4 @@ class PodcastClipDetailsModel {
           podcastClipState: podcastClipState ?? this.podcastClipState);
 }
 
-enum PodcastClipState {
-  IDLE,
-  FETCHING_IMAGE,
-  FETCHING_AUDIO_CLIP,
-  GENERATING_CLIP
-}
+enum PodcastClipState { IDLE, FETCHING_IMAGE, FETCHING_AUDIO_CLIP, GENERATING_CLIP }

--- a/lib/bloc/podcast_history/podcast_history_bloc.dart
+++ b/lib/bloc/podcast_history/podcast_history_bloc.dart
@@ -6,28 +6,21 @@ import 'package:breez/bloc/podcast_history/sqflite/podcast_history_local_model.d
 import 'package:rxdart/rxdart.dart';
 
 class PodcastHistoryBloc with AsyncActionsHandler {
-  final BehaviorSubject<PodcastHistoryTimeRange> _podcastHistoryRange =
-      BehaviorSubject();
+  final BehaviorSubject<PodcastHistoryTimeRange> _podcastHistoryRange = BehaviorSubject();
 
-  Stream<PodcastHistoryTimeRange> get posReportRange =>
-      _podcastHistoryRange.stream;
+  Stream<PodcastHistoryTimeRange> get posReportRange => _podcastHistoryRange.stream;
 
   final BehaviorSubject<bool> _showShareButton = BehaviorSubject();
 
   Stream<bool> get showShareButton => _showShareButton.stream;
 
-  final BehaviorSubject<PodcastHistoryRecord>
-      _podcastHistoryRecordBehaviourSubject = BehaviorSubject();
+  final BehaviorSubject<PodcastHistoryRecord> _podcastHistoryRecordBehaviourSubject = BehaviorSubject();
 
-  Stream<PodcastHistoryRecord> get podcastHistoryRecord =>
-      _podcastHistoryRecordBehaviourSubject.stream;
+  Stream<PodcastHistoryRecord> get podcastHistoryRecord => _podcastHistoryRecordBehaviourSubject.stream;
 
   //A buffer model comes in use while sorting
   PodcastHistoryRecord _podcastHistoryRecordBuffer = PodcastHistoryRecord(
-      totalBoostagramSentSum: 0,
-      totalDurationInMinsSum: 0,
-      totalSatsStreamedSum: 0,
-      podcastHistoryList: []);
+      totalBoostagramSentSum: 0, totalDurationInMinsSum: 0, totalSatsStreamedSum: 0, podcastHistoryList: []);
 
   PodcastHistoryBloc() {
     registerAsyncHandlers({
@@ -39,8 +32,7 @@ class PodcastHistoryBloc with AsyncActionsHandler {
   }
 
   void _loadSelectedReportTimeRange() async {
-    PodcastHistoryTimeRange timeRange =
-        await getPodcastHistoryTimeRageFromLocalDb();
+    PodcastHistoryTimeRange timeRange = await getPodcastHistoryTimeRageFromLocalDb();
 
     _podcastHistoryRange.add(timeRange);
   }
@@ -52,17 +44,15 @@ class PodcastHistoryBloc with AsyncActionsHandler {
   Future<PodcastHistoryTimeRange> getPodcastHistoryTimeRageFromLocalDb() async {
     PodcastHistoryTimeRange timeRange;
 
-    var localTimeRange =
-        await PodcastHistoryDatabase.instance.fetchPodcastHistoryTimeRange();
+    var localTimeRange = await PodcastHistoryDatabase.instance.fetchPodcastHistoryTimeRange();
 
     //If localTimeRange is null by default monthly range is set
     if (localTimeRange == null) {
       timeRange = PodcastHistoryTimeRange.monthly();
-      await PodcastHistoryDatabase.instance
-          .updatePodcastHistoryTimeRange(timeRange.timeRangeKey);
+      await PodcastHistoryDatabase.instance.updatePodcastHistoryTimeRange(timeRange.timeRangeKey);
     } else {
-      timeRange = PodcastHistoryTimeRange.getTimeRange(
-          timeRangeKey: localTimeRange.podcastHistoryTimeRangeKey);
+      timeRange =
+          PodcastHistoryTimeRange.getTimeRange(timeRangeKey: localTimeRange.podcastHistoryTimeRangeKey);
     }
 
     return timeRange;
@@ -71,10 +61,8 @@ class PodcastHistoryBloc with AsyncActionsHandler {
   Future _updatePodcastHistoryTimeRange(
     UpdatePodcastHistoryTimeRange action,
   ) async {
-    await fetchPodcastHistory(
-        startDate: action.range.startDate, endDate: action.range.endDate);
-    PodcastHistoryDatabase.instance
-        .updatePodcastHistoryTimeRange(action.range.timeRangeKey);
+    await fetchPodcastHistory(startDate: action.range.startDate, endDate: action.range.endDate);
+    PodcastHistoryDatabase.instance.updatePodcastHistoryTimeRange(action.range.timeRangeKey);
 
     _podcastHistoryRange.add(action.range);
   }
@@ -119,28 +107,22 @@ class PodcastHistoryBloc with AsyncActionsHandler {
   }
 
   _sortList(PodcastHistorySortEnum sortOption) {
-    List<PodcastHistoryModel> processedList = [
-      ..._podcastHistoryRecordBuffer.podcastHistoryList
-    ];
+    List<PodcastHistoryModel> processedList = [..._podcastHistoryRecordBuffer.podcastHistoryList];
 
     if (sortOption == PodcastHistorySortEnum.SORT_DURATION_DESCENDING) {
-      processedList
-          .sort((a, b) => b.durationInMins.compareTo(a.durationInMins));
+      processedList.sort((a, b) => b.durationInMins.compareTo(a.durationInMins));
     } else if (sortOption == PodcastHistorySortEnum.SORT_RECENTLY_HEARD) {
       processedList.sort((a, b) => b.timeStamp.compareTo(a.timeStamp));
     } else if (sortOption == PodcastHistorySortEnum.SORT_SATS_DESCENDING) {
       processedList.sort((a, b) => b.satsSpent.compareTo(a.satsSpent));
     } else if (sortOption == PodcastHistorySortEnum.SORT_BOOSTS_DESCENDING) {
-      processedList
-          .sort((a, b) => b.boostagramsSent.compareTo(a.boostagramsSent));
+      processedList.sort((a, b) => b.boostagramsSent.compareTo(a.boostagramsSent));
     }
 
     _podcastHistoryRecordBehaviourSubject.add(PodcastHistoryRecord(
-        totalBoostagramSentSum:
-            _podcastHistoryRecordBuffer.totalBoostagramSentSum,
+        totalBoostagramSentSum: _podcastHistoryRecordBuffer.totalBoostagramSentSum,
         totalSatsStreamedSum: _podcastHistoryRecordBuffer.totalSatsStreamedSum,
-        totalDurationInMinsSum:
-            _podcastHistoryRecordBuffer.totalDurationInMinsSum,
+        totalDurationInMinsSum: _podcastHistoryRecordBuffer.totalDurationInMinsSum,
         podcastHistoryList: processedList));
   }
 

--- a/lib/bloc/podcast_history/sqflite/podcast_history_database.dart
+++ b/lib/bloc/podcast_history/sqflite/podcast_history_database.dart
@@ -48,8 +48,7 @@ ${PodcastHistoryFields.durationInMins} 'DECIMAL NOT NULL'
  ''');
   }
 
-  Future<PodcastHistoryModel> addToPodcastHistoryRecord(
-      PodcastHistoryModel podcastHistory) async {
+  Future<PodcastHistoryModel> addToPodcastHistoryRecord(PodcastHistoryModel podcastHistory) async {
     final db = await instance.database;
     final id = await db.insert(podcastHistoryTable, podcastHistory.toJson());
     return podcastHistory.copy(fieldId: id);
@@ -58,20 +57,16 @@ ${PodcastHistoryFields.durationInMins} 'DECIMAL NOT NULL'
   updatePodcastHistoryTimeRange(String podcastHistoryTimeRangeKey) async {
     final db = await instance.database;
 
-    List<Map<String, Object>> localTimeRangeData =
-        await db.query(podcastHistoryTimeRangeTable);
+    List<Map<String, Object>> localTimeRangeData = await db.query(podcastHistoryTimeRangeTable);
 
     PodcastHistoryTimeRangeDbModel podcastHistoryTimeRangeDbModel =
-        PodcastHistoryTimeRangeDbModel(
-            fieldId: 1, podcastHistoryTimeRangeKey: podcastHistoryTimeRangeKey);
+        PodcastHistoryTimeRangeDbModel(fieldId: 1, podcastHistoryTimeRangeKey: podcastHistoryTimeRangeKey);
 
 //If the data in sqflite is empty we insert else update
     if (localTimeRangeData.isEmpty) {
-      await db.insert(podcastHistoryTimeRangeTable,
-          podcastHistoryTimeRangeDbModel.toJson());
+      await db.insert(podcastHistoryTimeRangeTable, podcastHistoryTimeRangeDbModel.toJson());
     } else {
-      await db.update(
-          podcastHistoryTimeRangeTable, podcastHistoryTimeRangeDbModel.toJson(),
+      await db.update(podcastHistoryTimeRangeTable, podcastHistoryTimeRangeDbModel.toJson(),
           where: '${PodcastHistoryTimeRangeFields.fieldId} = ?',
           whereArgs: [podcastHistoryTimeRangeDbModel.fieldId]);
     }

--- a/lib/bloc/podcast_history/sqflite/podcast_history_local_model.dart
+++ b/lib/bloc/podcast_history/sqflite/podcast_history_local_model.dart
@@ -11,19 +11,16 @@ class PodcastHistoryTimeRangeDbModel {
   final int fieldId;
   final String podcastHistoryTimeRangeKey;
 
-  PodcastHistoryTimeRangeDbModel(
-      {this.fieldId, this.podcastHistoryTimeRangeKey});
+  PodcastHistoryTimeRangeDbModel({this.fieldId, this.podcastHistoryTimeRangeKey});
 
   Map<String, Object> toJson() => {
         PodcastHistoryTimeRangeFields.fieldId: fieldId,
         PodcastHistoryTimeRangeFields.timeRangeKey: podcastHistoryTimeRangeKey,
       };
 
-  static PodcastHistoryTimeRangeDbModel fromJson(Map<String, Object> json) =>
-      PodcastHistoryTimeRangeDbModel(
-          fieldId: json[PodcastHistoryTimeRangeFields.fieldId] as int,
-          podcastHistoryTimeRangeKey:
-              json[PodcastHistoryTimeRangeFields.timeRangeKey] as String);
+  static PodcastHistoryTimeRangeDbModel fromJson(Map<String, Object> json) => PodcastHistoryTimeRangeDbModel(
+      fieldId: json[PodcastHistoryTimeRangeFields.fieldId] as int,
+      podcastHistoryTimeRangeKey: json[PodcastHistoryTimeRangeFields.timeRangeKey] as String);
 }
 
 class PodcastHistoryFields {
@@ -84,8 +81,7 @@ class PodcastHistoryModel {
         PodcastHistoryFields.podcastUrl: podcastUrl,
       };
 
-  static PodcastHistoryModel fromJson(Map<String, Object> json) =>
-      PodcastHistoryModel(
+  static PodcastHistoryModel fromJson(Map<String, Object> json) => PodcastHistoryModel(
         fieldId: json[PodcastHistoryFields.fieldId] as int,
         podcastId: json[PodcastHistoryFields.podcastId] as String,
         timeStamp: json[PodcastHistoryFields.timeStamp] != null

--- a/lib/bloc/podcast_payments/aggregated_payments.dart
+++ b/lib/bloc/podcast_payments/aggregated_payments.dart
@@ -12,8 +12,7 @@ class AggregatedPayments {
   SharedPreferences sharedPreferences;
 
   AggregatedPayments(this.sharedPreferences) {
-    var persistedAggregation =
-        sharedPreferences.getString(AGGREGATED_PAYMENTS_KEY);
+    var persistedAggregation = sharedPreferences.getString(AGGREGATED_PAYMENTS_KEY);
     if (persistedAggregation != null) {
       try {
         Map<String, dynamic> amounts = json.decode(persistedAggregation);
@@ -26,10 +25,8 @@ class AggregatedPayments {
   }
 
   Future<double> addAmount(String destination, double amount) async {
-    aggregatedAmount[destination] =
-        (aggregatedAmount[destination] ?? 0) + amount;
-    await sharedPreferences.setString(
-        AGGREGATED_PAYMENTS_KEY, json.encode(aggregatedAmount));
+    aggregatedAmount[destination] = (aggregatedAmount[destination] ?? 0) + amount;
+    await sharedPreferences.setString(AGGREGATED_PAYMENTS_KEY, json.encode(aggregatedAmount));
     return aggregatedAmount[destination];
   }
 

--- a/lib/bloc/podcast_payments/payment_options.dart
+++ b/lib/bloc/podcast_payments/payment_options.dart
@@ -11,8 +11,7 @@ class PaymentOptions {
     this.customSatsPerMinValue,
   });
 
-  PaymentOptions.initial()
-      : this._(preferredBoostValue: 5000, preferredSatsPerMinValue: 0);
+  PaymentOptions.initial() : this._(preferredBoostValue: 5000, preferredSatsPerMinValue: 0);
 
   PaymentOptions copyWith({
     int preferredBoostValue,
@@ -22,11 +21,9 @@ class PaymentOptions {
   }) {
     return PaymentOptions._(
       preferredBoostValue: preferredBoostValue ?? this.preferredBoostValue,
-      preferredSatsPerMinValue:
-          preferredSatsPerMinValue ?? this.preferredSatsPerMinValue,
+      preferredSatsPerMinValue: preferredSatsPerMinValue ?? this.preferredSatsPerMinValue,
       customBoostValue: customBoostValue ?? this.customBoostValue,
-      customSatsPerMinValue:
-          customSatsPerMinValue ?? this.customSatsPerMinValue,
+      customSatsPerMinValue: customSatsPerMinValue ?? this.customSatsPerMinValue,
     );
   }
 
@@ -43,8 +40,7 @@ class PaymentOptions {
         'customSatsPerMinValue': customSatsPerMinValue,
       };
 
-  List<int> get presetBoostAmountsList =>
-      [50, 100, 500, 1000, 5000, 10000, 50000];
+  List<int> get presetBoostAmountsList => [50, 100, 500, 1000, 5000, 10000, 50000];
 
   List get boostAmountList {
     List boostAmountList = presetBoostAmountsList;
@@ -56,8 +52,7 @@ class PaymentOptions {
     ];
   }
 
-  List<int> get presetSatsPerMinuteAmountsList =>
-      [0, 10, 25, 50, 100, 250, 500, 1000];
+  List<int> get presetSatsPerMinuteAmountsList => [0, 10, 25, 50, 100, 250, 500, 1000];
 
   List get satsPerMinuteIntervalsList {
     List satsPerMinuteIntervalsList = presetSatsPerMinuteAmountsList;

--- a/lib/bloc/pos_catalog/bloc.dart
+++ b/lib/bloc/pos_catalog/bloc.dart
@@ -28,8 +28,7 @@ class PosCatalogBloc with AsyncActionsHandler {
 
   final Stream<BreezUserModel> _userStream;
 
-  final StreamController<List<Item>> _itemsStreamController =
-      BehaviorSubject<List<Item>>();
+  final StreamController<List<Item>> _itemsStreamController = BehaviorSubject<List<Item>>();
 
   Stream<List<Item>> get itemsStream => _itemsStreamController.stream;
 
@@ -37,11 +36,9 @@ class PosCatalogBloc with AsyncActionsHandler {
 
   Stream<Sale> get currentSaleStream => _currentSaleController.stream;
 
-  final BehaviorSubject<List<ProductIcon>> _productIconsController =
-      BehaviorSubject<List<ProductIcon>>();
+  final BehaviorSubject<List<ProductIcon>> _productIconsController = BehaviorSubject<List<ProductIcon>>();
 
-  Stream<List<ProductIcon>> get productIconsStream =>
-      _productIconsController.stream;
+  Stream<List<ProductIcon>> get productIconsStream => _productIconsController.stream;
 
   final BehaviorSubject<String> _selectedCurrency = BehaviorSubject();
 
@@ -114,11 +111,9 @@ class PosCatalogBloc with AsyncActionsHandler {
   }
 
   Future _loadIcons() async {
-    String iconsJson =
-        await rootBundle.loadString('src/json/pos-icons-meta.json');
+    String iconsJson = await rootBundle.loadString('src/json/pos-icons-meta.json');
     List<dynamic> decoded = json.decode(iconsJson);
-    _productIconsController
-        .add(decoded.map((e) => ProductIcon.fromJson(e)).toList());
+    _productIconsController.add(decoded.map((e) => ProductIcon.fromJson(e)).toList());
   }
 
   void _loadSelectedCurrency() async {
@@ -158,8 +153,7 @@ class PosCatalogBloc with AsyncActionsHandler {
     var breezBridge = ServiceInjector().breezBridge;
 
     breezBridge.notificationStream
-        .where((event) =>
-            event.type == NotificationEvent_NotificationType.INVOICE_PAID)
+        .where((event) => event.type == NotificationEvent_NotificationType.INVOICE_PAID)
         .listen((event) async {
       var paymentHash = await breezBridge.getPaymentRequestHash(event.data[0]);
       await _repository.salePaymentCompleted(paymentHash);
@@ -248,8 +242,7 @@ class PosCatalogBloc with AsyncActionsHandler {
   }
 
   _importItems(ImportItems action) async {
-    action.resolve(await importItems(
-        await PosCsvUtils().retrieveItemListFromCSV(action.importFile)));
+    action.resolve(await importItems(await PosCsvUtils().retrieveItemListFromCSV(action.importFile)));
     _loadItems();
   }
 
@@ -290,8 +283,7 @@ class PosCatalogBloc with AsyncActionsHandler {
     if (action.id != null) {
       action.resolve(await _repository.fetchSaleByID(action.id));
     } else {
-      action.resolve(
-          await _repository.fetchSaleByPaymentHash(action.paymentHash));
+      action.resolve(await _repository.fetchSaleByPaymentHash(action.paymentHash));
     }
   }
 

--- a/lib/bloc/pos_catalog/model.dart
+++ b/lib/bloc/pos_catalog/model.dart
@@ -240,16 +240,14 @@ class Sale implements DBItem {
     }).toList();
 
     if (!hasSaleLine) {
-      saleLines.add(SaleLine.fromItem(item, quantity, satConversionRate)
-          .copyWith(saleID: id));
+      saleLines.add(SaleLine.fromItem(item, quantity, satConversionRate).copyWith(saleID: id));
     }
     return copyWith(saleLines: saleLines);
   }
 
   Sale removeItem(bool Function(SaleLine) predicate) {
     var saleLines = this.saleLines.toList();
-    return copyWith(
-        saleLines: saleLines..removeWhere((element) => predicate(element)));
+    return copyWith(saleLines: saleLines..removeWhere((element) => predicate(element)));
   }
 
   Sale updateItems(SaleLine Function(SaleLine) predicate) {
@@ -260,8 +258,7 @@ class Sale implements DBItem {
     }).toList());
   }
 
-  Sale incrementQuantity(int itemID, double satConversionRate,
-      {int quantity = 1}) {
+  Sale incrementQuantity(int itemID, double satConversionRate, {int quantity = 1}) {
     var saleLines = this.saleLines.map((sl) {
       if (sl.itemID == itemID) {
         return sl.copyWith(quantity: sl.quantity + quantity);
@@ -273,8 +270,7 @@ class Sale implements DBItem {
   }
 
   Sale addCustomItem(double price, String currency, double satConversionRate) {
-    int customItemsCount =
-        saleLines.where((element) => element.itemID == null).length;
+    int customItemsCount = saleLines.where((element) => element.itemID == null).length;
     var newSaleLines = saleLines.toList()
       ..add(SaleLine(
         itemName: getSystemAppLocalizations().pos_custom_item_name(
@@ -294,8 +290,7 @@ class Sale implements DBItem {
     Map<double, double> perCurrency = {};
     for (var element in saleLines) {
       perCurrency[element.satConversionRate] =
-          (perCurrency[element.satConversionRate] ?? 0) +
-              element.pricePerItem * element.quantity;
+          (perCurrency[element.satConversionRate] ?? 0) + element.pricePerItem * element.quantity;
     }
     perCurrency.forEach((rate, value) {
       totalSat += rate * value;
@@ -349,10 +344,7 @@ class SaleSummary {
         currencies = json["currencies"].toString().split(",").toList();
 
   List<String> fiatCurrencies() {
-    return currencies
-        .map((e) => e.toUpperCase())
-        .where((e) => e != "BTC" && e != "SAT")
-        .toList();
+    return currencies.map((e) => e.toUpperCase()).where((e) => e != "BTC" && e != "SAT").toList();
   }
 }
 

--- a/lib/bloc/pos_catalog/pos_csv_utils.dart
+++ b/lib/bloc/pos_catalog/pos_csv_utils.dart
@@ -18,8 +18,7 @@ class PosCsvUtils {
 
   Future export() async {
     _log.info("export pos items started");
-    String tmpFilePath =
-        await _saveCsvFile(const ListToCsvConverter().convert(_generateList()));
+    String tmpFilePath = await _saveCsvFile(const ListToCsvConverter().convert(_generateList()));
     _log.info("export pos items finished");
     return tmpFilePath;
   }

--- a/lib/bloc/pos_catalog/sqlite/repository.dart
+++ b/lib/bloc/pos_catalog/sqlite/repository.dart
@@ -46,14 +46,12 @@ class SqliteRepository implements Repository {
 
   @override
   Future<void> deleteAsset(String url) async {
-    return _deleteDBItems(await getDB(), "asset",
-        where: "url = ?", whereArgs: [url]);
+    return _deleteDBItems(await getDB(), "asset", where: "url = ?", whereArgs: [url]);
   }
 
   @override
   Future<List<int>> fetchAssetByURL(String url) async {
-    var assets = await _fetchDBItems(
-        await getDB(), "asset", (e) => Asset.fromMap(e),
+    var assets = await _fetchDBItems(await getDB(), "asset", (e) => Asset.fromMap(e),
         where: "url = ?", whereArgs: [url]);
     return assets.isNotEmpty ? assets[0].data : null;
   }
@@ -68,28 +66,24 @@ class SqliteRepository implements Repository {
 
   @override
   Future<void> updateItem(Item item) async {
-    return _updateDBItem(await getDB(), "item", item.toMap(),
-        where: "id = ?", whereArgs: [item.id]);
+    return _updateDBItem(await getDB(), "item", item.toMap(), where: "id = ?", whereArgs: [item.id]);
   }
 
   @override
   Future<List<Item>> fetchItems({String filter}) async {
     return _fetchDBItems(await getDB(), "item", (e) => Item.fromMap(e),
-        where: filter == null ? null : "name LIKE ? OR sku LIKE ?",
-        whereArgs: ['%$filter%', '%$filter%']);
+        where: filter == null ? null : "name LIKE ? OR sku LIKE ?", whereArgs: ['%$filter%', '%$filter%']);
   }
 
   @override
   Future<void> deleteItem(int id) async {
-    return _deleteDBItems(await getDB(), "item",
-        where: "id = ?", whereArgs: [id]);
+    return _deleteDBItems(await getDB(), "item", where: "id = ?", whereArgs: [id]);
   }
 
   @override
   Future<Item> fetchItemByID(int id) async {
-    var items = await _fetchDBItems(
-        await getDB(), "item", (e) => Item.fromMap(e),
-        where: "id = ?", whereArgs: [id]);
+    var items =
+        await _fetchDBItems(await getDB(), "item", (e) => Item.fromMap(e), where: "id = ?", whereArgs: [id]);
     return items.isNotEmpty ? items[0] : null;
   }
 
@@ -126,15 +120,13 @@ class SqliteRepository implements Repository {
 
   @override
   Future<Sale> fetchSaleByID(int id) async {
-    var items = await _fetchDBItems(
-        await getDB(), "sale", (e) => Sale.fromMap(e),
-        where: "id = ?", whereArgs: [id]);
+    var items =
+        await _fetchDBItems(await getDB(), "sale", (e) => Sale.fromMap(e), where: "id = ?", whereArgs: [id]);
     if (items.isEmpty) {
       return null;
     }
     Sale s = items[0];
-    var saleLines = await _fetchDBItems(
-        await getDB(), "sale_line", (e) => SaleLine.fromMap(e),
+    var saleLines = await _fetchDBItems(await getDB(), "sale_line", (e) => SaleLine.fromMap(e),
         where: "sale_id = ?", whereArgs: [s.id]);
     return s.copyWith(saleLines: saleLines);
   }
@@ -142,8 +134,7 @@ class SqliteRepository implements Repository {
   @override
   Future<Sale> fetchSaleByPaymentHash(String paymentHash) async {
     int saleID = await (await getDB()).transaction((txn) async {
-      var salePayment = await txn.query("sale_payments",
-          where: "payment_hash = ?", whereArgs: [paymentHash]);
+      var salePayment = await txn.query("sale_payments", where: "payment_hash = ?", whereArgs: [paymentHash]);
       if (salePayment.isEmpty) {
         return null;
       }
@@ -287,10 +278,7 @@ class SqliteRepository implements Repository {
       String currency = reportMap["currencies"] ?? "";
 
       Map<String, double> fiatValues = {};
-      if (currencies == 1 &&
-          currency != "" &&
-          currency != "BTC" &&
-          currency != "SAT") {
+      if (currencies == 1 && currency != "" && currency != "BTC" && currency != "SAT") {
         fiatValues[currency] = fiatValue;
       }
 

--- a/lib/bloc/reverse_swap/reverse_swap_actions.dart
+++ b/lib/bloc/reverse_swap/reverse_swap_actions.dart
@@ -9,8 +9,7 @@ class NewReverseSwap extends AsyncAction {
   final Int64 claimFees;
   final Int64 received;
 
-  NewReverseSwap(
-      this.amount, this.address, this.feesHash, this.claimFees, this.received);
+  NewReverseSwap(this.amount, this.address, this.feesHash, this.claimFees, this.received);
 }
 
 class PayReverseSwap extends AsyncAction {

--- a/lib/bloc/reverse_swap/reverse_swap_bloc.dart
+++ b/lib/bloc/reverse_swap/reverse_swap_bloc.dart
@@ -22,11 +22,9 @@ class ReverseSwapBloc with AsyncActionsHandler {
   final StreamController<InProgressReverseSwaps> _swapsInProgressController =
       BehaviorSubject<InProgressReverseSwaps>();
 
-  Stream<InProgressReverseSwaps> get swapInProgressStream =>
-      _swapsInProgressController.stream;
+  Stream<InProgressReverseSwaps> get swapInProgressStream => _swapsInProgressController.stream;
 
-  final StreamController<void> _broadcastTxStreamController =
-      StreamController<void>.broadcast();
+  final StreamController<void> _broadcastTxStreamController = StreamController<void>.broadcast();
 
   Stream<void> get broadcastTxStream => _broadcastTxStreamController.stream;
 
@@ -86,8 +84,7 @@ class ReverseSwapBloc with AsyncActionsHandler {
   }
 
   Future _getFeeClaimEstimates(GetClaimFeeEstimates action) async {
-    var estimates =
-        await _breezLib.reverseSwapClaimFeeEstimates(action.claimAddress);
+    var estimates = await _breezLib.reverseSwapClaimFeeEstimates(action.claimAddress);
     action.resolve(ReverseSwapClaimFeeEstimates(estimates));
   }
 
@@ -153,8 +150,7 @@ class ReverseSwapBloc with AsyncActionsHandler {
         fee,
       ),
       _paymentsStream
-          .where((payments) => payments.nonFilteredItems
-              .any((element) => element.paymentHash == hash))
+          .where((payments) => payments.nonFilteredItems.any((element) => element.paymentHash == hash))
           .first
     ]).then((_) => onComplete()).catchError((err) {
       onComplete(
@@ -172,19 +168,16 @@ class ReverseSwapBloc with AsyncActionsHandler {
 
   void _listenPushNotification() {
     _notificationsService.notifications
-        .where((message) =>
-            message["title"] == _notificationTitle() &&
-            message["body"] == _notificationBody())
+        .where(
+            (message) => message["title"] == _notificationTitle() && message["body"] == _notificationBody())
         .listen((message) {
       _broadcastTxStreamController.add(null);
     });
   }
 
-  String _notificationTitle() =>
-      getSystemAppLocalizations().reverse_swap_notification_title;
+  String _notificationTitle() => getSystemAppLocalizations().reverse_swap_notification_title;
 
-  String _notificationBody() =>
-      getSystemAppLocalizations().reverse_swap_notification_body;
+  String _notificationBody() => getSystemAppLocalizations().reverse_swap_notification_body;
 
   Future<int> _calculateFee(int amount) async {
     final calculateFee = CalculateFee(amount);

--- a/lib/bloc/reverse_swap/reverse_swap_model.dart
+++ b/lib/bloc/reverse_swap/reverse_swap_model.dart
@@ -17,8 +17,7 @@ class ReverseSwapDetails {
 }
 
 class ReverseSwapRequest {
-  ReverseSwapRequest(
-      this.claimAddress, this.amount, this.isMax, this.available, this.policy);
+  ReverseSwapRequest(this.claimAddress, this.amount, this.isMax, this.available, this.policy);
 
   final String claimAddress;
 
@@ -65,13 +64,11 @@ class InProgressReverseSwaps {
 
   InProgressReverseSwaps(this._statuses);
 
-  int get lockupTxETA => (_statuses?.paymentsStatus?.isNotEmpty == true)
-      ? _statuses.paymentsStatus[0].eta
-      : -1;
+  int get lockupTxETA =>
+      (_statuses?.paymentsStatus?.isNotEmpty == true) ? _statuses.paymentsStatus[0].eta : -1;
 
-  String get lockTxID => (_statuses?.paymentsStatus?.isNotEmpty == true)
-      ? _statuses.paymentsStatus[0].txID
-      : "";
+  String get lockTxID =>
+      (_statuses?.paymentsStatus?.isNotEmpty == true) ? _statuses.paymentsStatus[0].txID : "";
 
   bool get isNotEmpty => _statuses != null;
 }

--- a/lib/bloc/user_profile/backup_user_preferences.dart
+++ b/lib/bloc/user_profile/backup_user_preferences.dart
@@ -42,8 +42,7 @@ class BackupUserPreferences {
       image: image ?? this.image,
       themeId: themeId ?? this.themeId,
       preferredCurrencies: preferredCurrencies ?? this.preferredCurrencies,
-      cancellationTimeoutValue:
-          cancellationTimeoutValue ?? this.cancellationTimeoutValue,
+      cancellationTimeoutValue: cancellationTimeoutValue ?? this.cancellationTimeoutValue,
       businessAddress: businessAddress ?? this.businessAddress,
       paymentOptions: paymentOptions ?? this.paymentOptions,
     );
@@ -55,9 +54,8 @@ class BackupUserPreferences {
         animal = json['animal'],
         image = json['image'],
         themeId = json['themeId'] ?? "DARK",
-        preferredCurrencies =
-            (json['preferredCurrencies'] as List<dynamic>)?.cast<String>() ??
-                <String>['USD', 'EUR', 'GBP', 'JPY'],
+        preferredCurrencies = (json['preferredCurrencies'] as List<dynamic>)?.cast<String>() ??
+            <String>['USD', 'EUR', 'GBP', 'JPY'],
         cancellationTimeoutValue = json['cancellationTimeoutValue'] ?? 90.0,
         businessAddress = json['businessAddress'] == null
             ? BusinessAddress.initial()

--- a/lib/bloc/user_profile/breez_user_model.dart
+++ b/lib/bloc/user_profile/breez_user_model.dart
@@ -93,11 +93,9 @@ class BreezUserModel {
       locked: locked ?? this.locked,
       token: token ?? this.token,
       themeId: themeId ?? this.themeId,
-      registrationRequested:
-          registrationRequested ?? this.registrationRequested,
+      registrationRequested: registrationRequested ?? this.registrationRequested,
       hideBalance: hideBalance ?? this.hideBalance,
-      cancellationTimeoutValue:
-          cancellationTimeoutValue ?? this.cancellationTimeoutValue,
+      cancellationTimeoutValue: cancellationTimeoutValue ?? this.cancellationTimeoutValue,
       hasAdminPassword: hasAdminPassword ?? this.hasAdminPassword,
       businessAddress: businessAddress ?? this.businessAddress,
       defaultPosNote: defaultPosNote ?? this.defaultPosNote,
@@ -113,16 +111,13 @@ class BreezUserModel {
     return userID != null;
   }
 
-  String get avatarURL => image == null || image.isEmpty
-      ? 'breez://profile_image?animal=$animal&color=$color'
-      : image;
+  String get avatarURL =>
+      image == null || image.isEmpty ? 'breez://profile_image?animal=$animal&color=$color' : image;
 
   BreezUserModel.fromJson(Map<String, dynamic> json)
       : userID = json['userID'],
         token = json['token'],
-        currency = json['currency'] == null
-            ? Currency.SAT
-            : Currency.fromTickerSymbol(json['currency']),
+        currency = json['currency'] == null ? Currency.SAT : Currency.fromTickerSymbol(json['currency']),
         fiatCurrency = json['fiatCurrency'] ?? "USD",
         name = json['name'],
         color = json['color'],
@@ -135,8 +130,7 @@ class BreezUserModel {
                 json['securityModel'],
               ),
         themeId = json['themeId'] ?? "DARK",
-        registrationRequested =
-            json['registrationRequested'] ?? json['token'] != null,
+        registrationRequested = json['registrationRequested'] ?? json['token'] != null,
         hideBalance = json['hideBalance'] ?? false,
         cancellationTimeoutValue = json['cancellationTimeoutValue'] ?? 90.0,
         hasAdminPassword = json['hasAdminPassword'] ?? false,
@@ -145,9 +139,8 @@ class BreezUserModel {
             : BusinessAddress.fromJson(json['businessAddress']),
         defaultPosNote = json['defaultPosNote'] ?? "",
         posCurrencyShortName = json['posCurrencyShortName'] ?? "SAT",
-        preferredCurrencies =
-            (json['preferredCurrencies'] as List<dynamic>)?.cast<String>() ??
-                <String>['USD', 'EUR', 'GBP', 'JPY'],
+        preferredCurrencies = (json['preferredCurrencies'] as List<dynamic>)?.cast<String>() ??
+            <String>['USD', 'EUR', 'GBP', 'JPY'],
         appMode = AppMode.values[json["appMode"] ?? 0],
         paymentOptions = json["paymentOptions"] == null
             ? PaymentOptions.initial()
@@ -197,13 +190,11 @@ class BreezUserModel {
       themeId: userPreferences.themeId ?? themeId,
       registrationRequested: registrationRequested,
       hideBalance: hideBalance,
-      cancellationTimeoutValue:
-          userPreferences.cancellationTimeoutValue ?? cancellationTimeoutValue,
+      cancellationTimeoutValue: userPreferences.cancellationTimeoutValue ?? cancellationTimeoutValue,
       hasAdminPassword: hasAdminPassword,
       businessAddress: userPreferences.businessAddress ?? businessAddress,
       posCurrencyShortName: posCurrencyShortName,
-      preferredCurrencies:
-          userPreferences.preferredCurrencies ?? preferredCurrencies,
+      preferredCurrencies: userPreferences.preferredCurrencies ?? preferredCurrencies,
       appMode: appMode,
       paymentOptions: userPreferences.paymentOptions ?? paymentOptions,
       seenTutorials: seenTutorials,

--- a/lib/bloc/user_profile/currency.dart
+++ b/lib/bloc/user_profile/currency.dart
@@ -12,8 +12,7 @@ class Currency extends Object {
   const Currency._internal(this.tickerSymbol);
 
   factory Currency.fromTickerSymbol(String tickerSymbol) {
-    return currencies.firstWhere(
-        (c) => c.tickerSymbol.toUpperCase() == tickerSymbol.toUpperCase(),
+    return currencies.firstWhere((c) => c.tickerSymbol.toUpperCase() == tickerSymbol.toUpperCase(),
         orElse: () => null);
   }
 
@@ -45,8 +44,7 @@ class Currency extends Object {
 
   Int64 toSats(double amount) => _CurrencyFormatter().toSats(amount, this);
 
-  String get displayName =>
-      tickerSymbol.toLowerCase() == "sat" ? "sats" : tickerSymbol;
+  String get displayName => tickerSymbol.toLowerCase() == "sat" ? "sats" : tickerSymbol;
 
   String get symbol {
     switch (tickerSymbol) {
@@ -82,9 +80,7 @@ class _CurrencyFormatter {
   static final formatter = CurrencyFormatter().formatter;
 
   String format(satoshies, Currency currency,
-      {bool addCurrencySuffix = true,
-      bool addCurrencySymbol = false,
-      userInput = false}) {
+      {bool addCurrencySuffix = true, bool addCurrencySymbol = false, userInput = false}) {
     String formattedAmount = formatter.format(satoshies);
     switch (currency) {
       case Currency.BTC:

--- a/lib/bloc/user_profile/security_model.dart
+++ b/lib/bloc/user_profile/security_model.dart
@@ -1,39 +1,28 @@
 class SecurityModel {
-  static List<int> lockIntervals =
-      List.unmodifiable([0, 30, 120, 300, 600, 1800, 3600]);
+  static List<int> lockIntervals = List.unmodifiable([0, 30, 120, 300, 600, 1800, 3600]);
   static const int _defaultLockInterval = 120;
 
   final bool requiresPin;
   final bool isFingerprintEnabled;
   final int automaticallyLockInterval;
 
-  SecurityModel._(
-      {this.requiresPin,
-      this.isFingerprintEnabled,
-      this.automaticallyLockInterval});
+  SecurityModel._({this.requiresPin, this.isFingerprintEnabled, this.automaticallyLockInterval});
 
-  SecurityModel copyWith(
-      {bool requiresPin,
-      bool isFingerprintEnabled,
-      int automaticallyLockInterval}) {
+  SecurityModel copyWith({bool requiresPin, bool isFingerprintEnabled, int automaticallyLockInterval}) {
     return SecurityModel._(
         requiresPin: requiresPin ?? this.requiresPin,
         isFingerprintEnabled: isFingerprintEnabled ?? this.isFingerprintEnabled,
-        automaticallyLockInterval:
-            automaticallyLockInterval ?? this.automaticallyLockInterval);
+        automaticallyLockInterval: automaticallyLockInterval ?? this.automaticallyLockInterval);
   }
 
   SecurityModel.initial()
       : this._(
-            requiresPin: false,
-            isFingerprintEnabled: false,
-            automaticallyLockInterval: _defaultLockInterval);
+            requiresPin: false, isFingerprintEnabled: false, automaticallyLockInterval: _defaultLockInterval);
 
   SecurityModel.fromJson(Map<String, dynamic> json)
       : requiresPin = json['requiresPin'] ?? false,
         isFingerprintEnabled = json['isFingerprintEnabled'] ?? false,
-        automaticallyLockInterval =
-            json['automaticallyLockInterval'] ?? _defaultLockInterval;
+        automaticallyLockInterval = json['automaticallyLockInterval'] ?? _defaultLockInterval;
 
   Map<String, dynamic> toJson() => {
         'requiresPin': requiresPin,

--- a/lib/bloc/user_profile/seen_tutorials.dart
+++ b/lib/bloc/user_profile/seen_tutorials.dart
@@ -6,9 +6,7 @@ class SeenTutorials {
   SeenTutorials.initial() : this._(paymentStripTutorial: false);
 
   SeenTutorials copyWith({bool paymentStripTutorial}) {
-    return SeenTutorials._(
-        paymentStripTutorial:
-            paymentStripTutorial ?? this.paymentStripTutorial);
+    return SeenTutorials._(paymentStripTutorial: paymentStripTutorial ?? this.paymentStripTutorial);
   }
 
   SeenTutorials.fromJson(Map<String, dynamic> json)

--- a/lib/bloc/user_profile/user_profile_bloc.dart
+++ b/lib/bloc/user_profile/user_profile_bloc.dart
@@ -51,8 +51,7 @@ class UserProfileBloc {
   Stream<BreezUserModel> get userStream => _userStreamController.stream;
 
   final _userStreamPreviewController = BehaviorSubject<BreezUserModel>();
-  Stream<BreezUserModel> get userPreviewStream =>
-      _userStreamPreviewController.stream;
+  Stream<BreezUserModel> get userPreviewStream => _userStreamPreviewController.stream;
 
   final _currencyController = BehaviorSubject<Currency>();
   Sink<Currency> get currencySink => _currencyController.sink;
@@ -133,10 +132,8 @@ class UserProfileBloc {
     _deviceService.eventStream.listen((e) {
       if (e == NotificationType.PAUSE) {
         watcher?.cancel();
-        watcher = Timer(
-            Duration(
-                seconds: _userStreamController
-                    .value.securityModel.automaticallyLockInterval), () {
+        watcher =
+            Timer(Duration(seconds: _userStreamController.value.securityModel.automaticallyLockInterval), () {
           var currentUser = _userStreamController.value;
           if (currentUser.securityModel.requiresPin && !currentUser.locked) {
             _userStreamController.add(currentUser.copyWith(locked: true));
@@ -153,8 +150,7 @@ class UserProfileBloc {
   Future _initializeWithSavedUser(ServiceInjector injector) {
     return injector.sharedPreferences.then((preferences) async {
       _log.info("UserProfileBloc got preferences");
-      String jsonStr =
-          preferences.getString(USER_DETAILS_PREFERENCES_KEY) ?? "{}";
+      String jsonStr = preferences.getString(USER_DETAILS_PREFERENCES_KEY) ?? "{}";
       Map profile = json.decode(jsonStr);
       BreezUserModel user = BreezUserModel.fromJson(profile);
 
@@ -170,8 +166,7 @@ class UserProfileBloc {
       }
       if (!user.registered && Platform.isAndroid) {
         GooglePlayServicesAvailability availability =
-            await GoogleApiAvailability.instance
-                .checkGooglePlayServicesAvailability();
+            await GoogleApiAvailability.instance.checkGooglePlayServicesAvailability();
         _log.info("GooglePlayServicesAvailability:$availability");
         if ((availability == GooglePlayServicesAvailability.serviceMissing) ||
             (availability == GooglePlayServicesAvailability.serviceDisabled) ||
@@ -199,8 +194,7 @@ class UserProfileBloc {
   }
 
   Future _setLockState(SetLockState action) async {
-    _saveChanges(
-        await _preferences, _currentUser.copyWith(locked: action.locked));
+    _saveChanges(await _preferences, _currentUser.copyWith(locked: action.locked));
     action.resolve(action.locked);
   }
 
@@ -209,20 +203,17 @@ class UserProfileBloc {
   }
 
   Future _setAppMode(SetAppMode action) async {
-    _saveChanges(
-        await _preferences, _currentUser.copyWith(appMode: action.appMode));
+    _saveChanges(await _preferences, _currentUser.copyWith(appMode: action.appMode));
     action.resolve(action.appMode);
   }
 
   Future _setPOSCurrency(SetPOSCurrency action) async {
-    _saveChanges(await _preferences,
-        _currentUser.copyWith(posCurrencyShortName: action.shortName));
+    _saveChanges(await _preferences, _currentUser.copyWith(posCurrencyShortName: action.shortName));
     action.resolve(action.shortName);
   }
 
   Future _setPaymentOptions(SetPaymentOptions action) async {
-    _saveChanges(await _preferences,
-        _currentUser.copyWith(paymentOptions: action.paymentOptions));
+    _saveChanges(await _preferences, _currentUser.copyWith(paymentOptions: action.paymentOptions));
     action.resolve(action.paymentOptions);
   }
 
@@ -230,13 +221,11 @@ class UserProfileBloc {
     action.resolve(await _uploadImage(action.bytes));
   }
 
-  Future _setSeenPaymentStripTutorial(
-      SetSeenPaymentStripTutorial action) async {
+  Future _setSeenPaymentStripTutorial(SetSeenPaymentStripTutorial action) async {
     _saveChanges(
         await _preferences,
         _currentUser.copyWith(
-            seenTutorials: _currentUser.seenTutorials
-                .copyWith(paymentStripTutorial: action.seen)));
+            seenTutorials: _currentUser.seenTutorials.copyWith(paymentStripTutorial: action.seen)));
     action.resolve(action.seen);
   }
 
@@ -244,8 +233,7 @@ class UserProfileBloc {
     try {
       return _saveImage(bytes).then((file) {
         return _breezServer.uploadLogo(bytes).then((imageUrl) async {
-          _userStreamPreviewController
-              .add(_currentUser.copyWith(image: imageUrl));
+          _userStreamPreviewController.add(_currentUser.copyWith(image: imageUrl));
           return Future.value(null);
         });
       });
@@ -268,8 +256,7 @@ class UserProfileBloc {
     } catch (e) {
       //  This is a temporary workaround for flutter_secure_storage issues
       //  on apps published in Google Play for Android devices
-      if (e.toString().contains("java.lang.NullPointerException") &&
-          Platform.isAndroid) {
+      if (e.toString().contains("java.lang.NullPointerException") && Platform.isAndroid) {
         action.resolve(true);
         return;
       }
@@ -289,8 +276,7 @@ class UserProfileBloc {
       String hexHash = HEX.encode(hashedPassword);
       await _secureStorage.write(key: 'adminPassword', value: hexHash);
     }
-    await _saveChanges(await _preferences,
-        _currentUser.copyWith(hasAdminPassword: action.password != null));
+    await _saveChanges(await _preferences, _currentUser.copyWith(hasAdminPassword: action.password != null));
     action.resolve(null);
   }
 
@@ -301,33 +287,23 @@ class UserProfileBloc {
     action.resolve(listEquals(decodedHash, hashedPassword));
   }
 
-  Future _updateSecurityModelAction(
-      UpdateSecurityModel updateSecurityModelAction) async {
-    updateSecurityModelAction
-        .resolve(await _updateSecurityModel(updateSecurityModelAction));
+  Future _updateSecurityModelAction(UpdateSecurityModel updateSecurityModelAction) async {
+    updateSecurityModelAction.resolve(await _updateSecurityModel(updateSecurityModelAction));
   }
 
-  Future _resetSecurityModelAction(
-      ResetSecurityModel resetSecurityModelAction) async {
-    var updateSecurityModelAction =
-        UpdateSecurityModel(SecurityModel.initial());
-    resetSecurityModelAction
-        .resolve(await _updateSecurityModel(updateSecurityModelAction));
+  Future _resetSecurityModelAction(ResetSecurityModel resetSecurityModelAction) async {
+    var updateSecurityModelAction = UpdateSecurityModel(SecurityModel.initial());
+    resetSecurityModelAction.resolve(await _updateSecurityModel(updateSecurityModelAction));
   }
 
-  Future _updateSecurityModel(
-      UpdateSecurityModel updateSecurityModelAction) async {
+  Future _updateSecurityModel(UpdateSecurityModel updateSecurityModelAction) async {
     await _saveChanges(
-        await _preferences,
-        _currentUser.copyWith(
-            securityModel: updateSecurityModelAction.newModel));
+        await _preferences, _currentUser.copyWith(securityModel: updateSecurityModelAction.newModel));
     return updateSecurityModelAction.newModel;
   }
 
-  Future _updatePreferredCurrenciesAction(
-      UpdatePreferredCurrencies updateCurrencies) async {
-    var updated =
-        _currentUser.copyWith(preferredCurrencies: updateCurrencies.currencies);
+  Future _updatePreferredCurrenciesAction(UpdatePreferredCurrencies updateCurrencies) async {
+    var updated = _currentUser.copyWith(preferredCurrencies: updateCurrencies.currencies);
     await _saveChanges(await _preferences, updated);
     updateCurrencies.resolve(updateCurrencies.currencies);
   }
@@ -337,14 +313,12 @@ class UserProfileBloc {
   }
 
   Future _changeTheme(ChangeTheme action) async {
-    await _saveChanges(
-        await _preferences, _currentUser.copyWith(themeId: action.newTheme));
+    await _saveChanges(await _preferences, _currentUser.copyWith(themeId: action.newTheme));
     return action.newTheme;
   }
 
   Future _validateBiometrics(ValidateBiometrics action) async {
-    action.resolve(await _localAuthService.authenticate(
-        localizedReason: action.localizedReason));
+    action.resolve(await _localAuthService.authenticate(localizedReason: action.localizedReason));
   }
 
   Future _stopBiometrics(StopBiometrics action) async {
@@ -367,8 +341,7 @@ class UserProfileBloc {
     try {
       String token = await _notifications.getToken();
 
-      if (token != null &&
-          (token != user.token || user.userID == null || user.userID.isEmpty)) {
+      if (token != null && (token != user.token || user.userID == null || user.userID.isEmpty)) {
         //var userID = await _breezServer.registerDevice(token);
         var userID = token;
         userToRegister = userToRegister.copyWith(token: token, userID: userID);
@@ -385,15 +358,12 @@ class UserProfileBloc {
     BreezUserModel userModel,
   ) async {
     var appDir = await getApplicationDocumentsDirectory();
-    var backupAppDataDirPath =
-        '${appDir.path}${Platform.pathSeparator}app_data_backup';
-    final backupUserPrefsPath =
-        '$backupAppDataDirPath${Platform.pathSeparator}userPreferences.txt';
+    var backupAppDataDirPath = '${appDir.path}${Platform.pathSeparator}app_data_backup';
+    final backupUserPrefsPath = '$backupAppDataDirPath${Platform.pathSeparator}userPreferences.txt';
     if (await File(backupUserPrefsPath).exists()) {
       final backupUserPrefs = await File(backupUserPrefsPath).readAsString();
       Map<dynamic, dynamic> userData = json.decode(backupUserPrefs);
-      BackupUserPreferences userPrefs =
-          BackupUserPreferences.fromJson(userData);
+      BackupUserPreferences userPrefs = BackupUserPreferences.fromJson(userData);
       return userModel.fromUserPreferences(userPrefs);
     }
     return userModel;
@@ -402,16 +372,14 @@ class UserProfileBloc {
   void _listenCurrencyChange(ServiceInjector injector) {
     _currencyController.stream.listen((currency) async {
       var preferences = await injector.sharedPreferences;
-      await _saveChanges(
-          preferences, _currentUser.copyWith(currency: currency));
+      await _saveChanges(preferences, _currentUser.copyWith(currency: currency));
     });
   }
 
   void _listenFiatCurrencyChange(ServiceInjector injector) {
     _fiatConversionController.stream.listen((shortName) async {
       var preferences = await injector.sharedPreferences;
-      await _saveChanges(
-          preferences, _currentUser.copyWith(fiatCurrency: shortName));
+      await _saveChanges(preferences, _currentUser.copyWith(fiatCurrency: shortName));
     });
   }
 
@@ -437,20 +405,15 @@ class UserProfileBloc {
 
   _saveImage(List<int> logoBytes) {
     return getApplicationDocumentsDirectory()
-        .then((docDir) =>
-            Directory([docDir.path, PROFILE_DATA_FOLDER_PATH].join("/"))
-                .create(recursive: true))
-        .then((profileDir) => File([
-              profileDir.path,
-              'profile-${DateTime.now().millisecondsSinceEpoch}-.png'
-            ].join("/"))
+        .then(
+            (docDir) => Directory([docDir.path, PROFILE_DATA_FOLDER_PATH].join("/")).create(recursive: true))
+        .then((profileDir) =>
+            File([profileDir.path, 'profile-${DateTime.now().millisecondsSinceEpoch}-.png'].join("/"))
                 .writeAsBytes(logoBytes, flush: true));
   }
 
-  Future<bool> _saveChanges(
-      SharedPreferences preferences, BreezUserModel user) {
-    var res =
-        preferences.setString(USER_DETAILS_PREFERENCES_KEY, json.encode(user));
+  Future<bool> _saveChanges(SharedPreferences preferences, BreezUserModel user) {
+    var res = preferences.setString(USER_DETAILS_PREFERENCES_KEY, json.encode(user));
     _publishUser(user);
     return res;
   }

--- a/lib/handlers/check_channel_connection_handler.dart
+++ b/lib/handlers/check_channel_connection_handler.dart
@@ -43,9 +43,7 @@ class CheckChannelConnection {
 
   void startSubscription(AccountBloc accountBloc, BuildContext context) {
     _subscription = accountBloc.accountStream
-        .map((acc) =>
-            !(acc.connected && !acc.readyForPayments) ||
-            acc.nodeUpgrading == true)
+        .map((acc) => !(acc.connected && !acc.readyForPayments) || acc.nodeUpgrading == true)
         .distinct()
         .listen((ready) {
       if (ready) {

--- a/lib/handlers/ctp_join_session_handler.dart
+++ b/lib/handlers/ctp_join_session_handler.dart
@@ -5,12 +5,8 @@ import 'package:breez/widgets/loader.dart';
 import 'package:flutter/material.dart';
 
 class CTPJoinSessionHandler {
-  CTPJoinSessionHandler(
-      UserProfileBloc userProfileBloc,
-      ConnectPayBloc ctpBloc,
-      BuildContext context,
-      Function(RemoteSession session) onValidSession,
-      Function(Object error) onError) {
+  CTPJoinSessionHandler(UserProfileBloc userProfileBloc, ConnectPayBloc ctpBloc, BuildContext context,
+      Function(RemoteSession session) onValidSession, Function(Object error) onError) {
     ctpBloc.sessionInvites.listen(
       (sessionLink) async {
         if (ctpBloc.currentSession?.sessionID != sessionLink.sessionID) {

--- a/lib/handlers/podcast_url_handler.dart
+++ b/lib/handlers/podcast_url_handler.dart
@@ -86,8 +86,7 @@ Future handleDeeplink(
           throw texts.handler_podcast_error_load_episode;
         } else if (blocState is BlocPopulatedState) {
           // Retrieve episode list and play matching episode
-          var episodeList = await podcastBloc.episodes
-              .firstWhere((episodeList) => episodeList.isNotEmpty);
+          var episodeList = await podcastBloc.episodes.firstWhere((episodeList) => episodeList.isNotEmpty);
           var episode = episodeList.firstWhere(
             (episode) => episode.guid == episodeID,
             orElse: () => null,

--- a/lib/handlers/received_invoice_notification.dart
+++ b/lib/handlers/received_invoice_notification.dart
@@ -37,7 +37,7 @@ class InvoiceNotificationsHandler {
     _receivedInvoicesStream.where((payreq) => payreq != null && !_handlingRequest).listen((payreq) async {
       final navigator = Navigator.of(_context);
       var account = await _accountBloc.accountStream.firstWhere((a) => !a.initial, orElse: () => null);
-      if (account == null || !account.connected) {
+      if (account == null) {
         return;
       }
       if (!payreq.loaded) {

--- a/lib/handlers/received_invoice_notification.dart
+++ b/lib/handlers/received_invoice_notification.dart
@@ -34,12 +34,9 @@ class InvoiceNotificationsHandler {
 
   _listenPaymentRequests() {
     // show payment request dialog for decoded requests
-    _receivedInvoicesStream
-        .where((payreq) => payreq != null && !_handlingRequest)
-        .listen((payreq) async {
+    _receivedInvoicesStream.where((payreq) => payreq != null && !_handlingRequest).listen((payreq) async {
       final navigator = Navigator.of(_context);
-      var account = await _accountBloc.accountStream
-          .firstWhere((a) => !a.initial, orElse: () => null);
+      var account = await _accountBloc.accountStream.firstWhere((a) => !a.initial, orElse: () => null);
       if (account == null || !account.connected) {
         return;
       }

--- a/lib/handlers/received_invoice_notification.dart
+++ b/lib/handlers/received_invoice_notification.dart
@@ -91,6 +91,7 @@ class InvoiceNotificationsHandler {
     if (error is PaymentRequestError) {
       showFlushbar(_context, message: error.message);
     }
+    _handlingRequest = false;
   }
 
   _setLoading(bool visible) {

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -55,11 +55,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
-final GlobalKey firstPaymentItemKey =
-    GlobalKey(debugLabel: "firstPaymentItemKey");
+final GlobalKey firstPaymentItemKey = GlobalKey(debugLabel: "firstPaymentItemKey");
 final ScrollController scrollController = ScrollController();
-final GlobalKey<ScaffoldState> _scaffoldKey =
-    GlobalKey<ScaffoldState>(debugLabel: "scaffoldKey");
+final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>(debugLabel: "scaffoldKey");
 
 class Home extends StatefulWidget {
   final AccountBloc accountBloc;
@@ -212,14 +210,9 @@ class HomeState extends State<Home> with WidgetsBindingObserver {
                 _onNavigationItemSelected,
                 _filterItems,
               ),
-              bottomNavigationBar: appMode == AppMode.balance
-                  ? BottomActionsBar(firstPaymentItemKey)
-                  : null,
-              floatingActionButton: appMode == AppMode.balance
-                  ? QrActionButton(firstPaymentItemKey)
-                  : null,
-              floatingActionButtonLocation:
-                  FloatingActionButtonLocation.centerDocked,
+              bottomNavigationBar: appMode == AppMode.balance ? BottomActionsBar(firstPaymentItemKey) : null,
+              floatingActionButton: appMode == AppMode.balance ? QrActionButton(firstPaymentItemKey) : null,
+              floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
               body: widget._screenBuilders[_activeScreen] ?? _homePage(appMode),
             );
           },
@@ -339,8 +332,7 @@ class HomeState extends State<Home> with WidgetsBindingObserver {
     SyncUIHandler(widget.accountBloc, context);
     ShowPinHandler(widget.userProfileBloc, context);
 
-    _accountNotificationsSubscription =
-        widget.accountBloc.accountNotificationsStream.listen(
+    _accountNotificationsSubscription = widget.accountBloc.accountNotificationsStream.listen(
       (data) => showFlushbar(context, message: data),
       onError: (e) => showFlushbar(context, message: e.toString()),
     );
@@ -448,15 +440,12 @@ class HomeState extends State<Home> with WidgetsBindingObserver {
           print('_listenPaymentResults processing: $paymentHash');
         }
 
-        if (!fulfilledPayment.cancelled &&
-            !fulfilledPayment.ignoreGlobalFeedback) {
+        if (!fulfilledPayment.cancelled && !fulfilledPayment.ignoreGlobalFeedback) {
           await scrollController
               .animateTo(scrollController.position.minScrollExtent,
-                  duration: const Duration(milliseconds: 10),
-                  curve: Curves.ease)
+                  duration: const Duration(milliseconds: 10), curve: Curves.ease)
               .whenComplete(() async {
-            var action =
-                fulfilledPayment?.paymentItem?.lnurlPayInfo?.successAction;
+            var action = fulfilledPayment?.paymentItem?.lnurlPayInfo?.successAction;
             if (action?.hasTag() == true) {
               await Future.delayed(
                 const Duration(seconds: 1),
@@ -489,8 +478,7 @@ class HomeState extends State<Home> with WidgetsBindingObserver {
         await widget.accountBloc.accountStream.first.then(
           (accountModel) async {
             final errorString = error.toDisplayMessage(accountModel.currency);
-            if (error.validationError &&
-                errorString.contains("payment is in transition")) {
+            if (error.validationError && errorString.contains("payment is in transition")) {
               return;
             }
             showFlushbar(context, message: errorString);

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -103,59 +103,61 @@ class HomeState extends State<Home> with WidgetsBindingObserver {
   @override
   void initState() {
     super.initState();
-    _hiddenRoutes.add("/get_refund");
-    widget.accountBloc.accountStream.listen((acc) {
-      setState(() {
-        if (acc != null &&
-            acc.swapFundsStatus.maturedRefundableAddresses.isNotEmpty) {
-          _hiddenRoutes.remove("/get_refund");
-        } else {
-          _hiddenRoutes.add("/get_refund");
-        }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _hiddenRoutes.add("/get_refund");
+      widget.accountBloc.accountStream.listen((acc) {
+        setState(() {
+          if (acc != null &&
+              acc.swapFundsStatus.maturedRefundableAddresses.isNotEmpty) {
+            _hiddenRoutes.remove("/get_refund");
+          } else {
+            _hiddenRoutes.add("/get_refund");
+          }
+        });
       });
-    });
 
-    widget.accountBloc.accountStream.listen((acc) {
-      var activeAccountRoutes = [
-        "/connect_to_pay",
-        "/pay_invoice",
-        "/create_invoice"
-      ];
-      Function addOrRemove =
-          acc.connected ? _hiddenRoutes.remove : _hiddenRoutes.add;
-      setState(() {
-        for (var r in activeAccountRoutes) {
-          addOrRemove(r);
-        }
+      widget.accountBloc.accountStream.listen((acc) {
+        var activeAccountRoutes = [
+          "/connect_to_pay",
+          "/pay_invoice",
+          "/create_invoice"
+        ];
+        Function addOrRemove =
+            acc.connected ? _hiddenRoutes.remove : _hiddenRoutes.add;
+        setState(() {
+          for (var r in activeAccountRoutes) {
+            addOrRemove(r);
+          }
+        });
       });
-    });
 
-    AudioService.notificationClicked.where((event) => event == true).listen(
-        (event) async {
-      final navigator = Navigator.of(context);
-      final userBloc = AppBlocsProvider.of<UserProfileBloc>(context);
-      final audioBloc = Provider.of<AudioBloc>(context, listen: false);
-      final userModel = await userBloc.userStream.first;
-      final nowPlaying = await audioBloc.nowPlaying.first.timeout(
-        const Duration(seconds: 1),
-      );
-      if (nowPlaying != null &&
-          !breezPodcast.NowPlayingTransport.nowPlayingVisible) {
-        navigator.push(
-          MaterialPageRoute<void>(
-            builder: (context) => withPodcastTheme(userModel, NowPlaying()),
-            fullscreenDialog: false,
-          ),
+      AudioService.notificationClicked.where((event) => event == true).listen(
+          (event) async {
+        final navigator = Navigator.of(context);
+        final userBloc = AppBlocsProvider.of<UserProfileBloc>(context);
+        final audioBloc = Provider.of<AudioBloc>(context, listen: false);
+        final userModel = await userBloc.userStream.first;
+        final nowPlaying = await audioBloc.nowPlaying.first.timeout(
+          const Duration(seconds: 1),
         );
-      }
-    }, onDone: () {
-      if (kDebugMode) {
-        print("done");
-      }
-    }, onError: (e) {
-      if (kDebugMode) {
-        print("error $e");
-      }
+        if (nowPlaying != null &&
+            !breezPodcast.NowPlayingTransport.nowPlayingVisible) {
+          navigator.push(
+            MaterialPageRoute<void>(
+              builder: (context) => withPodcastTheme(userModel, NowPlaying()),
+              fullscreenDialog: false,
+            ),
+          );
+        }
+      }, onDone: () {
+        if (kDebugMode) {
+          print("done");
+        }
+      }, onError: (e) {
+        if (kDebugMode) {
+          print("error $e");
+        }
+      });
     });
   }
 

--- a/lib/l10n/locales.dart
+++ b/lib/l10n/locales.dart
@@ -11,13 +11,11 @@ class AnytimeFallbackLocalizationDelegate extends LocalizationsDelegate<L> {
   @override
   bool isSupported(Locale locale) =>
       supportedLocales().any((l) => l.languageCode == locale.languageCode) &&
-      anytime_texts.AppLocalizations.supportedLocales
-          .any((l) => l.languageCode == locale.languageCode);
+      anytime_texts.AppLocalizations.supportedLocales.any((l) => l.languageCode == locale.languageCode);
 
   // Fallback to English if Breez's supported locale is not supported by Anytime
   @override
-  Future<L> load(Locale locale) =>
-      SynchronousFuture(L.load(const Locale('en', ''), null));
+  Future<L> load(Locale locale) => SynchronousFuture(L.load(const Locale('en', ''), null));
 
   @override
   bool shouldReload(old) => false;

--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -95,8 +95,8 @@ class BreezLogger {
 
   String _recordToString(LogRecord record) =>
       "[${record.loggerName}] {${record.level.name}} (${_formatTime(record.time)}) : ${record.message}"
-          "${record.error != null ? "\n${record.error}" : ""}"
-          "${record.stackTrace != null ? "\n${record.stackTrace}" : ""}";
+      "${record.error != null ? "\n${record.error}" : ""}"
+      "${record.stackTrace != null ? "\n${record.stackTrace}" : ""}";
 
   String _formatTime(DateTime time) => time.toUtc().toIso8601String();
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,8 +35,7 @@ void main() async {
   runZonedGuarded(() async {
     WidgetsFlutterBinding.ensureInitialized();
     BreezLogger();
-    SystemChrome.setPreferredOrientations(
-        [DeviceOrientation.portraitUp, DeviceOrientation.portraitDown]);
+    SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp, DeviceOrientation.portraitDown]);
     //initializeDateFormatting(Platform.localeName, null);
     BreezDateUtils.setupLocales();
     var mobileService = await MobileSettingsService.instance();
@@ -74,8 +73,7 @@ void main() async {
                             builder: sharePodcastButtonBuilder,
                             child: ShareEpisodeButtonBuilder(
                                 builder: shareEpisodeButtonBuilder,
-                                child:
-                                    UserApp(repository.reloadDatabaseSink))))),
+                                child: UserApp(repository.reloadDatabaseSink))))),
               ))));
     });
   }, (error, stackTrace) async {
@@ -102,31 +100,24 @@ void _configureEasyLoading() {
 }
 
 Future runMigration(SharedPreferences preferences) async {
-  var userJson =
-      preferences.getString(UserProfileBloc.USER_DETAILS_PREFERENCES_KEY);
+  var userJson = preferences.getString(UserProfileBloc.USER_DETAILS_PREFERENCES_KEY);
   Map<String, dynamic> userData = json.decode(userJson ?? "{}");
 
-  var backupJson =
-      preferences.getString(BackupBloc.BACKUP_SETTINGS_PREFERENCES_KEY);
+  var backupJson = preferences.getString(BackupBloc.BACKUP_SETTINGS_PREFERENCES_KEY);
   Map<String, dynamic> backupData = json.decode(backupJson ?? "{}");
 
-  if (userData["securityModel"] != null &&
-      userData["securityModel"]["secureBackupWithPin"] == true) {
+  if (userData["securityModel"] != null && userData["securityModel"]["secureBackupWithPin"] == true) {
     backupData["backupKeyType"] = BackupKeyType.PIN.index;
     userData["securityModel"]["secureBackupWithPin"] = null;
-    await preferences.setString(
-        BackupBloc.BACKUP_SETTINGS_PREFERENCES_KEY, json.encode(backupData));
-    await preferences.setString(
-        UserProfileBloc.USER_DETAILS_PREFERENCES_KEY, json.encode(userData));
+    await preferences.setString(BackupBloc.BACKUP_SETTINGS_PREFERENCES_KEY, json.encode(backupData));
+    await preferences.setString(UserProfileBloc.USER_DETAILS_PREFERENCES_KEY, json.encode(userData));
   }
 
   // last backup time migration
-  var legacyBackupTime =
-      preferences.getInt(BackupBloc.LAST_BACKUP_TIME_PREFERENCE_KEY);
+  var legacyBackupTime = preferences.getInt(BackupBloc.LAST_BACKUP_TIME_PREFERENCE_KEY);
   if (legacyBackupTime != null) {
     Map<String, dynamic> backupStateData = {"lastBackupTime": legacyBackupTime};
-    await preferences.setString(BackupBloc.LAST_BACKUP_STATE_PREFERENCE_KEY,
-        json.encode(backupStateData));
+    await preferences.setString(BackupBloc.LAST_BACKUP_STATE_PREFERENCE_KEY, json.encode(backupStateData));
     await preferences.remove(BackupBloc.LAST_BACKUP_TIME_PREFERENCE_KEY);
   }
 }

--- a/lib/routes/account_required_actions.dart
+++ b/lib/routes/account_required_actions.dart
@@ -36,8 +36,7 @@ class AccountRequiredActionsIndicator extends StatefulWidget {
   }
 }
 
-class AccountRequiredActionsIndicatorState
-    extends State<AccountRequiredActionsIndicator> {
+class AccountRequiredActionsIndicatorState extends State<AccountRequiredActionsIndicator> {
   StreamSubscription<dynamic> _promptBackupSubscription;
   bool showingBackupDialog = false;
 
@@ -131,11 +130,8 @@ class AccountRequiredActionsIndicatorState
     int currentTimestamp = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     for (var l in lspList) {
       if (activity.containsKey(l.lspID) &&
-          ((currentTimestamp - activity[l.lspID].toInt()) >
-              4 * (l.maxInactiveDuration ~/ 5))) {
-        if ((warningDuration == 0) ||
-            (warningDuration >
-                (currentTimestamp - activity[l.lspID].toInt()))) {
+          ((currentTimestamp - activity[l.lspID].toInt()) > 4 * (l.maxInactiveDuration ~/ 5))) {
+        if ((warningDuration == 0) || (warningDuration > (currentTimestamp - activity[l.lspID].toInt()))) {
           warningDuration = (currentTimestamp - activity[l.lspID].toInt());
         }
       }
@@ -155,8 +151,8 @@ class AccountRequiredActionsIndicatorState
       streamC: accountBloc.accountStream,
       streamD: accountBloc.lspActivityStream,
       streamE: backupBloc.backupStateStream,
-      builder: (context, lspStatusSnapshot, settingsSnapshot, accountSnapshot,
-          lspActivitySnapshot, backupSnapshot) {
+      builder: (context, lspStatusSnapshot, settingsSnapshot, accountSnapshot, lspActivitySnapshot,
+          backupSnapshot) {
         final lspStatus = lspStatusSnapshot.data;
         final accountSettings = settingsSnapshot.data;
         final accountModel = accountSnapshot.data;
@@ -332,8 +328,7 @@ class WarningAction extends StatefulWidget {
   }
 }
 
-class WarningActionState extends State<WarningAction>
-    with SingleTickerProviderStateMixin {
+class WarningActionState extends State<WarningAction> with SingleTickerProviderStateMixin {
   Animation<double> _animation;
   AnimationController _animationController;
 

--- a/lib/routes/add_funds/address_widget.dart
+++ b/lib/routes/add_funds/address_widget.dart
@@ -63,8 +63,7 @@ class AddressWidget extends StatelessWidget {
                           ServiceInjector().device.setClipboardText(address);
                           showFlushbar(
                             context,
-                            message: texts
-                                .invoice_btc_address_deposit_address_copied,
+                            message: texts.invoice_btc_address_deposit_address_copied,
                           );
                         },
                         child: Text(

--- a/lib/routes/add_funds/deposit_to_btc_address_page.dart
+++ b/lib/routes/add_funds/deposit_to_btc_address_page.dart
@@ -66,9 +66,7 @@ class DepositToBTCAddressPageState extends State<DepositToBTCAddressPage> {
                         accSnapshot.data,
                         snapshot.data,
                         lspSnapshot.data,
-                        snapshot.hasError
-                            ? texts.invoice_btc_address_network_error
-                            : null,
+                        snapshot.hasError ? texts.invoice_btc_address_network_error : null,
                       ),
                       bottomNavigationBar: _buildBottomBar(
                         context,
@@ -160,9 +158,7 @@ class DepositToBTCAddressPageState extends State<DepositToBTCAddressPage> {
     Int64 maxAllowedDeposit,
   ) {
     final connected = accountModel.connected;
-    final minFees = (lspInfo != null)
-        ? lspInfo.longestValidOpeningFeeParams.minMsat ~/ 1000
-        : Int64(0);
+    final minFees = (lspInfo != null) ? lspInfo.longestValidOpeningFeeParams.minMsat ~/ 1000 : Int64(0);
     final showMinFeeMessage = minFees > 0;
     final minFeeFormatted = accountModel.currency.format(minFees);
     final minSats = accountModel.currency.format(
@@ -176,13 +172,11 @@ class DepositToBTCAddressPageState extends State<DepositToBTCAddressPage> {
       maxAllowedDeposit,
       includeDisplayName: true,
     );
-    final setUpFee =
-        (lspInfo.longestValidOpeningFeeParams.proportional / 10000).toString();
+    final setUpFee = (lspInfo.longestValidOpeningFeeParams.proportional / 10000).toString();
     final liquidity = accountModel.currency.format(
       connected ? accountModel.maxInboundLiquidity : Int64(0),
     );
-    final bool showFeeMessage =
-        maxAllowedDeposit > accountModel.maxInboundLiquidity;
+    final bool showFeeMessage = maxAllowedDeposit > accountModel.maxInboundLiquidity;
 
     if (!showFeeMessage) {
       return texts.invoice_btc_address_channel_not_needed(minSats, maxSats);
@@ -195,24 +189,21 @@ class DepositToBTCAddressPageState extends State<DepositToBTCAddressPage> {
         liquidity,
       );
     } else if (connected && !showMinFeeMessage) {
-      return texts
-          .invoice_btc_address_warning_without_min_fee_account_connected(
+      return texts.invoice_btc_address_warning_without_min_fee_account_connected(
         minSats,
         maxSats,
         setUpFee,
         liquidity,
       );
     } else if (!connected && showMinFeeMessage) {
-      return texts
-          .invoice_btc_address_warning_with_min_fee_account_not_connected(
+      return texts.invoice_btc_address_warning_with_min_fee_account_not_connected(
         minSats,
         maxSats,
         setUpFee,
         minFeeFormatted,
       );
     } else {
-      return texts
-          .invoice_btc_address_warning_without_min_fee_account_not_connected(
+      return texts.invoice_btc_address_warning_without_min_fee_account_not_connected(
         minSats,
         maxSats,
         setUpFee,
@@ -224,9 +215,7 @@ class DepositToBTCAddressPageState extends State<DepositToBTCAddressPage> {
     LSPInfo lspInfo,
     Int64 minAllowedDeposit,
   ) {
-    final minFees = (lspInfo != null)
-        ? lspInfo.cheapestOpeningFeeParams.minMsat ~/ 1000
-        : Int64(0);
+    final minFees = (lspInfo != null) ? lspInfo.cheapestOpeningFeeParams.minMsat ~/ 1000 : Int64(0);
     if (minAllowedDeposit == null) return minFees;
     if (minFees > minAllowedDeposit) return minFees;
     return minAllowedDeposit;
@@ -242,9 +231,7 @@ class DepositToBTCAddressPageState extends State<DepositToBTCAddressPage> {
 
     if (hasError || response?.errorMessage?.isNotEmpty == true) {
       return SingleButtonBottomBar(
-        text: hasError
-            ? texts.invoice_btc_address_action_retry
-            : texts.invoice_btc_address_action_close,
+        text: hasError ? texts.invoice_btc_address_action_retry : texts.invoice_btc_address_action_close,
         onPressed: () {
           if (hasError) {
             _addFundsBloc.addFundRequestSink.add(AddFundsInfo(true, false));

--- a/lib/routes/add_funds/moonpay_webview.dart
+++ b/lib/routes/add_funds/moonpay_webview.dart
@@ -32,6 +32,7 @@ class MoonpayWebViewState extends State<MoonpayWebView> {
 
   @override
   void didChangeDependencies() {
+    super.didChangeDependencies();
     if (!_isInit) {
       _addFundsBloc = BlocProvider.of<AddFundsBloc>(context);
       _addFundsBloc.addFundRequestSink.add(AddFundsInfo(false, false));
@@ -49,7 +50,6 @@ class MoonpayWebViewState extends State<MoonpayWebView> {
 
       _isInit = true;
     }
-    super.didChangeDependencies();
   }
 
   @override

--- a/lib/routes/admin_login_dialog.dart
+++ b/lib/routes/admin_login_dialog.dart
@@ -84,9 +84,7 @@ class _AdminLoginDialogState extends State<_AdminLoginDialog> {
           hintColor: themeData.dialogTheme.contentTextStyle.color,
           colorScheme: ColorScheme.dark(
             primary: themeData.textTheme.labelLarge.color,
-            error: theme.themeId == "BLUE"
-                ? Colors.red
-                : themeData.colorScheme.error,
+            error: theme.themeId == "BLUE" ? Colors.red : themeData.colorScheme.error,
           ),
           primaryColor: themeData.textTheme.labelLarge.color,
         ),

--- a/lib/routes/charge/cart/cart_bar_drop_down_button.dart
+++ b/lib/routes/charge/cart/cart_bar_drop_down_button.dart
@@ -52,8 +52,7 @@ class CartBarDropDownButton extends StatelessWidget {
     );
     _log.info('Currencies after first addition: [${_fold(currencies)}]');
     currencies.addAll(
-      accountModel.preferredFiatConversionList
-          .map((f) => CurrencyWrapper.fromFiat(f)),
+      accountModel.preferredFiatConversionList.map((f) => CurrencyWrapper.fromFiat(f)),
     );
     _log.info('Currencies after second addition: [${_fold(currencies)}]');
     final dropDownItems = currencies.map(
@@ -65,7 +64,6 @@ class CartBarDropDownButton extends StatelessWidget {
   }
 
   String _fold(List<CurrencyWrapper> currencies) {
-    return currencies.fold(
-        "", (p, e) => p.isEmpty ? e.shortName : "$p, ${e.shortName}");
+    return currencies.fold("", (p, e) => p.isEmpty ? e.shortName : "$p, ${e.shortName}");
   }
 }

--- a/lib/routes/charge/currency_wrapper.dart
+++ b/lib/routes/charge/currency_wrapper.dart
@@ -52,8 +52,7 @@ class CurrencyWrapper {
     return fiat.satConversionRate;
   }
 
-  RegExp get whitelistedPattern =>
-      btc?.whitelistedPattern ?? fiat.whitelistedPattern;
+  RegExp get whitelistedPattern => btc?.whitelistedPattern ?? fiat.whitelistedPattern;
 
   String format(
     double value, {

--- a/lib/routes/charge/items/item_avatar.dart
+++ b/lib/routes/charge/items/item_avatar.dart
@@ -10,8 +10,7 @@ class ItemAvatar extends StatelessWidget {
   final String itemName;
   final bool useDecoration;
 
-  const ItemAvatar(this.avatarURL,
-      {Key key, this.radius = 20.0, this.itemName, this.useDecoration = false})
+  const ItemAvatar(this.avatarURL, {Key key, this.radius = 20.0, this.itemName, this.useDecoration = false})
       : super(key: key);
 
   @override
@@ -93,11 +92,9 @@ class _IconAvatar extends StatelessWidget {
       decoration: useDecoration
           ? BoxDecoration(
               shape: BoxShape.circle,
-              border: Border.all(
-                  color: Colors.white, width: 1.0, style: BorderStyle.solid),
+              border: Border.all(color: Colors.white, width: 1.0, style: BorderStyle.solid),
               image: DecorationImage(
-                  colorFilter: ColorFilter.mode(
-                      Theme.of(context).primaryColorLight, BlendMode.srcATop),
+                  colorFilter: ColorFilter.mode(Theme.of(context).primaryColorLight, BlendMode.srcATop),
                   image: const AssetImage("src/images/avatarbg.png"),
                   fit: BoxFit.cover))
           : null,
@@ -158,11 +155,9 @@ class _UnknownAvatar extends StatelessWidget {
       decoration: useDecoration
           ? BoxDecoration(
               shape: BoxShape.circle,
-              border: Border.all(
-                  color: Colors.white, width: 1.0, style: BorderStyle.solid),
+              border: Border.all(color: Colors.white, width: 1.0, style: BorderStyle.solid),
               image: DecorationImage(
-                  colorFilter: ColorFilter.mode(
-                      Theme.of(context).primaryColorLight, BlendMode.srcATop),
+                  colorFilter: ColorFilter.mode(Theme.of(context).primaryColorLight, BlendMode.srcATop),
                   image: const AssetImage("src/images/avatarbg.png"),
                   fit: BoxFit.cover))
           : null,
@@ -184,11 +179,7 @@ class _UnknownAvatar extends StatelessWidget {
   String _getFirstTwoLetters() {
     var whitespaceRemovedName = itemName.replaceAll(RegExp(r"\s+\b|\b\s"), "");
     return whitespaceRemovedName
-        .substring(
-            0,
-            whitespaceRemovedName.length >= 2
-                ? 2
-                : whitespaceRemovedName.length)
+        .substring(0, whitespaceRemovedName.length >= 2 ? 2 : whitespaceRemovedName.length)
         .trim();
   }
 }

--- a/lib/routes/charge/items/item_avatar_picker.dart
+++ b/lib/routes/charge/items/item_avatar_picker.dart
@@ -164,9 +164,7 @@ class ItemAvatarPickerState extends State<ItemAvatarPicker> {
               contentPadding: const EdgeInsets.only(top: 16, left: 16),
               suffixIcon: IconButton(
                 icon: Icon(
-                  _imageFilterController.text.isEmpty
-                      ? Icons.search
-                      : Icons.close,
+                  _imageFilterController.text.isEmpty ? Icons.search : Icons.close,
                   size: 20,
                 ),
                 onPressed: _imageFilterController.text.isEmpty

--- a/lib/routes/charge/items/item_page.dart
+++ b/lib/routes/charge/items/item_page.dart
@@ -198,8 +198,8 @@ class ItemPageState extends State<ItemPage> {
         FilteringTextInputFormatter.allow(
           _selectedCurrency.whitelistedPattern,
         ),
-        TextInputFormatter.withFunction((oldValue, newValue) =>
-            newValue.copyWith(text: newValue.text.replaceAll(',', '.'))),
+        TextInputFormatter.withFunction(
+            (oldValue, newValue) => newValue.copyWith(text: newValue.text.replaceAll(',', '.'))),
       ],
       controller: _priceController,
       decoration: InputDecoration(
@@ -396,17 +396,13 @@ class ItemPageState extends State<ItemPage> {
       ),
       body: body,
       bottomNavigationBar: SingleButtonBottomBar(
-        text: widget.item != null
-            ? texts.pos_invoice_item_management_title_save
-            : _title.toUpperCase(),
+        text: widget.item != null ? texts.pos_invoice_item_management_title_save : _title.toUpperCase(),
         onPressed: () {
           if (_formKey.currentState.validate()) {
             if (widget.item != null) {
               UpdateItem updateItem = UpdateItem(
                 widget.item.copyWith(
-                  imageURL: _itemImage != null && _itemImage.isNotEmpty
-                      ? _itemImage
-                      : null,
+                  imageURL: _itemImage != null && _itemImage.isNotEmpty ? _itemImage : null,
                   name: _nameController.text.trimRight(),
                   currency: _selectedCurrency.shortName,
                   price: double.parse(_priceController.text),

--- a/lib/routes/charge/items/item_page.dart
+++ b/lib/routes/charge/items/item_page.dart
@@ -52,6 +52,7 @@ class ItemPageState extends State<ItemPage> {
 
   @override
   void didChangeDependencies() {
+    super.didChangeDependencies();
     if (!_isInit) {
       final texts = context.texts();
       _accountBloc = AppBlocsProvider.of<AccountBloc>(context);
@@ -99,7 +100,6 @@ class ItemPageState extends State<ItemPage> {
       _nameController.addListener(() => setState(() {}));
       _isInit = true;
     }
-    super.didChangeDependencies();
   }
 
   @override

--- a/lib/routes/charge/items/items_list.dart
+++ b/lib/routes/charge/items/items_list.dart
@@ -11,8 +11,7 @@ class ItemsList extends StatelessWidget {
   final List<Item> _items;
   final Function(Item item, GlobalKey avatarKey) _addItem;
 
-  const ItemsList(
-      this.accountModel, this.posCatalogBloc, this._items, this._addItem);
+  const ItemsList(this.accountModel, this.posCatalogBloc, this._items, this._addItem);
 
   @override
   Widget build(BuildContext context) {
@@ -21,8 +20,8 @@ class ItemsList extends StatelessWidget {
         shrinkWrap: true,
         primary: false,
         itemBuilder: (BuildContext context, int index) {
-          return CatalogItem(accountModel, posCatalogBloc, _items[index],
-              _items.length - 1 == index, _addItem);
+          return CatalogItem(
+              accountModel, posCatalogBloc, _items[index], _items.length - 1 == index, _addItem);
         });
   }
 }

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -156,6 +156,7 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: themeData.appBarTheme.systemOverlayStyle.copyWith(
         systemNavigationBarColor: themeData.colorScheme.background,
+        systemNavigationBarIconBrightness: Brightness.dark,
       ),
       child: Scaffold(
         body: StreamBuilder<Sale>(

--- a/lib/routes/charge/pos_invoice.dart
+++ b/lib/routes/charge/pos_invoice.dart
@@ -89,9 +89,8 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
     if (accountSubscription == null) {
       AccountBloc accountBloc = AppBlocsProvider.of<AccountBloc>(context);
       accountSubscription = accountBloc.accountStream.listen((acc) {
-        currentCurrency =
-            CurrencyWrapper.fromShortName(acc.posCurrencyShortName, acc) ??
-                CurrencyWrapper.fromBTC(Currency.SAT);
+        currentCurrency = CurrencyWrapper.fromShortName(acc.posCurrencyShortName, acc) ??
+            CurrencyWrapper.fromBTC(Currency.SAT);
       });
 
       FetchRates fetchRatesAction = FetchRates();
@@ -121,8 +120,7 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
         }
 
         // if the current pending item does not exist, then it was removed.
-        if (s.saleLines.firstWhere(
-                (s) => s.isCustom && s.itemName == currentPendingItem.itemName,
+        if (s.saleLines.firstWhere((s) => s.isCustom && s.itemName == currentPendingItem.itemName,
                 orElse: () => null) ==
             null) {
           setState(() {
@@ -245,8 +243,7 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
     if (persistedCurrency == null && rates.isEmpty) {
       return const Center(child: Loader());
     }
-    final totalAmount =
-        currentSale.totalChargeSat / currentCurrency.satConversionRate;
+    final totalAmount = currentSale.totalChargeSat / currentCurrency.satConversionRate;
 
     return Stack(
       children: [
@@ -277,16 +274,14 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
                         try {
                           navigator.push(loaderRoute);
 
-                          final tempFees =
-                              lspStatus.currentLSP.cheapestOpeningFeeParams;
+                          final tempFees = lspStatus.currentLSP.cheapestOpeningFeeParams;
                           fetchLSPList(lspBloc).then(
                             (lspList) {
                               if (loaderRoute.isActive) {
                                 navigator.removeRoute(loaderRoute);
                               }
                               var refreshedLSP = lspList.firstWhere(
-                                (lsp) =>
-                                    lsp.lspID == lspStatus.currentLSP.lspID,
+                                (lsp) => lsp.lspID == lspStatus.currentLSP.lspID,
                               );
                               // Show fee dialog if necessary and submit invoice
                               showSetupFeesDialog(
@@ -460,16 +455,12 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
       items: [
         ViewSwitchItem(
           texts.pos_invoice_tab_keypad,
-          () => AppBlocsProvider.of<PosCatalogBloc>(context)
-              .actionsSink
-              .add(UpdatePosSelectedTab("KEYPAD")),
+          () => AppBlocsProvider.of<PosCatalogBloc>(context).actionsSink.add(UpdatePosSelectedTab("KEYPAD")),
           iconData: Icons.dialpad,
         ),
         ViewSwitchItem(
           texts.pos_invoice_tab_items,
-          () => AppBlocsProvider.of<PosCatalogBloc>(context)
-              .actionsSink
-              .add(UpdatePosSelectedTab("ITEMS")),
+          () => AppBlocsProvider.of<PosCatalogBloc>(context).actionsSink.add(UpdatePosSelectedTab("ITEMS")),
           iconData: Icons.playlist_add,
         ),
       ],
@@ -892,8 +883,8 @@ class POSInvoiceState extends State<POSInvoice> with TickerProviderStateMixin {
     });
   }
 
-  void _changeCurrency(Sale currentSale, String value,
-      UserProfileBloc userProfileBloc, CurrencyWrapper currentCurrency) {
+  void _changeCurrency(
+      Sale currentSale, String value, UserProfileBloc userProfileBloc, CurrencyWrapper currentCurrency) {
     _log.info("_changeCurrency from ${currentCurrency.shortName} to $value");
     if (currentCurrency.shortName.toUpperCase() == value) {
       return;

--- a/lib/routes/charge/pos_invoice_cart_bar.dart
+++ b/lib/routes/charge/pos_invoice_cart_bar.dart
@@ -95,9 +95,7 @@ class _PosInvoiceCartBarState extends State<PosInvoiceCartBar> {
                 child: Padding(
                   padding: const EdgeInsets.only(left: 8.0),
                   child: Text(
-                    widget.isKeypadView
-                        ? widget.currentCurrency.format(widget.currentAmount)
-                        : "",
+                    widget.isKeypadView ? widget.currentCurrency.format(widget.currentAmount) : "",
                     maxLines: 1,
                     style: theme.invoiceAmountStyle.copyWith(
                       color: themeData.textTheme.headlineSmall.color,

--- a/lib/routes/charge/pos_invoice_items_view.dart
+++ b/lib/routes/charge/pos_invoice_items_view.dart
@@ -137,9 +137,7 @@ class PosInvoiceItemsView extends StatelessWidget {
         final themeData = Theme.of(context);
         final newOption = await showMenu(
           context: context,
-          color: theme.themeId == "BLUE"
-              ? themeData.canvasColor
-              : themeData.colorScheme.background,
+          color: theme.themeId == "BLUE" ? themeData.canvasColor : themeData.colorScheme.background,
           position: RelativeRect.fromLTRB(offset.dx, offset.dy, 0, 0),
           items: items.map((e) => _dropdownItem(context, e, sort)).toList(),
         );

--- a/lib/routes/charge/pos_payment_dialog.dart
+++ b/lib/routes/charge/pos_payment_dialog.dart
@@ -86,8 +86,7 @@ class PosPaymentDialogState extends State<PosPaymentDialog> {
       }
     });
 
-    _paidInvoiceSubscription =
-        widget._invoiceBloc.paidInvoicesStream.listen((paidRequest) {
+    _paidInvoiceSubscription = widget._invoiceBloc.paidInvoicesStream.listen((paidRequest) {
       setState(() {
         if (paidRequest.paymentHash == widget.paymentRequest.paymentHash) {
           Navigator.of(context).pop(const PosPaymentResult(paid: true));
@@ -95,8 +94,7 @@ class PosPaymentDialogState extends State<PosPaymentDialog> {
       });
     });
 
-    _nfcInvoiceSubscription =
-        widget._lnUrlBloc.nfcWithdrawStream.listen(_listenNfcWithdraw);
+    _nfcInvoiceSubscription = widget._lnUrlBloc.nfcWithdrawStream.listen(_listenNfcWithdraw);
 
     widget._lnUrlBloc.actionsSink.add(RegisterNfcSaleRequest(
       Int64(widget.satAmount.toInt()),
@@ -188,9 +186,7 @@ class PosPaymentDialogState extends State<PosPaymentDialog> {
               color: themeData.primaryTextTheme.labelLarge.color,
               tooltip: texts.pos_dialog_invoice_copy,
               onPressed: () {
-                ServiceInjector()
-                    .device
-                    .setClipboardText(widget.paymentRequest.rawPayReq);
+                ServiceInjector().device.setClipboardText(widget.paymentRequest.rawPayReq);
                 showFlushbar(
                   context,
                   message: texts.pos_dialog_invoice_copied,
@@ -212,11 +208,8 @@ class PosPaymentDialogState extends State<PosPaymentDialog> {
     final texts = context.texts();
 
     final lspFee = widget.paymentRequest.lspFee;
-    var saleCurrency = CurrencyWrapper.fromShortName(
-        widget._user.posCurrencyShortName, account);
-    var userCurrency = (saleCurrency.isFiat)
-        ? CurrencyWrapper.fromBTC(Currency.SAT)
-        : saleCurrency;
+    var saleCurrency = CurrencyWrapper.fromShortName(widget._user.posCurrencyShortName, account);
+    var userCurrency = (saleCurrency.isFiat) ? CurrencyWrapper.fromBTC(Currency.SAT) : saleCurrency;
     var priceInSaleCurrency = "";
     if (saleCurrency.isFiat) {
       String salePrice = saleCurrency.format(
@@ -224,8 +217,7 @@ class PosPaymentDialogState extends State<PosPaymentDialog> {
         includeCurrencySymbol: true,
         removeTrailingZeros: true,
       );
-      priceInSaleCurrency =
-          saleCurrency.rtl ? "($salePrice) " : " ($salePrice)";
+      priceInSaleCurrency = saleCurrency.rtl ? "($salePrice) " : " ($salePrice)";
     }
 
     return SingleChildScrollView(

--- a/lib/routes/charge/sale_view.dart
+++ b/lib/routes/charge/sale_view.dart
@@ -60,6 +60,7 @@ class SaleViewState extends State<SaleView> {
 
   @override
   void didChangeDependencies() {
+    super.didChangeDependencies();
     if (_currentSaleSubscription == null) {
       if (!widget.readOnly) {
         final posCatalogBloc = AppBlocsProvider.of<PosCatalogBloc>(context);
@@ -83,7 +84,6 @@ class SaleViewState extends State<SaleView> {
         _noteController.text = widget.readOnlySale.note;
       }
     }
-    super.didChangeDependencies();
   }
 
   @override

--- a/lib/routes/charge/sale_view.dart
+++ b/lib/routes/charge/sale_view.dart
@@ -64,8 +64,7 @@ class SaleViewState extends State<SaleView> {
     if (_currentSaleSubscription == null) {
       if (!widget.readOnly) {
         final posCatalogBloc = AppBlocsProvider.of<PosCatalogBloc>(context);
-        _currentSaleSubscription =
-            posCatalogBloc.currentSaleStream.listen((sale) {
+        _currentSaleSubscription = posCatalogBloc.currentSaleStream.listen((sale) {
           setState(() {
             bool updateNote = saleInProgress == null;
             saleInProgress = sale;
@@ -92,8 +91,7 @@ class SaleViewState extends State<SaleView> {
     super.dispose();
   }
 
-  bool get showNote =>
-      !widget.readOnly || widget.readOnlySale.note?.isNotEmpty == true;
+  bool get showNote => !widget.readOnly || widget.readOnlySale.note?.isNotEmpty == true;
 
   @override
   Widget build(BuildContext context) {
@@ -109,8 +107,7 @@ class SaleViewState extends State<SaleView> {
           return const Loader();
         }
 
-        CurrencyWrapper saleCurrency =
-            widget.saleCurrency ?? CurrencyWrapper.fromBTC(Currency.SAT);
+        CurrencyWrapper saleCurrency = widget.saleCurrency ?? CurrencyWrapper.fromBTC(Currency.SAT);
         String title = texts.sale_view_title;
         if (widget.salePayment != null) {
           title = BreezDateUtils.formatYearMonthDayHourMinute(
@@ -171,9 +168,7 @@ class SaleViewState extends State<SaleView> {
           ),
           bottomNavigationBar: Container(
             decoration: BoxDecoration(
-              color: theme.themeId == "BLUE"
-                  ? themeData.colorScheme.background
-                  : themeData.canvasColor,
+              color: theme.themeId == "BLUE" ? themeData.colorScheme.background : themeData.canvasColor,
               boxShadow: [
                 BoxShadow(
                   color: Colors.black.withOpacity(0.3),
@@ -413,12 +408,10 @@ class SaleLinesList extends StatelessWidget {
         //primary: false,
         itemBuilder: (context, index) {
           return ListTileTheme(
-            textColor: theme.themeId == "BLUE"
-                ? themeData.canvasColor
-                : themeData.textTheme.titleMedium.color,
-            iconColor: theme.themeId == "BLUE"
-                ? themeData.canvasColor
-                : themeData.textTheme.titleMedium.color,
+            textColor:
+                theme.themeId == "BLUE" ? themeData.canvasColor : themeData.textTheme.titleMedium.color,
+            iconColor:
+                theme.themeId == "BLUE" ? themeData.canvasColor : themeData.textTheme.titleMedium.color,
             child: Column(
               children: [
                 SaleLineWidget(
@@ -428,8 +421,7 @@ class SaleLinesList extends StatelessWidget {
                       : () => posCatalogBloc.actionsSink.add(
                             SetCurrentSale(
                               currentSale.copyWith(
-                                saleLines: currentSale.saleLines
-                                  ..removeAt(index),
+                                saleLines: currentSale.saleLines..removeAt(index),
                               ),
                             ),
                           ),
@@ -537,9 +529,8 @@ class SaleLineWidget extends StatelessWidget {
                 child: Text(
                   saleLine.quantity.toString(),
                   style: TextStyle(
-                    color: theme.themeId == "BLUE"
-                        ? Colors.black.withOpacity(0.7)
-                        : listTileThemeData.textColor,
+                    color:
+                        theme.themeId == "BLUE" ? Colors.black.withOpacity(0.7) : listTileThemeData.textColor,
                     fontSize: 18.0,
                   ),
                 ),
@@ -551,13 +542,9 @@ class SaleLineWidget extends StatelessWidget {
                     iconSize: 22.0,
                     color: iconColor,
                     icon: Icon(
-                      saleLine.quantity == 1
-                          ? Icons.delete_outline
-                          : Icons.remove,
+                      saleLine.quantity == 1 ? Icons.delete_outline : Icons.remove,
                     ),
-                    onPressed: () => saleLine.quantity == 1
-                        ? onDelete()
-                        : onChangeQuantity(-1),
+                    onPressed: () => saleLine.quantity == 1 ? onDelete() : onChangeQuantity(-1),
                   ),
           ],
         ),
@@ -583,9 +570,7 @@ class CurrencyDisplay extends StatelessWidget {
     double priceInFiat = saleLine.totalFiat;
     double priceInSats = saleLine.totalSats;
     TextStyle textStyle = TextStyle(
-      color: ListTileTheme.of(context)
-          .textColor
-          .withOpacity(theme.themeId == "BLUE" ? 0.75 : 0.5),
+      color: ListTileTheme.of(context).textColor.withOpacity(theme.themeId == "BLUE" ? 0.75 : 0.5),
     );
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,

--- a/lib/routes/charge/successful_payment.dart
+++ b/lib/routes/charge/successful_payment.dart
@@ -16,8 +16,7 @@ class SuccessfulPaymentRoute extends StatefulWidget {
   }
 }
 
-class SuccessfulPaymentRouteState extends State<SuccessfulPaymentRoute>
-    with WidgetsBindingObserver {
+class SuccessfulPaymentRouteState extends State<SuccessfulPaymentRoute> with WidgetsBindingObserver {
   Future _showFuture;
 
   @override

--- a/lib/routes/close_channels/coop_close_channels_dialog.dart
+++ b/lib/routes/close_channels/coop_close_channels_dialog.dart
@@ -91,8 +91,7 @@ class _CoopCloseChannelsDialogState extends State<CoopCloseChannelsDialog> {
                 child: Image.asset(
                   loaderThemeData.loaderAssetPath,
                   height: 64.0,
-                  colorBlendMode:
-                      loaderThemeData.loaderColorBlendMode ?? BlendMode.srcIn,
+                  colorBlendMode: loaderThemeData.loaderColorBlendMode ?? BlendMode.srcIn,
                   gaplessPlayback: true,
                 ),
               ),
@@ -115,16 +114,14 @@ class _CoopCloseChannelsDialogState extends State<CoopCloseChannelsDialog> {
                             );
                           } catch (e) {
                             final RenderBox box = context.findRenderObject();
-                            final offset =
-                                box.localToGlobal(Offset.zero) & box.size;
+                            final offset = box.localToGlobal(Offset.zero) & box.size;
                             final rect = Rect.fromPoints(
                               offset.topLeft,
                               offset.bottomRight,
                             );
                             Share.share(
                               "contact@breez.technology",
-                              subject: texts
-                                  .close_channels_dialog_failure_message_middle,
+                              subject: texts.close_channels_dialog_failure_message_middle,
                               sharePositionOrigin: rect,
                             );
                           }
@@ -154,8 +151,7 @@ class _CoopCloseChannelsDialogState extends State<CoopCloseChannelsDialog> {
                     texts.close_channels_dialog_action_close,
                     style: themeData.primaryTextTheme.labelLarge,
                   ),
-                  onPressed: () =>
-                      Navigator.of(context).removeRoute(_currentRoute),
+                  onPressed: () => Navigator.of(context).removeRoute(_currentRoute),
                 ),
               ]
             : null,

--- a/lib/routes/connect_to_pay/animations/connected.dart
+++ b/lib/routes/connect_to_pay/animations/connected.dart
@@ -12,8 +12,7 @@ class ConnectedWidget extends StatefulWidget {
   }
 }
 
-class ConnectedWidgetState extends State<ConnectedWidget>
-    with TickerProviderStateMixin {
+class ConnectedWidgetState extends State<ConnectedWidget> with TickerProviderStateMixin {
   AnimationController _animationController;
   AnimationController _circleController;
   Animation<double> _lineWidthFactor;
@@ -23,10 +22,8 @@ class ConnectedWidgetState extends State<ConnectedWidget>
   @override
   void initState() {
     super.initState();
-    _animationController = AnimationController(
-        vsync: this, duration: widget._connectionEmulationDuration);
-    _circleController = AnimationController(
-        vsync: this, duration: widget._connectionEmulationDuration);
+    _animationController = AnimationController(vsync: this, duration: widget._connectionEmulationDuration);
+    _circleController = AnimationController(vsync: this, duration: widget._connectionEmulationDuration);
     _lineWidthFactor = Tween<double>(
       begin: 0.0,
       end: 1.0,
@@ -84,9 +81,7 @@ class ConnectedWidgetState extends State<ConnectedWidget>
   Widget build(BuildContext context) {
     return CustomPaint(
         painter: _ConnectedCustomPainter(_lineWidthFactor,
-            showCircle: widget._waitingAction,
-            circleLocation: _circleLocation,
-            circleRadius: _circleRadius));
+            showCircle: widget._waitingAction, circleLocation: _circleLocation, circleRadius: _circleRadius));
   }
 }
 
@@ -99,8 +94,7 @@ class _ConnectedCustomPainter extends CustomPainter {
   final int numberOfCircles = 10;
   final double circleHeight = 7.0;
 
-  _ConnectedCustomPainter(this._lineWidthFactor,
-      {this.showCircle, this.circleLocation, this.circleRadius});
+  _ConnectedCustomPainter(this._lineWidthFactor, {this.showCircle, this.circleLocation, this.circleRadius});
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -108,34 +102,25 @@ class _ConnectedCustomPainter extends CustomPainter {
       ..strokeWidth = lineHeight
       ..color = Colors.white;
     paintCircles(canvas, size);
-    canvas.drawCircle(
-        Offset(size.width * _lineWidthFactor.value, size.height / 2),
-        lineHeight / 2,
-        paint);
-    canvas.drawLine(Offset(0.0, size.height / 2),
-        Offset(size.width * _lineWidthFactor.value, size.height / 2), paint);
+    canvas.drawCircle(Offset(size.width * _lineWidthFactor.value, size.height / 2), lineHeight / 2, paint);
+    canvas.drawLine(
+        Offset(0.0, size.height / 2), Offset(size.width * _lineWidthFactor.value, size.height / 2), paint);
 
     if (showCircle) {
-      canvas.drawCircle(
-          Offset(size.width * circleLocation.value, size.height / 2),
-          (lineHeight / 2) +
-              (lineHeight * 2) * (0.5 - (circleRadius.value - 0.5).abs()),
-          paint);
+      canvas.drawCircle(Offset(size.width * circleLocation.value, size.height / 2),
+          (lineHeight / 2) + (lineHeight * 2) * (0.5 - (circleRadius.value - 0.5).abs()), paint);
     }
   }
 
   void paintCircles(Canvas canvas, Size size) {
     var width = size.width,
-        marginBetweenCircles =
-            (width - (circleHeight * numberOfCircles)) / (numberOfCircles - 1);
+        marginBetweenCircles = (width - (circleHeight * numberOfCircles)) / (numberOfCircles - 1);
 
     canvas.drawCircle(size.centerLeft(const Offset(2.5, 0.0)), circleHeight / 2,
         Paint()..color = Colors.white.withOpacity(0.3));
     for (var i = 1; i < numberOfCircles; ++i) {
       canvas.drawCircle(
-          size.centerLeft(Offset(
-              i * (circleHeight + marginBetweenCircles) + circleHeight / 2,
-              0.0)),
+          size.centerLeft(Offset(i * (circleHeight + marginBetweenCircles) + circleHeight / 2, 0.0)),
           circleHeight / 2,
           Paint()..color = Colors.white.withOpacity(0.3));
     }

--- a/lib/routes/connect_to_pay/animations/pending_share.dart
+++ b/lib/routes/connect_to_pay/animations/pending_share.dart
@@ -12,8 +12,7 @@ class PendingShareIndicator extends StatefulWidget {
   }
 }
 
-class PendingShareIndicatorState extends State<PendingShareIndicator>
-    with TickerProviderStateMixin {
+class PendingShareIndicatorState extends State<PendingShareIndicator> with TickerProviderStateMixin {
   static const animationDuration = Duration(milliseconds: 500);
   static const rotatingDuration = Duration(milliseconds: 1000);
   AnimationController _scaleAnimationController;
@@ -25,10 +24,8 @@ class PendingShareIndicatorState extends State<PendingShareIndicator>
   @override
   void initState() {
     super.initState();
-    _scaleAnimationController =
-        AnimationController(vsync: this, duration: animationDuration);
-    _rotateAnimationController =
-        AnimationController(vsync: this, duration: rotatingDuration);
+    _scaleAnimationController = AnimationController(vsync: this, duration: animationDuration);
+    _rotateAnimationController = AnimationController(vsync: this, duration: rotatingDuration);
 
     _scale1 = _linearTween(_scaleAnimationController, 0.3, 1.0);
     _scale2 = _linearTween(_scaleAnimationController, 0.6, 1.0);
@@ -45,8 +42,7 @@ class PendingShareIndicatorState extends State<PendingShareIndicator>
     _rotateAnimationController.repeat();
   }
 
-  Animation<double> _linearTween(
-      AnimationController controller, double begin, double end) {
+  Animation<double> _linearTween(AnimationController controller, double begin, double end) {
     return Tween<double>(
       begin: begin,
       end: end,
@@ -71,8 +67,7 @@ class PendingShareIndicatorState extends State<PendingShareIndicator>
 
   @override
   Widget build(BuildContext context) {
-    return CustomPaint(
-        painter: _ConnectedCustomPainter(_scale1, _scale2, _rotate));
+    return CustomPaint(painter: _ConnectedCustomPainter(_scale1, _scale2, _rotate));
   }
 }
 
@@ -104,8 +99,7 @@ class _ConnectedCustomPainter extends CustomPainter {
     canvas.rotate(_rotate.value);
     List<double> startAngles = [-3 * math.pi / 4, math.pi / 4];
     for (int i = 0; i < 2; i++) {
-      Rect rect = Rect.fromLTRB(-x + circleSpacing, -y + circleSpacing,
-          x - circleSpacing, y - circleSpacing);
+      Rect rect = Rect.fromLTRB(-x + circleSpacing, -y + circleSpacing, x - circleSpacing, y - circleSpacing);
       canvas.drawArc(rect, startAngles[i], math.pi / 2, false, arcPaint);
     }
   }

--- a/lib/routes/connect_to_pay/animations/pulse_animation.dart
+++ b/lib/routes/connect_to_pay/animations/pulse_animation.dart
@@ -14,8 +14,7 @@ class PulseAnimationDecorator extends StatefulWidget {
   }
 }
 
-class _PulseAnimationDecoratorState extends State<PulseAnimationDecorator>
-    with TickerProviderStateMixin {
+class _PulseAnimationDecoratorState extends State<PulseAnimationDecorator> with TickerProviderStateMixin {
   AnimationController _animationController;
   Animation<double> _decorationRadius;
 
@@ -72,17 +71,14 @@ class _PulseAnimationDecoratorState extends State<PulseAnimationDecorator>
     return Stack(
       alignment: AlignmentDirectional.center,
       children: <Widget>[
-        Positioned(
-            child: SizedBox(
-                width: widget._maxRadius * 2, height: widget._maxRadius * 2)),
+        Positioned(child: SizedBox(width: widget._maxRadius * 2, height: widget._maxRadius * 2)),
         Positioned(
             top: widget._maxRadius - _decorationRadius.value,
             left: widget._maxRadius - _decorationRadius.value,
             child: Container(
               height: _decorationRadius.value * 2,
               width: _decorationRadius.value * 2,
-              decoration: const BoxDecoration(
-                  shape: BoxShape.circle, color: theme.pulseAnimationColor),
+              decoration: const BoxDecoration(shape: BoxShape.circle, color: theme.pulseAnimationColor),
             )),
         Positioned(child: child)
       ],

--- a/lib/routes/connect_to_pay/animations/waiting_peer_connect.dart
+++ b/lib/routes/connect_to_pay/animations/waiting_peer_connect.dart
@@ -7,8 +7,7 @@ class WaitingPeerConnectWidget extends StatefulWidget {
   }
 }
 
-class _WaitingPeerConnectWidgetState extends State<WaitingPeerConnectWidget>
-    with TickerProviderStateMixin {
+class _WaitingPeerConnectWidgetState extends State<WaitingPeerConnectWidget> with TickerProviderStateMixin {
   AnimationController _animationController;
 
   @override
@@ -42,17 +41,12 @@ class _ConnectingCustomPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     var width = size.width,
-        marginBetweenCircles =
-            (width - (circleHeight * numberOfCircles)) / (numberOfCircles - 1);
+        marginBetweenCircles = (width - (circleHeight * numberOfCircles)) / (numberOfCircles - 1);
 
     drawCircle(canvas, 0, size.centerLeft(const Offset(2.5, 0.0)));
     for (var i = 1; i < numberOfCircles; ++i) {
-      drawCircle(
-          canvas,
-          i,
-          size.centerLeft(Offset(
-              i * (circleHeight + marginBetweenCircles) + circleHeight / 2,
-              0.0)));
+      drawCircle(canvas, i,
+          size.centerLeft(Offset(i * (circleHeight + marginBetweenCircles) + circleHeight / 2, 0.0)));
     }
   }
 
@@ -64,12 +58,8 @@ class _ConnectingCustomPainter extends CustomPainter {
     }
     double distance = (circleIndex - rangeIndex).abs();
     double sizeFactor = (((1.8 - distance) / 4) + 1.0).clamp(1.0, 1.45);
-    canvas.drawCircle(
-        start,
-        circleHeight / 2 * sizeFactor,
-        Paint()
-          ..color = Colors.white
-              .withOpacity(((sizeFactor * 2) - 1.7).clamp(0.0, 1.0)));
+    canvas.drawCircle(start, circleHeight / 2 * sizeFactor,
+        Paint()..color = Colors.white.withOpacity(((sizeFactor * 2) - 1.7).clamp(0.0, 1.0)));
   }
 
   @override

--- a/lib/routes/connect_to_pay/connect_to_pay_page.dart
+++ b/lib/routes/connect_to_pay/connect_to_pay_page.dart
@@ -27,7 +27,7 @@ class ConnectToPayPage extends StatefulWidget {
 
   @override
   State<StatefulWidget> createState() {
-    return ConnectToPayPageState(_currentSession);
+    return ConnectToPayPageState();
   }
 }
 
@@ -44,12 +44,15 @@ class ConnectToPayPageState extends State<ConnectToPayPage> {
   bool _destroySessionOnTerminate = true;
   bool _isInit = false;
 
-  ConnectToPayPageState(
-    this._currentSession,
-  );
+  @override
+  void initState() {
+    super.initState();
+    _currentSession = widget._currentSession;
+  }
 
   @override
   void didChangeDependencies() {
+    super.didChangeDependencies();
     if (!_isInit) {
       final texts = context.texts();
       final ctpBloc = AppBlocsProvider.of<ConnectPayBloc>(context);
@@ -72,7 +75,6 @@ class ConnectToPayPageState extends State<ConnectToPayPage> {
         _error = error;
       }
     }
-    super.didChangeDependencies();
   }
 
   void registerErrorsListener() async {

--- a/lib/routes/connect_to_pay/connect_to_pay_page.dart
+++ b/lib/routes/connect_to_pay/connect_to_pay_page.dart
@@ -65,9 +65,7 @@ class ConnectToPayPageState extends State<ConnectToPayPage> {
           ctpBloc.startSession(_currentSession);
         }
         _payer = _currentSession.runtimeType == PayerRemoteSession;
-        _title = _payer
-            ? texts.connect_to_pay_title_payer
-            : texts.connect_to_pay_title_payee;
+        _title = _payer ? texts.connect_to_pay_title_payer : texts.connect_to_pay_title_payee;
         registerErrorsListener();
         registerEndOfSessionListener(context);
         _isInit = true;
@@ -82,8 +80,7 @@ class ConnectToPayPageState extends State<ConnectToPayPage> {
       _popWithMessage(error.description);
     });
 
-    _remotePartyErrorSubscription =
-        _currentSession.paymentSessionStateStream.listen((s) {
+    _remotePartyErrorSubscription = _currentSession.paymentSessionStateStream.listen((s) {
       final error = !_payer ? s.payerData?.error : s.payeeData?.error;
       if (error != null) {
         _popWithMessage(error);
@@ -93,11 +90,9 @@ class ConnectToPayPageState extends State<ConnectToPayPage> {
 
   void registerEndOfSessionListener(BuildContext context) async {
     final texts = context.texts();
-    _endOfSessionSubscription =
-        _currentSession.paymentSessionStateStream.listen(
+    _endOfSessionSubscription = _currentSession.paymentSessionStateStream.listen(
       (session) {
-        _remoteUserName ??=
-            _payer ? session.payeeData?.userName : session.payerData?.userName;
+        _remoteUserName ??= _payer ? session.payeeData?.userName : session.payerData?.userName;
 
         if (session.remotePartyCancelled) {
           _popWithMessage(
@@ -111,8 +106,7 @@ class ConnectToPayPageState extends State<ConnectToPayPage> {
         }
 
         if (session.paymentFulfilled) {
-          final formattedAmount = _currentSession.currentUser.currency
-              .format(Int64(session.settledAmount));
+          final formattedAmount = _currentSession.currentUser.currency.format(Int64(session.settledAmount));
           _popWithMessage(
             _payer
                 ? texts.connect_to_pay_success_payer(

--- a/lib/routes/connect_to_pay/connected_peer.dart
+++ b/lib/routes/connect_to_pay/connected_peer.dart
@@ -16,27 +16,20 @@ class ConnectedPeer extends StatelessWidget {
   final bool _renderPayer;
   final Function() _onShareInvite;
 
-  const ConnectedPeer(
-      this._renderPayer, this._paymentSessionData, this._onShareInvite);
+  const ConnectedPeer(this._renderPayer, this._paymentSessionData, this._onShareInvite);
 
   @override
   Widget build(BuildContext context) {
-    String imageURL = _renderPayer
-        ? _paymentSessionData.payerData.imageURL
-        : _paymentSessionData.payeeData.imageURL;
-    bool showShare = !_renderPayer &&
-        !_me &&
-        !_paymentSessionData.invitationSent &&
-        imageURL == null;
+    String imageURL =
+        _renderPayer ? _paymentSessionData.payerData.imageURL : _paymentSessionData.payeeData.imageURL;
+    bool showShare = !_renderPayer && !_me && !_paymentSessionData.invitationSent && imageURL == null;
     bool showAlien = !_renderPayer && imageURL == null;
 
     return Column(children: <Widget>[
       Stack(alignment: AlignmentDirectional.center, children: <Widget>[
         Positioned(
             child: AnimatedOpacity(
-                opacity: showShare && _paymentSessionData.invitationReady
-                    ? 1.0
-                    : 0.0,
+                opacity: showShare && _paymentSessionData.invitationReady ? 1.0 : 0.0,
                 duration: const Duration(milliseconds: 1000),
                 child: PulseAnimationDecorator(Container(), 55.0, 45.0))),
         Positioned(
@@ -44,15 +37,11 @@ class ConnectedPeer extends StatelessWidget {
                 duration: const Duration(milliseconds: 1000),
                 opacity: !showShare ? 1.0 : 0.0,
                 child: AlienAvatar())),
-        Positioned(
-            child: !showShare && !showAlien
-                ? buildPeerAvatar(imageURL)
-                : const SizedBox()),
+        Positioned(child: !showShare && !showAlien ? buildPeerAvatar(imageURL) : const SizedBox()),
         Positioned(
             child: showShare
                 ? _ShareInviteWidget(
-                    !_paymentSessionData.invitationReady ||
-                        _paymentSessionData.sessionSecret == null,
+                    !_paymentSessionData.invitationReady || _paymentSessionData.sessionSecret == null,
                     _onShareInvite)
                 : const SizedBox()),
         _paymentSessionData.invitationReady || _renderPayer
@@ -76,14 +65,12 @@ class ConnectedPeer extends StatelessWidget {
                 width: 24.0,
                 child: _online
                     ? DelayRender(
-                        duration:
-                            PaymentSessionState.connectionEmulationDuration,
+                        duration: PaymentSessionState.connectionEmulationDuration,
                         child: Container(
                             decoration: BoxDecoration(
                           color: Colors.greenAccent[400],
                           border: Border.all(color: Colors.white, width: 3.0),
-                          borderRadius:
-                              const BorderRadius.all(Radius.circular(12.0)),
+                          borderRadius: const BorderRadius.all(Radius.circular(12.0)),
                         )))
                     : const SizedBox())
             : const SizedBox()
@@ -93,15 +80,13 @@ class ConnectedPeer extends StatelessWidget {
 
   Widget buildPeerAvatar(String imageURL) {
     if (_me || _renderPayer) {
-      return BreezAvatar(imageURL,
-          radius: 30.0, backgroundColor: theme.sessionAvatarBackgroundColor);
+      return BreezAvatar(imageURL, radius: 30.0, backgroundColor: theme.sessionAvatarBackgroundColor);
     }
 
     return AnimatedOpacity(
         duration: const Duration(milliseconds: 1000),
         opacity: 1.0,
-        child: BreezAvatar(imageURL,
-            radius: 30.0, backgroundColor: theme.sessionAvatarBackgroundColor));
+        child: BreezAvatar(imageURL, radius: 30.0, backgroundColor: theme.sessionAvatarBackgroundColor));
   }
 
   bool get _online => _renderPayer
@@ -151,8 +136,7 @@ class AvatarDecorator extends StatelessWidget {
     return Container(
         width: 60.0,
         height: 60.0,
-        decoration: BoxDecoration(
-            color: theme.sessionAvatarBackgroundColor, shape: BoxShape.circle),
+        decoration: BoxDecoration(color: theme.sessionAvatarBackgroundColor, shape: BoxShape.circle),
         child: Padding(
           padding: const EdgeInsets.all(6.0),
           child: child,

--- a/lib/routes/connect_to_pay/connection_status.dart
+++ b/lib/routes/connect_to_pay/connection_status.dart
@@ -41,16 +41,13 @@ class _IdleCustomPainter extends CustomPainter {
     var width = size.width,
         numberOfCircles = 10,
         circleHeight = 7.0,
-        marginBetweenCircles =
-            (width - (circleHeight * numberOfCircles)) / (numberOfCircles - 1);
+        marginBetweenCircles = (width - (circleHeight * numberOfCircles)) / (numberOfCircles - 1);
 
     canvas.drawCircle(size.centerLeft(const Offset(2.5, 0.0)), circleHeight / 2,
         Paint()..color = Colors.white.withOpacity(0.3));
     for (var i = 1; i < numberOfCircles; ++i) {
       canvas.drawCircle(
-          size.centerLeft(Offset(
-              i * (circleHeight + marginBetweenCircles) + circleHeight / 2,
-              0.0)),
+          size.centerLeft(Offset(i * (circleHeight + marginBetweenCircles) + circleHeight / 2, 0.0)),
           circleHeight / 2,
           Paint()..color = Colors.white.withOpacity(0.3));
     }

--- a/lib/routes/connect_to_pay/payee_session_widget.dart
+++ b/lib/routes/connect_to_pay/payee_session_widget.dart
@@ -83,8 +83,7 @@ class PayeeSessionWidget extends StatelessWidget {
                               refreshedLSP.cheapestOpeningFeeParams,
                             ),
                             () {
-                              _currentSession.approvePaymentSink
-                                  .add(refreshedLSP.raw);
+                              _currentSession.approvePaymentSink.add(refreshedLSP.raw);
                               return;
                             },
                           );
@@ -106,8 +105,7 @@ class PayeeSessionWidget extends StatelessWidget {
                   padding: const EdgeInsets.fromLTRB(25.0, 25.0, 25.0, 21.0),
                   child: PeersConnection(sessionState),
                 ),
-                payerAmount == null ||
-                        _account.maxInboundLiquidity >= payerAmount
+                payerAmount == null || _account.maxInboundLiquidity >= payerAmount
                     ? const SizedBox()
                     : WarningBox(
                         contentPadding: const EdgeInsets.all(8),

--- a/lib/routes/connect_to_pay/payer_session_widget.dart
+++ b/lib/routes/connect_to_pay/payer_session_widget.dart
@@ -50,9 +50,7 @@ class PayerSessionWidget extends StatelessWidget {
                 _currentSession.sentInvitesSink.add(null);
               }),
             ),
-            waitingFormPayee(sessionState)
-                ? Container()
-                : _waitingFormPayee(sessionState),
+            waitingFormPayee(sessionState) ? Container() : _waitingFormPayee(sessionState),
           ],
         );
       },
@@ -69,8 +67,7 @@ class PayerSessionWidget extends StatelessWidget {
           child: PaymentDetailsForm(
             _account,
             sessionState,
-            (amountToPay, {description}) =>
-                _currentSession.paymentDetailsSink.add(
+            (amountToPay, {description}) => _currentSession.paymentDetailsSink.add(
               PaymentDetails(amountToPay, description),
             ),
           ),

--- a/lib/routes/connect_to_pay/peers_connection.dart
+++ b/lib/routes/connect_to_pay/peers_connection.dart
@@ -20,18 +20,14 @@ class PeersConnection extends StatelessWidget {
   bool _isPayerWaiting() {
     final payerData = _sessionState.payerData;
     final payeeData = _sessionState.payeeData;
-    return _sessionState.payer &&
-        payerData.amount != null &&
-        payeeData.paymentRequest == null;
+    return _sessionState.payer && payerData.amount != null && payeeData.paymentRequest == null;
   }
 
   bool _isPayeeWaiting() {
     final payerData = _sessionState.payerData;
     final payeeData = _sessionState.payeeData;
     return !_sessionState.payer &&
-        (payerData.amount == null ||
-            payeeData.paymentRequest != null &&
-                !_sessionState.paymentFulfilled);
+        (payerData.amount == null || payeeData.paymentRequest != null && !_sessionState.paymentFulfilled);
   }
 
   @override
@@ -57,10 +53,8 @@ class PeersConnection extends StatelessWidget {
     double peerContainerSize = 110.0;
     double nameContainerSize = 20.0;
     double peerAvatarWidth = 60.0;
-    double connectionLineMargin =
-        (peerContainerSize - peerAvatarWidth) / 2 + peerAvatarWidth;
-    double nameMargin =
-        (peerContainerSize - peerAvatarWidth) / 2 + peerAvatarWidth + 8.0;
+    double connectionLineMargin = (peerContainerSize - peerAvatarWidth) / 2 + peerAvatarWidth;
+    double nameMargin = (peerContainerSize - peerAvatarWidth) / 2 + peerAvatarWidth + 8.0;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/routes/connect_to_pay/session_instructions.dart
+++ b/lib/routes/connect_to_pay/session_instructions.dart
@@ -44,9 +44,7 @@ class SessionInstructions extends StatelessWidget {
                       Expanded(
                         flex: 1,
                         child: Padding(
-                          padding: hasActions
-                              ? const EdgeInsets.only(bottom: 36.0)
-                              : const EdgeInsets.only(),
+                          padding: hasActions ? const EdgeInsets.only(bottom: 36.0) : const EdgeInsets.only(),
                           child: Center(child: _child),
                         ),
                       ),
@@ -77,9 +75,7 @@ class SessionInstructions extends StatelessWidget {
                         style: BorderStyle.solid,
                       ),
                     ),
-                    onPressed: _disabledActions.contains(action)
-                        ? null
-                        : () => _onAction(action),
+                    onPressed: _disabledActions.contains(action) ? null : () => _onAction(action),
                     child: Text(
                       action.toUpperCase(),
                       style: theme.sessionActionBtnStyle,

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -85,10 +85,7 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
       if (widget.lnurlWithdraw != null) {
         _log.info("lnurlw = ${widget.lnurlWithdraw}");
         accBloc.accountStream
-            .firstWhere(
-                (account) =>
-                    (account != null && account != AccountModel.initial()),
-                orElse: null)
+            .firstWhere((account) => (account != null && account != AccountModel.initial()), orElse: null)
             .then((state) {
           _log.info("we have currency state ${state.currency}");
           setState(() {
@@ -146,8 +143,7 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
 
               return Padding(
                 padding: EdgeInsets.only(
-                  bottom:
-                      Platform.isIOS && _amountFocusNode.hasFocus ? 40.0 : 0.0,
+                  bottom: Platform.isIOS && _amountFocusNode.hasFocus ? 40.0 : 0.0,
                 ),
                 child: SingleButtonBottomBar(
                   stickToBottom: true,
@@ -165,16 +161,14 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
                               _log.info(
                                 "lsp status ${lspStatus.lastConnectionError}",
                               );
-                              final tempFees =
-                                  lspStatus.currentLSP.cheapestOpeningFeeParams;
+                              final tempFees = lspStatus.currentLSP.cheapestOpeningFeeParams;
                               fetchLSPList(lspBloc).then(
                                 (lspList) {
                                   if (loaderRoute.isActive) {
                                     navigator.removeRoute(loaderRoute);
                                   }
                                   var refreshedLSP = lspList.firstWhere(
-                                    (lsp) =>
-                                        lsp.lspID == lspStatus.currentLSP.lspID,
+                                    (lsp) => lsp.lspID == lspStatus.currentLSP.lspID,
                                   );
                                   // Show fee dialog if necessary and create invoice dialog
                                   showSetupFeesDialog(
@@ -243,8 +237,7 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
       body: StreamBuilder<AccountModel>(
         stream: accountBloc.accountStream,
         builder: (context, snapshot) {
-          if (snapshot.connectionState != ConnectionState.done &&
-              !snapshot.hasData) {
+          if (snapshot.connectionState != ConnectionState.done && !snapshot.hasData) {
             return StaticLoader();
           }
           final acc = snapshot.data;
@@ -254,11 +247,8 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
               LSPStatus lspStatus = snapshot.data;
               String validatePayment(Int64 amount) {
                 if (lspStatus?.currentLSP != null) {
-                  final channelMinimumFee =
-                      lspStatus.currentLSP.cheapestOpeningFeeParams.minMsat ~/
-                          1000;
-                  if (amount > acc.maxInboundLiquidity &&
-                      amount <= channelMinimumFee) {
+                  final channelMinimumFee = lspStatus.currentLSP.cheapestOpeningFeeParams.minMsat ~/ 1000;
+                  if (amount > acc.maxInboundLiquidity && amount <= channelMinimumFee) {
                     return texts.invoice_insufficient_amount_fee(
                       acc.currency.format(channelMinimumFee),
                     );
@@ -298,8 +288,7 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
                             validatorFn: validatePayment,
                             style: theme.FieldTextStyle.textStyle,
                           ),
-                          if (_withdrawFetchResponse != null &&
-                              !_withdrawFetchResponse.isFixedAmount) ...[
+                          if (_withdrawFetchResponse != null && !_withdrawFetchResponse.isFixedAmount) ...[
                             Padding(
                               padding: const EdgeInsets.only(top: 8),
                               child: RichText(
@@ -319,10 +308,8 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
                                             ),
                                     ),
                                     TextSpan(
-                                      text: texts.lnurl_fetch_invoice_and(acc
-                                          .currency
-                                          .format(_withdrawFetchResponse
-                                              .maxAmount)),
+                                      text: texts.lnurl_fetch_invoice_and(
+                                          acc.currency.format(_withdrawFetchResponse.maxAmount)),
                                       recognizer: TapGestureRecognizer()
                                         ..onTap = () => _pasteAmount(
                                               acc.currency,
@@ -465,13 +452,10 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
     LSPInfo lspInfo,
   ) {
     final connected = accountModel.connected;
-    final minFee = (lspInfo != null)
-        ? lspInfo.cheapestOpeningFeeParams.minMsat ~/ 1000
-        : Int64(0);
+    final minFee = (lspInfo != null) ? lspInfo.cheapestOpeningFeeParams.minMsat ~/ 1000 : Int64(0);
     final minFeeFormatted = accountModel.currency.format(minFee);
     final showMinFeeMessage = minFee > 0;
-    final setUpFee =
-        (lspInfo.cheapestOpeningFeeParams.proportional / 10000).toString();
+    final setUpFee = (lspInfo.cheapestOpeningFeeParams.proportional / 10000).toString();
     final liquidity = accountModel.currency.format(
       connected ? accountModel.maxInboundLiquidity : Int64(0),
     );
@@ -493,8 +477,7 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
         minFeeFormatted,
       );
     } else {
-      return texts
-          .invoice_lightning_warning_without_min_fee_account_not_connected(
+      return texts.invoice_lightning_warning_without_min_fee_account_not_connected(
         setUpFee,
       );
     }
@@ -535,8 +518,7 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
                 context,
                 texts.qr_action_button_error_code_not_processed,
                 Text(
-                  texts.invoice_receive_fail_message(
-                      extractExceptionMessage(error)),
+                  texts.invoice_receive_fail_message(extractExceptionMessage(error)),
                   style: themeData.dialogTheme.contentTextStyle,
                 ),
               );

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -110,8 +110,8 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
 
   @override
   void initState() {
-    _doneAction = KeyboardDoneAction([_amountFocusNode]);
     super.initState();
+    _doneAction = KeyboardDoneAction([_amountFocusNode]);
   }
 
   @override

--- a/lib/routes/create_invoice/lnurl_withdraw_dialog.dart
+++ b/lib/routes/create_invoice/lnurl_withdraw_dialog.dart
@@ -33,8 +33,7 @@ class LNURlWithdrawDialog extends StatefulWidget {
   }
 }
 
-class LNUrlWithdrawDialogState extends State<LNURlWithdrawDialog>
-    with SingleTickerProviderStateMixin {
+class LNUrlWithdrawDialogState extends State<LNURlWithdrawDialog> with SingleTickerProviderStateMixin {
   String _error;
   Animation<double> _opacityAnimation;
   ModalRoute _currentRoute;

--- a/lib/routes/create_invoice/qr_code_dialog.dart
+++ b/lib/routes/create_invoice/qr_code_dialog.dart
@@ -37,8 +37,7 @@ class QrCodeDialog extends StatefulWidget {
   }
 }
 
-class QrCodeDialogState extends State<QrCodeDialog>
-    with SingleTickerProviderStateMixin {
+class QrCodeDialogState extends State<QrCodeDialog> with SingleTickerProviderStateMixin {
   Animation<double> _opacityAnimation;
   StreamSubscription<PaymentRequestModel> _invoiceSubscription;
   ModalRoute _currentRoute;
@@ -159,8 +158,7 @@ class QrCodeDialogState extends State<QrCodeDialog>
                                   0xe917,
                                   fontFamily: "icomoon",
                                 )),
-                                color:
-                                    themeData.primaryTextTheme.labelLarge.color,
+                                color: themeData.primaryTextTheme.labelLarge.color,
                                 onPressed: () {
                                   Share.share(
                                     "lightning:${requestModel.rawPayReq}",
@@ -183,12 +181,9 @@ class QrCodeDialogState extends State<QrCodeDialog>
                                   0xe90b,
                                   fontFamily: "icomoon",
                                 )),
-                                color:
-                                    themeData.primaryTextTheme.labelLarge.color,
+                                color: themeData.primaryTextTheme.labelLarge.color,
                                 onPressed: () {
-                                  ServiceInjector()
-                                      .device
-                                      .setClipboardText(requestModel.rawPayReq);
+                                  ServiceInjector().device.setClipboardText(requestModel.rawPayReq);
                                   showFlushbar(
                                     context,
                                     message: texts.qr_code_dialog_copied,
@@ -238,8 +233,7 @@ class QrCodeDialogState extends State<QrCodeDialog>
                                   valueColor: AlwaysStoppedAnimation<Color>(
                                     themeData.primaryTextTheme.labelLarge.color,
                                   ),
-                                  backgroundColor:
-                                      themeData.colorScheme.background,
+                                  backgroundColor: themeData.colorScheme.background,
                                 ),
                               ),
                             ),
@@ -264,8 +258,7 @@ class QrCodeDialogState extends State<QrCodeDialog>
                                   ),
                                 ),
                               ),
-                              const Padding(
-                                  padding: EdgeInsets.only(top: 16.0)),
+                              const Padding(padding: EdgeInsets.only(top: 16.0)),
                               SizedBox(
                                 width: MediaQuery.of(context).size.width,
                                 child: _buildExpiryAndFeeMessage(
@@ -279,9 +272,7 @@ class QrCodeDialogState extends State<QrCodeDialog>
                             ],
                           ),
                     duration: const Duration(seconds: 1),
-                    crossFadeState: (!snapshot.hasData ||
-                            requestModel?.rawPayReq == null ||
-                            !synced)
+                    crossFadeState: (!snapshot.hasData || requestModel?.rawPayReq == null || !synced)
                         ? CrossFadeState.showFirst
                         : CrossFadeState.showSecond,
                   );
@@ -304,10 +295,8 @@ class QrCodeDialogState extends State<QrCodeDialog>
     return StreamBuilder<AccountModel>(
       stream: widget._accountBloc.accountStream,
       builder: (context, accSnapshot) {
-        bool hasError = accSnapshot.hasError ||
-            !accSnapshot.hasData ||
-            snapshot.hasError ||
-            !snapshot.hasData;
+        bool hasError =
+            accSnapshot.hasError || !accSnapshot.hasData || snapshot.hasError || !snapshot.hasData;
 
         return WarningBox(
           boxPadding: const EdgeInsets.symmetric(
@@ -317,15 +306,12 @@ class QrCodeDialogState extends State<QrCodeDialog>
             vertical: 12,
             horizontal: 8,
           ),
-          backgroundColor:
-              theme.themeId == "BLUE" ? const Color(0xFFf3f8fc) : null,
+          backgroundColor: theme.themeId == "BLUE" ? const Color(0xFFf3f8fc) : null,
           borderColor: theme.themeId == "BLUE" ? const Color(0xFF0085fb) : null,
           child: Text(
             _warningMessage(context, hasError, snapshot, accSnapshot),
             textAlign: TextAlign.center,
-            style: (hasError)
-                ? themeData.dialogTheme.contentTextStyle
-                : themeData.primaryTextTheme.bodySmall,
+            style: (hasError) ? themeData.dialogTheme.contentTextStyle : themeData.primaryTextTheme.bodySmall,
           ),
         );
       },

--- a/lib/routes/dev/default_commands.dart
+++ b/lib/routes/dev/default_commands.dart
@@ -14,8 +14,7 @@ class Command extends StatelessWidget {
         },
         child: Container(
             alignment: Alignment.centerLeft,
-            padding:
-                const EdgeInsets.symmetric(vertical: 8.0, horizontal: 24.0),
+            padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 24.0),
             child: Text(
               command,
               textAlign: TextAlign.left,

--- a/lib/routes/dev/dev.dart
+++ b/lib/routes/dev/dev.dart
@@ -86,11 +86,6 @@ class DevViewState extends State<DevView> {
 
   bool _showDefaultCommands = true;
 
-  @override
-  void initState() {
-    super.initState();
-  }
-
   void _sendCommand(String command) {
     FocusScope.of(context).requestFocus(FocusNode());
     _lastCommand = command;

--- a/lib/routes/dev/dev.dart
+++ b/lib/routes/dev/dev.dart
@@ -124,8 +124,7 @@ class DevViewState extends State<DevView> {
           children: defaultCliCommandsText(
             (command) {
               _cliInputController.text = "$command ";
-              FocusScope.of(_scaffoldKey.currentState.context)
-                  .requestFocus(_cliEntryFocusNode);
+              FocusScope.of(_scaffoldKey.currentState.context).requestFocus(_cliEntryFocusNode);
             },
           ),
         ),
@@ -149,8 +148,7 @@ class DevViewState extends State<DevView> {
     BackupBloc backupBloc = AppBlocsProvider.of<BackupBloc>(context);
     AddFundsBloc addFundsBloc = BlocProvider.of<AddFundsBloc>(context);
     UserProfileBloc userBloc = AppBlocsProvider.of<UserProfileBloc>(context);
-    MarketplaceBloc marketplaceBloc =
-        AppBlocsProvider.of<MarketplaceBloc>(context);
+    MarketplaceBloc marketplaceBloc = AppBlocsProvider.of<MarketplaceBloc>(context);
     return StreamBuilder<BackupState>(
       stream: backupBloc.backupStateStream,
       builder: (ctx, backupSnapshot) => StreamBuilder(
@@ -223,8 +221,7 @@ class DevViewState extends State<DevView> {
                                           focusNode: _cliEntryFocusNode,
                                           controller: _cliInputController,
                                           decoration: const InputDecoration(
-                                            hintText:
-                                                'Enter a command or use the links below',
+                                            hintText: 'Enter a command or use the links below',
                                           ),
                                           onSubmitted: (command) {
                                             _sendCommand(command);
@@ -279,40 +276,29 @@ class DevViewState extends State<DevView> {
                                       ),
                                       child: Column(
                                         mainAxisSize: MainAxisSize.max,
-                                        crossAxisAlignment:
-                                            CrossAxisAlignment.start,
+                                        crossAxisAlignment: CrossAxisAlignment.start,
                                         children: <Widget>[
                                           _showDefaultCommands
                                               ? Container()
                                               : Row(
-                                                  mainAxisAlignment:
-                                                      MainAxisAlignment.end,
+                                                  mainAxisAlignment: MainAxisAlignment.end,
                                                   children: <Widget>[
                                                     IconButton(
                                                       icon: const Icon(
                                                         Icons.content_copy,
                                                       ),
-                                                      tooltip:
-                                                          'Copy to Clipboard',
+                                                      tooltip: 'Copy to Clipboard',
                                                       iconSize: 19.0,
                                                       onPressed: () {
-                                                        ServiceInjector()
-                                                            .device
-                                                            .setClipboardText(
-                                                                _cliText);
-                                                        ScaffoldMessenger.of(
-                                                                context)
-                                                            .showSnackBar(
+                                                        ServiceInjector().device.setClipboardText(_cliText);
+                                                        ScaffoldMessenger.of(context).showSnackBar(
                                                           SnackBar(
                                                             content: Text(
                                                               'Copied to clipboard.',
-                                                              style: theme
-                                                                  .snackBarStyle,
+                                                              style: theme.snackBarStyle,
                                                             ),
-                                                            backgroundColor: theme
-                                                                .snackBarBackgroundColor,
-                                                            duration:
-                                                                const Duration(
+                                                            backgroundColor: theme.snackBarBackgroundColor,
+                                                            duration: const Duration(
                                                               seconds: 2,
                                                             ),
                                                           ),
@@ -327,8 +313,7 @@ class DevViewState extends State<DevView> {
                                                       tooltip: 'Share',
                                                       onPressed: () {
                                                         _shareFile(
-                                                          _lastCommand
-                                                              .split(" ")[0],
+                                                          _lastCommand.split(" ")[0],
                                                           _cliText,
                                                         );
                                                       },
@@ -437,8 +422,7 @@ class DevViewState extends State<DevView> {
     }
     choices.add(
       Choice(
-        title:
-            "${addFundsSettings.moonpayIpCheck ? "Disable" : "Enable"} MoonPay IP Check",
+        title: "${addFundsSettings.moonpayIpCheck ? "Disable" : "Enable"} MoonPay IP Check",
         icon: Icons.network_check,
         function: () => _enableMoonpayIpCheck(addFundsBloc, addFundsSettings),
       ),
@@ -479,8 +463,7 @@ class DevViewState extends State<DevView> {
         icon: Icons.phone_android,
         function: () async {
           await widget._breezBridge.setNonBlockingUnconfirmedSwaps();
-          await widget._breezBridge
-              .resetUnconfirmedReverseSwapClaimTransaction();
+          await widget._breezBridge.resetUnconfirmedReverseSwapClaimTransaction();
         },
       ),
     );
@@ -491,16 +474,14 @@ class DevViewState extends State<DevView> {
         function: () async {
           Directory tempDir = await getTemporaryDirectory();
           tempDir = await tempDir.createTemp("graph");
-          var walletFiles =
-              await ServiceInjector().breezBridge.getWalletDBpFilePath();
+          var walletFiles = await ServiceInjector().breezBridge.getWalletDBpFilePath();
           var encoder = ZipFileEncoder();
           var zipFilePath = '${tempDir.path}/wallet-files.zip';
           encoder.create(zipFilePath);
           var i = 1;
           for (var f in walletFiles) {
             var file = File(f);
-            encoder.addFile(file,
-                "${i.toString()}_${file.path.split(Platform.pathSeparator).last}");
+            encoder.addFile(file, "${i.toString()}_${file.path.split(Platform.pathSeparator).last}");
             i += 1;
           }
           encoder.close();
@@ -710,9 +691,7 @@ class DevViewState extends State<DevView> {
     String filePath = '${tempDir.path}/graph.json';
     navigator.push(loaderRoute).whenComplete(() => userCancelled = true);
 
-    widget._breezBridge
-        .sendCommand("describegraph $filePath --include_unannounced")
-        .then((_) {
+    widget._breezBridge.sendCommand("describegraph $filePath --include_unannounced").then((_) {
       var encoder = ZipFileEncoder();
       encoder.create('${tempDir.path}/graph.zip');
       encoder.addFile(File(filePath));

--- a/lib/routes/fiat_currencies/fiat_currency_settings.dart
+++ b/lib/routes/fiat_currencies/fiat_currency_settings.dart
@@ -52,8 +52,7 @@ class FiatCurrencySettingsState extends State<FiatCurrencySettings> {
           if (!snapshot.hasData) return Container();
           final account = snapshot.data;
 
-          if (account.fiatConversionList.isEmpty ||
-              account.fiatCurrency == null) {
+          if (account.fiatConversionList.isEmpty || account.fiatCurrency == null) {
             return const Center(
               child: Loader(
                 color: Colors.white,
@@ -80,8 +79,7 @@ class FiatCurrencySettingsState extends State<FiatCurrencySettings> {
                   lastItemTargetHeight: 8,
                   scrollController: _scrollController,
                   onListReorder: (oldListIndex, newListIndex) => {},
-                  onItemReorder: (from, oldListIndex, to, newListIndex) =>
-                      _onReorder(
+                  onItemReorder: (from, oldListIndex, to, newListIndex) => _onReorder(
                     context,
                     account,
                     from,
@@ -129,8 +127,7 @@ class FiatCurrencySettingsState extends State<FiatCurrencySettings> {
   ) {
     for (var i = 0; i < preferredFiatCurrencies.length; i++) {
       if (isAboveMinAmount(account, i)) {
-        widget.userProfileBloc.fiatConversionSink
-            .add(preferredFiatCurrencies[i]);
+        widget.userProfileBloc.fiatConversionSink.add(preferredFiatCurrencies[i]);
         break;
       }
     }
@@ -173,8 +170,7 @@ class FiatCurrencySettingsState extends State<FiatCurrencySettings> {
           if (checked) {
             prefCurrencies.add(currencyData.shortName);
             // center item in viewport
-            if (_scrollController.offset >=
-                (ITEM_HEIGHT * (prefCurrencies.length - 1))) {
+            if (_scrollController.offset >= (ITEM_HEIGHT * (prefCurrencies.length - 1))) {
               _scrollController.animateTo(
                 ((2 * prefCurrencies.length - 1) * ITEM_HEIGHT -
                         _scrollController.position.viewportDimension) /

--- a/lib/routes/funds_over_limit_dialog.dart
+++ b/lib/routes/funds_over_limit_dialog.dart
@@ -21,10 +21,6 @@ class SwapRefundDialog extends StatefulWidget {
 
 class SwapRefundDialogState extends State<SwapRefundDialog> {
   Future _fetchFuture;
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   void didChangeDependencies() {

--- a/lib/routes/get_refund/get_refund_page.dart
+++ b/lib/routes/get_refund/get_refund_page.dart
@@ -34,8 +34,7 @@ class GetRefundPage extends StatelessWidget {
           }
           var account = accSnapshot.data;
           return GetRefundList(
-            refundableAddresses:
-                account.swapFundsStatus.maturedRefundableAddresses,
+            refundableAddresses: account.swapFundsStatus.maturedRefundableAddresses,
             currency: account.currency,
             allowRebroadcastRefunds: allowRebroadcastRefunds,
             onRefundPressed: (item) => onRefund(context, account, item),

--- a/lib/routes/get_refund/wait_broadcast_dialog.dart
+++ b/lib/routes/get_refund/wait_broadcast_dialog.dart
@@ -37,8 +37,7 @@ class _WaitBroadcastDialog extends State<WaitBroadcastDialog> {
   @override
   void initState() {
     super.initState();
-    _broadcastSubscription =
-        widget._accountBloc.broadcastRefundResponseStream.listen((response) {
+    _broadcastSubscription = widget._accountBloc.broadcastRefundResponseStream.listen((response) {
       setState(() {
         _error = null;
         _response = response;
@@ -202,9 +201,7 @@ class _WaitBroadcastDialog extends State<WaitBroadcastDialog> {
                           fontFamily: "icomoon",
                         ),
                       ),
-                      onPressed: () => ServiceInjector()
-                          .device
-                          .setClipboardText(_response.txID),
+                      onPressed: () => ServiceInjector().device.setClipboardText(_response.txID),
                     ),
                     IconButton(
                       alignment: Alignment.topRight,

--- a/lib/routes/home/account_page.dart
+++ b/lib/routes/home/account_page.dart
@@ -38,8 +38,7 @@ class AccountPage extends StatefulWidget {
   }
 }
 
-class AccountPageState extends State<AccountPage>
-    with SingleTickerProviderStateMixin {
+class AccountPageState extends State<AccountPage> with SingleTickerProviderStateMixin {
   final currencyList = Currency.currencies.map((c) => c.tickerSymbol).toList();
 
   AccountBloc _accountBloc;
@@ -109,25 +108,19 @@ class AccountPageState extends State<AccountPage>
     final lspBloc = AppBlocsProvider.of<LSPBloc>(context);
     final queryData = MediaQuery.of(context);
 
-    final listHeightSpace = queryData.size.height -
-        DASHBOARD_MIN_HEIGHT -
-        kToolbarHeight -
-        FILTER_MAX_SIZE -
-        25.0;
+    final listHeightSpace =
+        queryData.size.height - DASHBOARD_MIN_HEIGHT - kToolbarHeight - FILTER_MAX_SIZE - 25.0;
     final startDate = paymentsModel?.filter?.startDate;
     final endDate = paymentsModel?.filter?.endDate;
     final dateFilterSpace = startDate != null && endDate != null ? 0.65 : 0.0;
     final payments = paymentsModel.paymentsList;
     final bottomPlaceholderSpace = payments == null || payments.isEmpty
         ? 0.0
-        : (listHeightSpace -
-                (PAYMENT_LIST_ITEM_HEIGHT + 8) *
-                    (payments.length + 1 + dateFilterSpace))
+        : (listHeightSpace - (PAYMENT_LIST_ITEM_HEIGHT + 8) * (payments.length + 1 + dateFilterSpace))
             .clamp(0.0, listHeightSpace);
 
     String message;
-    bool showMessage = account?.syncUIState != SyncUIState.BLOCKING &&
-        (account != null && !account.initial);
+    bool showMessage = account?.syncUIState != SyncUIState.BLOCKING && (account != null && !account.initial);
 
     List<Widget> slivers = [];
     slivers.add(SliverPersistentHeader(

--- a/lib/routes/home/account_page.dart
+++ b/lib/routes/home/account_page.dart
@@ -48,21 +48,22 @@ class AccountPageState extends State<AccountPage>
 
   @override
   void didChangeDependencies() {
+    super.didChangeDependencies();
     if (!_isInit) {
       _accountBloc = AppBlocsProvider.of<AccountBloc>(context);
       _userProfileBloc = AppBlocsProvider.of<UserProfileBloc>(context);
       //a listener that rebuilds our widget tree when payment filter changes
       _accountBloc.paymentFilterStream.listen((event) {
-        widget.scrollController.position
-            .restoreOffset(widget.scrollController.offset + 1);
-        Future.delayed(
-          const Duration(milliseconds: 150),
-          () => {setState(() {})},
-        );
+        if (widget.scrollController.position.hasContentDimensions) {
+          widget.scrollController.position.restoreOffset(widget.scrollController.offset + 1);
+          Future.delayed(
+            const Duration(milliseconds: 150),
+            () => {setState(() {})},
+          );
+        }
       });
       _isInit = true;
     }
-    super.didChangeDependencies();
   }
 
   @override

--- a/lib/routes/home/bottom_actions_bar.dart
+++ b/lib/routes/home/bottom_actions_bar.dart
@@ -120,8 +120,7 @@ class _BottomActionsBarState extends State<BottomActionsBar> {
                       if (clipBoardSnapshot.hasData) {
                         await clipBoardSnapshot.data.then((clipboardData) {
                           if (clipboardData != null) {
-                            if (clipboardData.type == "lnurl" ||
-                                clipboardData.type == "lightning-address") {
+                            if (clipboardData.type == "lnurl" || clipboardData.type == "lightning-address") {
                               lnurlBloc.lnurlInputSink.add(clipboardData.data);
                             } else if (clipboardData.type == "invoice") {
                               invoiceBloc.decodeInvoiceSink.add(
@@ -173,9 +172,7 @@ class _BottomActionsBarState extends State<BottomActionsBar> {
                   ),
                   ListTile(
                     enabled: account.connected,
-                    leading: _ActionImage(
-                        iconAssetPath: "src/icon/bitcoin.png",
-                        enabled: account.connected),
+                    leading: _ActionImage(iconAssetPath: "src/icon/bitcoin.png", enabled: account.connected),
                     title: Text(
                       texts.bottom_action_bar_send_btc_address,
                       style: theme.bottomSheetTextStyle,
@@ -203,8 +200,7 @@ class _BottomActionsBarState extends State<BottomActionsBar> {
                             ListTile(
                               enabled: account.connected,
                               leading: _ActionImage(
-                                  iconAssetPath: "src/icon/escher.png",
-                                  enabled: account.connected),
+                                  iconAssetPath: "src/icon/escher.png", enabled: account.connected),
                               title: Text(
                                 texts.bottom_action_bar_escher,
                                 style: theme.bottomSheetTextStyle,
@@ -342,8 +338,7 @@ Future showReceiveOptions(
                   return const SizedBox();
                 }
 
-                List<Widget> children =
-                    snapshot.data.where((v) => v.isAllowed).map(
+                List<Widget> children = snapshot.data.where((v) => v.isAllowed).map(
                   (v) {
                     return Column(
                       children: [
@@ -353,12 +348,10 @@ Future showReceiveOptions(
                           indent: 72.0,
                         ),
                         ListTile(
-                          enabled: v.enabled &&
-                              (account.connected || !v.requireActiveChannel),
+                          enabled: v.enabled && (account.connected || !v.requireActiveChannel),
                           leading: _ActionImage(
                             iconAssetPath: v.icon,
-                            enabled:
-                                account.connected || !v.requireActiveChannel,
+                            enabled: account.connected || !v.requireActiveChannel,
                           ),
                           title: Text(
                             v.shortName ?? v.name,
@@ -378,16 +371,13 @@ Future showReceiveOptions(
                                       navigator.removeRoute(loaderRoute);
                                     }
                                     var refreshedLSP = lspList.firstWhere(
-                                      (lsp) =>
-                                          lsp.lspID ==
-                                          lspSnapshot.data.selectedLSP,
+                                      (lsp) => lsp.lspID == lspSnapshot.data.selectedLSP,
                                     );
                                     (v.showLSPFee)
                                         ? promptLSPFeeAndNavigate(
                                             parentContext,
                                             account,
-                                            refreshedLSP
-                                                .longestValidOpeningFeeParams,
+                                            refreshedLSP.longestValidOpeningFeeParams,
                                             v.route,
                                           )
                                         : navigator.pushNamed(v.route);
@@ -446,8 +436,7 @@ Future showReceiveOptions(
                                   account.warningMaxChanReserveAmount,
                                 ),
                               ),
-                              maxFontSize:
-                                  themeData.textTheme.titleMedium.fontSize,
+                              maxFontSize: themeData.textTheme.titleMedium.fontSize,
                               style: themeData.textTheme.titleLarge,
                               textAlign: TextAlign.center,
                             ),

--- a/lib/routes/home/flip_transition.dart
+++ b/lib/routes/home/flip_transition.dart
@@ -16,8 +16,7 @@ class FlipTransition extends StatefulWidget {
   }
 }
 
-class FlipTransitionState extends State<FlipTransition>
-    with TickerProviderStateMixin {
+class FlipTransitionState extends State<FlipTransition> with TickerProviderStateMixin {
   AnimationController _flipAnimationController;
   Animation _flipAnimation;
   static const flipDuration = Duration(seconds: 2);
@@ -25,11 +24,9 @@ class FlipTransitionState extends State<FlipTransition>
   @override
   void initState() {
     super.initState();
-    _flipAnimationController =
-        AnimationController(vsync: this, duration: flipDuration);
+    _flipAnimationController = AnimationController(vsync: this, duration: flipDuration);
     _flipAnimation = Tween(begin: 0.0, end: 1.0).animate(CurvedAnimation(
-        parent: _flipAnimationController,
-        curve: const Interval(0.0, 1.0, curve: Curves.fastOutSlowIn)));
+        parent: _flipAnimationController, curve: const Interval(0.0, 1.0, curve: Curves.fastOutSlowIn)));
 
     _flipAnimationController.addStatusListener((status) {
       if (status == AnimationStatus.completed) {
@@ -58,9 +55,7 @@ class FlipTransitionState extends State<FlipTransition>
             child: Transform(
               transform: Matrix4.identity()..rotateY(pi * _flipAnimation.value),
               alignment: Alignment.center,
-              child: _flipAnimationController.value >= 0.4
-                  ? widget.secondChild
-                  : widget.firstChild,
+              child: _flipAnimationController.value >= 0.4 ? widget.secondChild : widget.firstChild,
             ),
           ),
         );

--- a/lib/routes/home/moonpay_route.dart
+++ b/lib/routes/home/moonpay_route.dart
@@ -18,9 +18,7 @@ void showMoonpayWebview(BuildContext context) {
     onClose: () => cancelled = true,
   );
   Navigator.push(context, loaderRoute);
-  addFundsBloc.moonpayNextOrderStream.first
-      .timeout(const Duration(seconds: 15))
-      .then((order) {
+  addFundsBloc.moonpayNextOrderStream.first.timeout(const Duration(seconds: 15)).then((order) {
     if (cancelled) {
       return;
     }

--- a/lib/routes/home/payment_item.dart
+++ b/lib/routes/home/payment_item.dart
@@ -89,8 +89,7 @@ class _PaymentItemState extends State<PaymentItem> {
                       Text(
                         BreezDateUtils.formatTimelineRelative(
                           DateTime.fromMillisecondsSinceEpoch(
-                            widget._paymentInfo.creationTimestamp.toInt() *
-                                1000,
+                            widget._paymentInfo.creationTimestamp.toInt() * 1000,
                           ),
                         ),
                         style: themeData.paymentItemSubtitleTextStyle,
@@ -102,8 +101,7 @@ class _PaymentItemState extends State<PaymentItem> {
                 trailing: SizedBox(
                   height: 44,
                   child: Column(
-                    mainAxisAlignment: widget._paymentInfo.fee == 0 ||
-                            widget._paymentInfo.pending
+                    mainAxisAlignment: widget._paymentInfo.fee == 0 || widget._paymentInfo.pending
                         ? MainAxisAlignment.center
                         : MainAxisAlignment.spaceAround,
                     crossAxisAlignment: CrossAxisAlignment.end,
@@ -150,9 +148,8 @@ class _PaymentItemState extends State<PaymentItem> {
     final themeData = Theme.of(context);
 
     final type = widget._paymentInfo.type;
-    final negative = type == PaymentType.SENT ||
-        type == PaymentType.WITHDRAWAL ||
-        type == PaymentType.CLOSED_CHANNEL;
+    final negative =
+        type == PaymentType.SENT || type == PaymentType.WITHDRAWAL || type == PaymentType.CLOSED_CHANNEL;
     final amount = widget._paymentInfo.currency.format(
       widget._paymentInfo.amount,
       includeDisplayName: false,

--- a/lib/routes/home/payment_item_avatar.dart
+++ b/lib/routes/home/payment_item_avatar.dart
@@ -31,8 +31,7 @@ class PaymentItemAvatar extends StatelessWidget {
       final metadataImage = _metadataImage();
       if (metadataImage != null) return metadataImage;
 
-      IconData icon = (paymentItem.type == PaymentType.RECEIVED ||
-              paymentItem.type == PaymentType.DEPOSIT)
+      IconData icon = (paymentItem.type == PaymentType.RECEIVED || paymentItem.type == PaymentType.DEPOSIT)
           ? Icons.add_rounded
           : Icons.remove_rounded;
       Widget child = Icon(icon, color: const Color(0xb3303234));

--- a/lib/routes/home/payments_filter.dart
+++ b/lib/routes/home/payments_filter.dart
@@ -79,9 +79,7 @@ class PaymentFilterSliverState extends State<PaymentFilterSliver> {
         builder: (context, shrinkedHeight, overlapContent) {
           return AnimatedOpacity(
             duration: const Duration(milliseconds: 100),
-            opacity: !_hasNoFilter
-                ? 1.0
-                : (scrollOffset - widget._maxSize / 2).clamp(0.0, 1.0),
+            opacity: !_hasNoFilter ? 1.0 : (scrollOffset - widget._maxSize / 2).clamp(0.0, 1.0),
             child: Container(
               color: theme.customData[theme.themeId].dashboardBgColor,
               child: Padding(
@@ -132,15 +130,9 @@ class PaymentsFilterState extends State<PaymentsFilter> {
   void initState() {
     super.initState();
     final today = DateTime.now();
-    formattedStartDate = DateTime(
-        widget._paymentsModel.firstDate.year,
-        widget._paymentsModel.firstDate.month,
-        widget._paymentsModel.firstDate.day,
-        0,
-        0,
-        0);
-    formattedEndDate =
-        DateTime(today.year, today.month, today.day, 23, 59, 59, 999);
+    formattedStartDate = DateTime(widget._paymentsModel.firstDate.year, widget._paymentsModel.firstDate.month,
+        widget._paymentsModel.firstDate.day, 0, 0, 0);
+    formattedEndDate = DateTime(today.year, today.month, today.day, 23, 59, 59, 999);
   }
 
   @override
@@ -171,11 +163,7 @@ class PaymentsFilterState extends State<PaymentsFilter> {
       );
     }
 
-    return Row(children: [
-      _buildExportButton(),
-      _buildCalendarButton(),
-      _buildFilterDropdown()
-    ]);
+    return Row(children: [_buildExportButton(), _buildCalendarButton(), _buildFilterDropdown()]);
   }
 
   Padding _buildCalendarButton() {
@@ -202,10 +190,8 @@ class PaymentsFilterState extends State<PaymentsFilter> {
               ).then((result) {
                 bool hasStartDateChanged = result[0] != formattedStartDate;
                 bool hasEndDateChanged = result[1] != formattedEndDate;
-                bool hasDateFilterChanged =
-                    hasStartDateChanged || hasEndDateChanged;
-                bool hasActiveDateFilter =
-                    widget._paymentsModel.filter.initial == false;
+                bool hasDateFilterChanged = hasStartDateChanged || hasEndDateChanged;
+                bool hasActiveDateFilter = widget._paymentsModel.filter.initial == false;
 
                 if (hasDateFilterChanged) {
                   widget._accountBloc.paymentFilterSink.add(

--- a/lib/routes/home/qr_action_button.dart
+++ b/lib/routes/home/qr_action_button.dart
@@ -163,6 +163,7 @@ class _QrActionButtonState extends State<QrActionButton> {
                   }
 
                   _log.finest("Scanned string is unrecognized");
+                  // ignore: use_build_context_synchronously
                   showFlushbar(
                     context,
                     message: texts.qr_action_button_error_code_not_processed,

--- a/lib/routes/home/qr_action_button.dart
+++ b/lib/routes/home/qr_action_button.dart
@@ -94,8 +94,7 @@ class _QrActionButtonState extends State<QrActionButton> {
                   }
 
                   // regular lightning invoice.
-                  if (lower.startsWith("lightning:") ||
-                      lower.startsWith("ln")) {
+                  if (lower.startsWith("lightning:") || lower.startsWith("ln")) {
                     _log.finest(
                       "Scanned string is a regular lightning invoice",
                     );
@@ -110,8 +109,7 @@ class _QrActionButtonState extends State<QrActionButton> {
                     _log.finest("Scanned string is a bitcoin address");
                     String requestAmount;
                     if (btcInvoice.satAmount != null) {
-                      final account =
-                          await profileBloc.userStream.take(1).first;
+                      final account = await profileBloc.userStream.take(1).first;
                       requestAmount = account.currency.format(
                         btcInvoice.satAmount,
                         userInput: true,

--- a/lib/routes/home/wallet_dashboard.dart
+++ b/lib/routes/home/wallet_dashboard.dart
@@ -70,45 +70,44 @@ class WalletDashboardState extends State<WalletDashboard> {
           Positioned(
             top: 60 - BALANCE_OFFSET_TRANSITION * widget._offsetFactor,
             child: Center(
-              child:
-                  widget._accountModel != null && !widget._accountModel.initial
-                      ? TextButton(
-                          style: _balanceStyle(),
-                          onPressed: () {
-                            if (widget._userModel.hideBalance) {
-                              widget._onPrivacyChange(false);
-                              return;
-                            }
-                            final list = Currency.currencies;
-                            final index = list.indexOf(
-                              widget._accountModel.currency,
-                            );
-                            final nextCurrencyIndex = (index + 1) % list.length;
-                            if (nextCurrencyIndex == 1) {
-                              widget._onPrivacyChange(true);
-                            }
-                            widget._onCurrencyChange(
-                              list[nextCurrencyIndex],
-                            );
-                          },
-                          child: widget._userModel.hideBalance
-                              ? _balanceHide(
+              child: widget._accountModel != null && !widget._accountModel.initial
+                  ? TextButton(
+                      style: _balanceStyle(),
+                      onPressed: () {
+                        if (widget._userModel.hideBalance) {
+                          widget._onPrivacyChange(false);
+                          return;
+                        }
+                        final list = Currency.currencies;
+                        final index = list.indexOf(
+                          widget._accountModel.currency,
+                        );
+                        final nextCurrencyIndex = (index + 1) % list.length;
+                        if (nextCurrencyIndex == 1) {
+                          widget._onPrivacyChange(true);
+                        }
+                        widget._onCurrencyChange(
+                          list[nextCurrencyIndex],
+                        );
+                      },
+                      child: widget._userModel.hideBalance
+                          ? _balanceHide(
+                              startHeaderSize,
+                              endHeaderFontSize,
+                            )
+                          : (widget._offsetFactor > 0.8 &&
+                                  _showFiatCurrency &&
+                                  widget._accountModel.fiatCurrency != null)
+                              ? _balanceText(
                                   startHeaderSize,
                                   endHeaderFontSize,
                                 )
-                              : (widget._offsetFactor > 0.8 &&
-                                      _showFiatCurrency &&
-                                      widget._accountModel.fiatCurrency != null)
-                                  ? _balanceText(
-                                      startHeaderSize,
-                                      endHeaderFontSize,
-                                    )
-                                  : _balanceRichText(
-                                      startHeaderSize,
-                                      endHeaderFontSize,
-                                    ),
-                        )
-                      : const SizedBox(),
+                              : _balanceRichText(
+                                  startHeaderSize,
+                                  endHeaderFontSize,
+                                ),
+                    )
+                  : const SizedBox(),
             ),
           ),
           Positioned(
@@ -152,8 +151,7 @@ class WalletDashboardState extends State<WalletDashboard> {
     return Text(
       widget._accountModel.formattedFiatBalance,
       style: themeData.walletDashboardHeaderTextStyle.copyWith(
-        fontSize: startHeaderSize -
-            (startHeaderSize - endHeaderFontSize) * widget._offsetFactor,
+        fontSize: startHeaderSize - (startHeaderSize - endHeaderFontSize) * widget._offsetFactor,
       ),
     );
   }
@@ -168,8 +166,7 @@ class WalletDashboardState extends State<WalletDashboard> {
     return RichText(
       text: TextSpan(
         style: headlineMedium.copyWith(
-          fontSize: startHeaderSize -
-              (startHeaderSize - endHeaderFontSize) * widget._offsetFactor,
+          fontSize: startHeaderSize - (startHeaderSize - endHeaderFontSize) * widget._offsetFactor,
         ),
         text: widget._accountModel.currency.format(
           widget._accountModel.balance,
@@ -179,9 +176,8 @@ class WalletDashboardState extends State<WalletDashboard> {
           TextSpan(
             text: " ${widget._accountModel.currency.displayName}",
             style: headlineMedium.copyWith(
-              fontSize: startHeaderSize * 0.6 -
-                  (startHeaderSize * 0.6 - endHeaderFontSize) *
-                      widget._offsetFactor,
+              fontSize:
+                  startHeaderSize * 0.6 - (startHeaderSize * 0.6 - endHeaderFontSize) * widget._offsetFactor,
             ),
           ),
         ],
@@ -199,8 +195,7 @@ class WalletDashboardState extends State<WalletDashboard> {
     return Text(
       texts.wallet_dashboard_balance_hide,
       style: themeData.walletDashboardHeaderTextStyle.copyWith(
-        fontSize: startHeaderSize -
-            (startHeaderSize - endHeaderFontSize) * widget._offsetFactor,
+        fontSize: startHeaderSize - (startHeaderSize - endHeaderFontSize) * widget._offsetFactor,
       ),
     );
   }

--- a/lib/routes/home/widgets/payments_list/dialog/closed_channel_payment_details.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/closed_channel_payment_details.dart
@@ -32,8 +32,7 @@ class ClosedChannelPaymentDetails extends StatefulWidget {
   }
 }
 
-class ClosedChannelPaymentDetailsState
-    extends State<ClosedChannelPaymentDetails> {
+class ClosedChannelPaymentDetailsState extends State<ClosedChannelPaymentDetails> {
   bool showRefreshChainButton = false;
   bool mismatchChecked = false;
   bool mismatchedLoading = false;
@@ -53,10 +52,7 @@ class ClosedChannelPaymentDetailsState
   void checkMismatch() {
     final channel = widget.closedChannel;
     final lsp = widget.lsp;
-    if (!mismatchChecked &&
-        channel.pending &&
-        lsp != null &&
-        lsp.currentLSP != null) {
+    if (!mismatchChecked && channel.pending && lsp != null && lsp.currentLSP != null) {
       mismatchChecked = true;
       setState(() {
         mismatchedLoading = true;

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_description.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_description.dart
@@ -31,9 +31,8 @@ class PaymentDetailsDialogDescription extends StatelessWidget {
             child: AutoSizeText(
               description,
               style: themeData.primaryTextTheme.headlineMedium,
-              textAlign: description.length > 40 && !description.contains("\n")
-                  ? TextAlign.start
-                  : TextAlign.center,
+              textAlign:
+                  description.length > 40 && !description.contains("\n") ? TextAlign.start : TextAlign.center,
             ),
           ),
         ),

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_expiration.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_expiration.dart
@@ -21,8 +21,7 @@ class PaymentDetailsDialogExpiration extends StatelessWidget {
     final texts = context.texts();
     final themeData = Theme.of(context);
 
-    if (!paymentInfo.pending ||
-        paymentInfo.type == PaymentType.CLOSED_CHANNEL) {
+    if (!paymentInfo.pending || paymentInfo.type == PaymentType.CLOSED_CHANNEL) {
       return Container();
     }
 

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_title.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_title.dart
@@ -25,9 +25,7 @@ class PaymentDetailsDialogTitle extends StatelessWidget {
                 top: Radius.circular(12.0),
               ),
             ),
-            color: theme.themeId == "BLUE"
-                ? themeData.primaryColorDark
-                : themeData.canvasColor,
+            color: theme.themeId == "BLUE" ? themeData.primaryColorDark : themeData.canvasColor,
           ),
           height: 64.0,
           width: mediaQuery.size.width,

--- a/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
@@ -50,16 +50,14 @@ class ShareablePaymentRow extends StatelessWidget {
                   padding: const EdgeInsets.only(left: 16.0, right: 0.0),
                   child: GestureDetector(
                     onTap: () => isTxID
-                        ? launchLinkOnExternalBrowser(
-                            "https://blockstream.info/tx/$sharedValue")
+                        ? launchLinkOnExternalBrowser("https://blockstream.info/tx/$sharedValue")
                         : null,
                     child: Text(
                       sharedValue,
                       textAlign: TextAlign.left,
                       overflow: TextOverflow.clip,
                       maxLines: 4,
-                      style: themeData.primaryTextTheme.displaySmall
-                          .copyWith(fontSize: 10),
+                      style: themeData.primaryTextTheme.displaySmall.copyWith(fontSize: 10),
                     ),
                   ),
                 ),
@@ -75,17 +73,14 @@ class ShareablePaymentRow extends StatelessWidget {
                       IconButton(
                         alignment: Alignment.centerRight,
                         padding: const EdgeInsets.only(right: 8.0),
-                        tooltip:
-                            texts.payment_details_dialog_copy_action(title),
+                        tooltip: texts.payment_details_dialog_copy_action(title),
                         iconSize: 16.0,
                         color: themeData.primaryTextTheme.labelLarge.color,
                         icon: const Icon(
                           IconData(0xe90b, fontFamily: 'icomoon'),
                         ),
                         onPressed: () {
-                          ServiceInjector()
-                              .device
-                              .setClipboardText(sharedValue);
+                          ServiceInjector().device.setClipboardText(sharedValue);
                           Navigator.pop(context);
                           showFlushbar(
                             context,

--- a/lib/routes/home/widgets/payments_list/dialog/tx_widget.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/tx_widget.dart
@@ -37,8 +37,7 @@ class TxWidget extends StatelessWidget {
         Padding(
           padding: padding ?? const EdgeInsets.only(top: 20.0),
           child: LinkLauncher(
-            linkTitle: txLabel ??
-                texts.payment_details_dialog_transaction_label_default,
+            linkTitle: txLabel ?? texts.payment_details_dialog_transaction_label_default,
             textStyle: textStyle,
             linkName: txID,
             linkAddress: txURL,

--- a/lib/routes/home/widgets/payments_list/payment_details_dialog.dart
+++ b/lib/routes/home/widgets/payments_list/payment_details_dialog.dart
@@ -123,8 +123,7 @@ List<Widget> _getPaymentInfoDetails(
   PaymentInfo paymentInfo,
 ) {
   if (paymentInfo is StreamedPaymentInfo) {
-    return groupBy<PaymentInfo, String>(
-            paymentInfo.singlePayments, (p) => p.title)
+    return groupBy<PaymentInfo, String>(paymentInfo.singlePayments, (p) => p.title)
         .entries
         .map((ent) => PaymentDetailsDialogDestination(
               title: ent.key,

--- a/lib/routes/initial_walkthrough/dialogs/beta_warning_dialog.dart
+++ b/lib/routes/initial_walkthrough/dialogs/beta_warning_dialog.dart
@@ -13,11 +13,6 @@ class BetaWarningDialogState extends State<BetaWarningDialog> {
   bool _showReminderText = false;
 
   @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
     final texts = context.texts();
     final themeData = Theme.of(context);

--- a/lib/routes/initial_walkthrough/dialogs/select_backup_provider_dialog.dart
+++ b/lib/routes/initial_walkthrough/dialogs/select_backup_provider_dialog.dart
@@ -29,8 +29,7 @@ class SelectBackupProviderDialog extends StatefulWidget {
   }
 }
 
-class SelectBackupProviderDialogState
-    extends State<SelectBackupProviderDialog> {
+class SelectBackupProviderDialogState extends State<SelectBackupProviderDialog> {
   int _selectedProviderIndex = 0;
   List<BackupProvider> _backupProviders;
   @override
@@ -193,9 +192,7 @@ class SelectBackupProviderDialogState
     return listBackupsAction.future.then((snapshots) {
       EasyLoading.dismiss();
 
-      if (snapshots != null &&
-          snapshots.isNotEmpty &&
-          snapshots is List<SnapshotInfo>) {
+      if (snapshots != null && snapshots.isNotEmpty && snapshots is List<SnapshotInfo>) {
         Navigator.pop(context, snapshots);
       } else {
         throw context.texts().initial_walk_through_error_backup_location;
@@ -210,7 +207,7 @@ class SelectBackupProviderDialogState
 
     switch (error.runtimeType) {
       case InsufficientScopeException:
-        if(Platform.isIOS){
+        if (Platform.isIOS) {
           Navigator.pop(context);
         }
         showFlushbar(

--- a/lib/routes/initial_walkthrough/dialogs/widgets/snapshot_info_tile.dart
+++ b/lib/routes/initial_walkthrough/dialogs/widgets/snapshot_info_tile.dart
@@ -34,12 +34,10 @@ class _SnapshotInfoTileState extends State<SnapshotInfoTile> {
     final texts = context.texts();
     final themeData = Theme.of(context);
 
-    final isSelected =
-        (widget.selectedSnapshot?.nodeID == widget.snapshotInfo.nodeID);
+    final isSelected = (widget.selectedSnapshot?.nodeID == widget.snapshotInfo.nodeID);
 
     var date = widget.snapshotInfo.modifiedTime;
-    var parsedDate =
-        DateTime.tryParse(widget.snapshotInfo.modifiedTime).toLocal();
+    var parsedDate = DateTime.tryParse(widget.snapshotInfo.modifiedTime).toLocal();
     if (parsedDate != null) {
       date = BreezDateUtils.formatYearMonthDayHourMinute(parsedDate);
     }
@@ -57,9 +55,7 @@ class _SnapshotInfoTileState extends State<SnapshotInfoTile> {
         widget.snapshotInfo.encrypted
             ? texts.restore_dialog_modified_encrypted(date)
             : texts.restore_dialog_modified_not_encrypted(date),
-        style: themeData.primaryTextTheme.bodySmall
-            .copyWith(fontSize: 9)
-            .apply(fontSizeDelta: 1.3),
+        style: themeData.primaryTextTheme.bodySmall.copyWith(fontSize: 9).apply(fontSizeDelta: 1.3),
       ),
       subtitle: Text(
         widget.snapshotInfo.nodeID,

--- a/lib/routes/initial_walkthrough/initial_walkthrough.dart
+++ b/lib/routes/initial_walkthrough/initial_walkthrough.dart
@@ -41,8 +41,7 @@ class InitialWalkthroughPage extends StatefulWidget {
   State<InitialWalkthroughPage> createState() => _InitialWalkthroughPageState();
 }
 
-class _InitialWalkthroughPageState extends State<InitialWalkthroughPage>
-    with SingleTickerProviderStateMixin {
+class _InitialWalkthroughPageState extends State<InitialWalkthroughPage> with SingleTickerProviderStateMixin {
   final GlobalKey scaffoldKey = GlobalKey<ScaffoldState>();
   AnimationController controller;
   Animation<int> animation;
@@ -120,8 +119,7 @@ class _InitialWalkthroughPageState extends State<InitialWalkthroughPage>
                         child: AnimatedBuilder(
                           animation: animation,
                           builder: (BuildContext context, Widget child) {
-                            String frame =
-                                animation.value.toString().padLeft(2, '0');
+                            String frame = animation.value.toString().padLeft(2, '0');
                             return Image.asset(
                               'src/animations/welcome/frame_${frame}_delay-0.04s.png',
                               gaplessPlayback: true,

--- a/lib/routes/initial_walkthrough/mnemonics/enter_mnemonics.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/enter_mnemonics.dart
@@ -32,9 +32,7 @@ class EnterMnemonicsPageState extends State<EnterMnemonicsPage> {
       widget.is24Word ? 24 : 12,
       (_) => TextEditingController(),
     );
-    for (var i = 0;
-        i < textEditingControllers.length && i < widget.initialWords.length;
-        i++) {
+    for (var i = 0; i < textEditingControllers.length && i < widget.initialWords.length; i++) {
       textEditingControllers[i].text = widget.initialWords[i];
     }
   }

--- a/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form.dart
@@ -35,8 +35,7 @@ class RestoreFormState extends State<RestoreForm> {
   void initState() {
     super.initState();
     _autoValidateMode = AutovalidateMode.disabled;
-    focusNodes =
-        List<FocusNode>.generate(widget.is24Word ? 24 : 12, (_) => FocusNode());
+    focusNodes = List<FocusNode>.generate(widget.is24Word ? 24 : 12, (_) => FocusNode());
   }
 
   @override
@@ -123,8 +122,7 @@ class RestoreFormState extends State<RestoreForm> {
   }
 
   FutureOr<List<String>> _getSuggestions(pattern) {
-    var suggestionList =
-        WORDLIST.where((item) => item.startsWith(pattern)).toList();
+    var suggestionList = WORDLIST.where((item) => item.startsWith(pattern)).toList();
     return suggestionList.isNotEmpty ? suggestionList : List.empty();
   }
 }

--- a/lib/routes/lnurl_fetch_invoice_page.dart
+++ b/lib/routes/lnurl_fetch_invoice_page.dart
@@ -83,8 +83,8 @@ class LNURLFetchInvoicePageState extends State<LNURLFetchInvoicePage> {
 
   @override
   void initState() {
-    _doneAction = KeyboardDoneAction(<FocusNode>[_amountFocusNode]);
     super.initState();
+    _doneAction = KeyboardDoneAction(<FocusNode>[_amountFocusNode]);
   }
 
   @override

--- a/lib/routes/lnurl_fetch_invoice_page.dart
+++ b/lib/routes/lnurl_fetch_invoice_page.dart
@@ -134,10 +134,7 @@ class LNURLFetchInvoicePageState extends State<LNURLFetchInvoicePage> {
             }
             var account = snapshot.data;
             return Padding(
-              padding: EdgeInsets.only(
-                  bottom: (Platform.isIOS && _amountFocusNode.hasFocus)
-                      ? 40.0
-                      : 0.0),
+              padding: EdgeInsets.only(bottom: (Platform.isIOS && _amountFocusNode.hasFocus) ? 40.0 : 0.0),
               child: SingleButtonBottomBar(
                 stickToBottom: true,
                 text: texts.lnurl_fetch_invoice_action_continue,
@@ -216,8 +213,7 @@ class LNURLFetchInvoicePageState extends State<LNURLFetchInvoicePage> {
                           style: theme.FieldTextStyle.labelStyle,
                           children: <TextSpan>[
                             TextSpan(
-                              text: texts.lnurl_fetch_invoice_min(
-                                  acc.currency.format(response.minAmount)),
+                              text: texts.lnurl_fetch_invoice_min(acc.currency.format(response.minAmount)),
                               recognizer: TapGestureRecognizer()
                                 ..onTap = () => _pasteAmount(
                                       acc.currency,
@@ -225,8 +221,7 @@ class LNURLFetchInvoicePageState extends State<LNURLFetchInvoicePage> {
                                     ),
                             ),
                             TextSpan(
-                              text: texts.lnurl_fetch_invoice_and(
-                                  acc.currency.format(response.maxAmount)),
+                              text: texts.lnurl_fetch_invoice_and(acc.currency.format(response.maxAmount)),
                               recognizer: TapGestureRecognizer()
                                 ..onTap = () => _pasteAmount(
                                       acc.currency,
@@ -373,8 +368,7 @@ class LNURLFetchInvoicePageState extends State<LNURLFetchInvoicePage> {
     _loaderRoute = createLoaderRoute(context);
     navigator.push(_loaderRoute);
 
-    _payFetchResponse.amount =
-        account.currency.parse(_amountController.text) * 1000;
+    _payFetchResponse.amount = account.currency.parse(_amountController.text) * 1000;
     _payFetchResponse.comment = _commentController.text;
 
     var action = FetchInvoice(_payFetchResponse);
@@ -393,8 +387,7 @@ class LNURLFetchInvoicePageState extends State<LNURLFetchInvoicePage> {
       );
     }).then((payinfo) {
       invoiceBloc.decodeInvoiceSink.add(payinfo.invoice);
-      _log.info(
-          '_getInvoice: Found LNUrlPayInfo. Beginning payment request flow.');
+      _log.info('_getInvoice: Found LNUrlPayInfo. Beginning payment request flow.');
       _removeLoader();
 
       /*

--- a/lib/routes/lsp/lsp_webview.dart
+++ b/lib/routes/lsp/lsp_webview.dart
@@ -55,18 +55,16 @@ class LSPWebViewPageState extends State<LSPWebViewPage> {
 
   void _onPageFinished(String url) async {
     // redirect post messages to javascript channel
-    _webViewController.runJavaScript(
-        'window.onmessage = (message) => window.BreezWebView.postMessage(message.data);');
-    _webViewController.runJavaScript(
-        await rootBundle.loadString('src/scripts/lightningLinkInterceptor.js'));
+    _webViewController
+        .runJavaScript('window.onmessage = (message) => window.BreezWebView.postMessage(message.data);');
+    _webViewController.runJavaScript(await rootBundle.loadString('src/scripts/lightningLinkInterceptor.js'));
   }
 
   void _onMessageReceived(JavaScriptMessage message) {
     if (message != null) {
       var decodedMsg = JSON.jsonDecode(message.message);
       String lightningLink = decodedMsg["lightningLink"];
-      if (lightningLink != null &&
-          lightningLink.toLowerCase().startsWith("lightning:lnurl")) {
+      if (lightningLink != null && lightningLink.toLowerCase().startsWith("lightning:lnurl")) {
         Navigator.pop(context, lightningLink.substring(10));
       }
     }

--- a/lib/routes/marketplace/lnurl_webview.dart
+++ b/lib/routes/marketplace/lnurl_webview.dart
@@ -59,9 +59,7 @@ class LNURLWebViewPageState extends State<LNURLWebViewPage> {
   Future _handleLNUrlAuth() async {
     final texts = context.texts();
     Uri uri = widget.endpointURI;
-    var response = widget.vendorModel.id == "lnmarkets"
-        ? await http.post(uri)
-        : await http.get(uri);
+    var response = widget.vendorModel.id == "lnmarkets" ? await http.post(uri) : await http.get(uri);
     if (response.statusCode != 200 && response.statusCode != 201) {
       throw Exception(
         texts.lnurl_webview_error_message(widget.vendorModel.displayName),

--- a/lib/routes/marketplace/make_invoice_request.dart
+++ b/lib/routes/marketplace/make_invoice_request.dart
@@ -44,8 +44,7 @@ class MakeInvoiceRequest extends StatelessWidget {
           style: themeData.primaryTextTheme.displaySmall.copyWith(
             fontSize: 16,
           ),
-          textAlign:
-              description.length > 40 ? TextAlign.justify : TextAlign.center,
+          textAlign: description.length > 40 ? TextAlign.justify : TextAlign.center,
           maxLines: 3,
         ),
       ));

--- a/lib/routes/marketplace/marketplace.dart
+++ b/lib/routes/marketplace/marketplace.dart
@@ -29,9 +29,7 @@ class MarketplacePageState extends State<MarketplacePage> {
       ),
       child: Scaffold(
         key: _scaffoldKey,
-        backgroundColor: theme.themeId == "BLUE"
-            ? themeData.colorScheme.background
-            : themeData.canvasColor,
+        backgroundColor: theme.themeId == "BLUE" ? themeData.colorScheme.background : themeData.canvasColor,
         body: StreamBuilder(
           stream: marketplaceBloc.vendorsStream,
           builder: (context, snapshot) {
@@ -58,8 +56,7 @@ class MarketplacePageState extends State<MarketplacePage> {
           texts.market_place_no_vendors,
           textAlign: TextAlign.center,
           style: themeData.textTheme.headlineMedium.copyWith(
-            color:
-                theme.themeId == "BLUE" ? themeData.canvasColor : Colors.white,
+            color: theme.themeId == "BLUE" ? themeData.canvasColor : Colors.white,
           ),
         ),
       ),
@@ -70,9 +67,7 @@ class MarketplacePageState extends State<MarketplacePage> {
     final accountBloc = AppBlocsProvider.of<AccountBloc>(context);
 
     return SizedBox(
-      height: MediaQuery.of(context).size.height -
-          kToolbarHeight -
-          MediaQuery.of(context).padding.top,
+      height: MediaQuery.of(context).size.height - kToolbarHeight - MediaQuery.of(context).padding.top,
       child: ListView.builder(
         itemBuilder: (context, i) => VendorRow(accountBloc, vendorModel[i]),
         itemCount: vendorModel.length,

--- a/lib/routes/marketplace/nostr_event_handlers.dart
+++ b/lib/routes/marketplace/nostr_event_handlers.dart
@@ -19,12 +19,10 @@ class NostrEventHandler {
   final NostrBloc _nostrBloc = NostrBloc();
   NostrEventHandler(this.context, this.appName);
 
-  Future<String> get initNostrProvider =>
-      rootBundle.loadString('src/scripts/nostr-provider.js');
+  Future<String> get initNostrProvider => rootBundle.loadString('src/scripts/nostr-provider.js');
 
   Future<String> handleNostrEventMessage(postMessage) async {
-    Map<String, Future<dynamic> Function(Map<String, dynamic> data)>
-        nostrHandlersMapping = {
+    Map<String, Future<dynamic> Function(Map<String, dynamic> data)> nostrHandlersMapping = {
       "getPublicKey": _getPublicKey,
       "signEvent": _signEvent,
       "getRelays": _getRelays,
@@ -55,8 +53,7 @@ class NostrEventHandler {
     // getting prompt choice
     SharedPreferences prefs = await SharedPreferences.getInstance();
 
-    final nostrSettings =
-        prefs.getString(NostrSettings.NOSTR_SETTINGS_PREFERENCES_KEY);
+    final nostrSettings = prefs.getString(NostrSettings.NOSTR_SETTINGS_PREFERENCES_KEY);
 
     Map<String, dynamic> settings = json.decode(nostrSettings);
     var nostrSettingsModel = NostrSettings.fromJson(settings);
@@ -84,8 +81,7 @@ class NostrEventHandler {
 
     SharedPreferences prefs = await SharedPreferences.getInstance();
 
-    final nostrSettings =
-        prefs.getString(NostrSettings.NOSTR_SETTINGS_PREFERENCES_KEY);
+    final nostrSettings = prefs.getString(NostrSettings.NOSTR_SETTINGS_PREFERENCES_KEY);
 
     Map<String, dynamic> settings = json.decode(nostrSettings);
     var nostrSettingsModel = NostrSettings.fromJson(settings);
@@ -93,8 +89,7 @@ class NostrEventHandler {
     final rememberChoice = nostrSettingsModel.isRememberSignEvent;
 
     if (rememberChoice == false || rememberChoice == null) {
-      final shouldSignEvent = await _showDialogForSignEvent(
-          eventData, eventData['content'], messageKind);
+      final shouldSignEvent = await _showDialogForSignEvent(eventData, eventData['content'], messageKind);
 
       if (!shouldSignEvent) {
         return;
@@ -125,10 +120,9 @@ class NostrEventHandler {
     return Future(() => null);
   }
 
-  Future _showDialogForSignEvent(Map<String, dynamic> eventData,
-      String eventContent, String messageKind) async {
-    String textContent =
-        '$appName requires you to sign this $messageKind with your nostr key.';
+  Future _showDialogForSignEvent(
+      Map<String, dynamic> eventData, String eventContent, String messageKind) async {
+    String textContent = '$appName requires you to sign this $messageKind with your nostr key.';
     return showDialog(
         context: context,
         barrierDismissible: false,

--- a/lib/routes/marketplace/vendor_row.dart
+++ b/lib/routes/marketplace/vendor_row.dart
@@ -17,14 +17,9 @@ class VendorRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Color vendorFgColor =
-        theme.vendorTheme[_vendor.id.toLowerCase()]?.iconFgColor ??
-            Colors.transparent;
-    Color vendorBgColor =
-        theme.vendorTheme[_vendor.id.toLowerCase()]?.iconBgColor ??
-            Colors.white;
-    Color vendorTextColor =
-        theme.vendorTheme[_vendor.id.toLowerCase()]?.textColor ?? Colors.black;
+    Color vendorFgColor = theme.vendorTheme[_vendor.id.toLowerCase()]?.iconFgColor ?? Colors.transparent;
+    Color vendorBgColor = theme.vendorTheme[_vendor.id.toLowerCase()]?.iconBgColor ?? Colors.white;
+    Color vendorTextColor = theme.vendorTheme[_vendor.id.toLowerCase()]?.textColor ?? Colors.black;
 
     final vendorLogo = _vendor.logo != null
         ? Image(
@@ -60,8 +55,7 @@ class VendorRow extends StatelessWidget {
                   responseID: _vendor.responseID,
                 );
               }
-              return VendorWebViewPage(
-                  accountBloc, _vendor.url, _vendor.displayName);
+              return VendorWebViewPage(accountBloc, _vendor.url, _vendor.displayName);
             },
           ));
         },
@@ -77,9 +71,8 @@ class VendorRow extends StatelessWidget {
                 )
               ],
               border: Border.all(
-                  color: vendorBgColor == Colors.white
-                      ? Theme.of(context).highlightColor
-                      : Colors.transparent,
+                  color:
+                      vendorBgColor == Colors.white ? Theme.of(context).highlightColor : Colors.transparent,
                   style: BorderStyle.solid,
                   width: 1.0),
               borderRadius: BorderRadius.circular(14.0)),
@@ -100,8 +93,7 @@ class VendorRow extends StatelessWidget {
       return <Widget>[
         vendorLogo,
         const Padding(padding: EdgeInsets.only(left: 8.0)),
-        Text(_vendor.displayName,
-            style: theme.vendorTitleStyle.copyWith(color: vendorTextColor)),
+        Text(_vendor.displayName, style: theme.vendorTitleStyle.copyWith(color: vendorTextColor)),
       ];
     }
   }

--- a/lib/routes/marketplace/vendor_webview.dart
+++ b/lib/routes/marketplace/vendor_webview.dart
@@ -42,6 +42,7 @@ class VendorWebViewPageState extends State<VendorWebViewPage> {
 
   @override
   void didChangeDependencies() {
+    super.didChangeDependencies();
     if (!_isInit) {
       _invoiceBloc = AppBlocsProvider.of<InvoiceBloc>(context);
       _weblnHandlers = WebLNHandlers(context, widget.accountBloc, _invoiceBloc);
@@ -58,7 +59,6 @@ class VendorWebViewPageState extends State<VendorWebViewPage> {
     if (_webViewController.platform is AndroidWebViewController) {
       AndroidWebViewController.enableDebugging(true);
     }
-    super.didChangeDependencies();
   }
 
   @override

--- a/lib/routes/marketplace/vendor_webview.dart
+++ b/lib/routes/marketplace/vendor_webview.dart
@@ -96,8 +96,7 @@ class VendorWebViewPageState extends State<VendorWebViewPage> {
   _handleNavigationRequest(NavigationRequest request) {
     if (request.url.startsWith('lightning:')) {
       return NavigationDecision.prevent;
-    } else if (request.url.startsWith('tg:') ||
-        request.url.startsWith('fold:')) {
+    } else if (request.url.startsWith('tg:') || request.url.startsWith('fold:')) {
       launchUrlString(request.url);
       return NavigationDecision.prevent;
     }
@@ -106,18 +105,16 @@ class VendorWebViewPageState extends State<VendorWebViewPage> {
 
   void _onPageFinished(String url) async {
     // intercept ln link clicks
-    _webViewController.runJavaScript(
-        await rootBundle.loadString('src/scripts/lightningLinkInterceptor.js'));
+    _webViewController.runJavaScript(await rootBundle.loadString('src/scripts/lightningLinkInterceptor.js'));
     // redirect post messages to javascript channel
-    _webViewController.runJavaScript(
-        'window.onmessage = (message) => window.BreezWebView.postMessage(message.data);');
+    _webViewController
+        .runJavaScript('window.onmessage = (message) => window.BreezWebView.postMessage(message.data);');
 
     _webViewController.runJavaScript(await _weblnHandlers.initWebLNScript);
 
     // inject nostr-provider for Snort
     if (widget._title == "Snort") {
-      _webViewController
-          .runJavaScript(await _nostrEventHandler.initNostrProvider);
+      _webViewController.runJavaScript(await _nostrEventHandler.initNostrProvider);
     }
 
     if (kDebugMode) {
@@ -143,8 +140,7 @@ class VendorWebViewPageState extends State<VendorWebViewPage> {
       // handle lightning links and WebLN payments
       if (postMessage["lightningLink"] != null &&
           postMessage["lightningLink"].toLowerCase().startsWith("lightning:")) {
-        _invoiceBloc.newLightningLinkSink
-            .add(postMessage["lightningLink"].substring(10));
+        _invoiceBloc.newLightningLinkSink.add(postMessage["lightningLink"].substring(10));
       } else {
         _weblnHandlers.handleMessage(postMessage).then((resScript) {
           if (resScript != null) {

--- a/lib/routes/marketplace/webln_handlers.dart
+++ b/lib/routes/marketplace/webln_handlers.dart
@@ -22,10 +22,8 @@ class WebLNHandlers {
   AccountModel _account;
 
   WebLNHandlers(this.context, this.accountBloc, this.invoiceBloc) {
-    _readyInvoicesSubscription = invoiceBloc.readyInvoicesStream
-        .asBroadcastStream()
-        .where((p) => p != null)
-        .listen((bolt11) {
+    _readyInvoicesSubscription =
+        invoiceBloc.readyInvoicesStream.asBroadcastStream().where((p) => p != null).listen((bolt11) {
       _currentInvoiceRequestCompleter?.complete(bolt11.rawPayReq);
       _currentInvoiceRequestCompleter = null;
     }, onError: (_) {
@@ -33,17 +31,13 @@ class WebLNHandlers {
       _currentInvoiceRequestCompleter = null;
     });
 
-    _accountModelSubscription =
-        accountBloc.accountStream.listen((acc) => _account = acc);
+    _accountModelSubscription = accountBloc.accountStream.listen((acc) => _account = acc);
   }
 
-  Future<String> get initWebLNScript =>
-      rootBundle.loadString('src/scripts/initializeWebLN.js');
+  Future<String> get initWebLNScript => rootBundle.loadString('src/scripts/initializeWebLN.js');
 
   Future<String> handleMessage(postMessage) async {
-    Map<String,
-            Future<Map<String, dynamic>> Function(Map<String, dynamic> data)>
-        handlersMapping = {
+    Map<String, Future<Map<String, dynamic>> Function(Map<String, dynamic> data)> handlersMapping = {
       "sendPayment": _sendPayment,
       "makeInvoice": _makeInvoice,
       "enable": (_) => Future.value({}),
@@ -105,13 +99,11 @@ class WebLNHandlers {
         context: context,
         barrierDismissible: false,
         builder: (ctx) {
-          return MakeInvoiceRequest(
-              amount: amount, description: memo, account: _account);
+          return MakeInvoiceRequest(amount: amount, description: memo, account: _account);
         });
 
     if (accept == true) {
-      invoiceBloc.newInvoiceRequestSink
-          .add(InvoiceRequestModel(null, memo, null, Int64(amount)));
+      invoiceBloc.newInvoiceRequestSink.add(InvoiceRequestModel(null, memo, null, Int64(amount)));
       return _trackInvoice().then((bolt11) => {"paymentRequest": bolt11});
     }
     return Future.error("Request denied");
@@ -131,8 +123,7 @@ class WebLNHandlers {
   Future _trackPayment(String bolt11) {
     Completer paymentCompleter = Completer();
     _sentPaymentResultSubscription?.cancel();
-    _sentPaymentResultSubscription =
-        accountBloc.completedPaymentsStream.listen((payment) {
+    _sentPaymentResultSubscription = accountBloc.completedPaymentsStream.listen((payment) {
       if (payment.paymentRequest.paymentRequest == bolt11) {
         if (payment.cancelled) {
           paymentCompleter.completeError("canceled");

--- a/lib/routes/network/network.dart
+++ b/lib/routes/network/network.dart
@@ -69,8 +69,7 @@ class NetworkPageState extends State<NetworkPage> {
   Future<void> _loadPeers() async {
     loadPeersAction = Completer();
     Peers peers = await _breezLib.getPeers();
-    peers.peer.forEachIndexed(
-        (index, peer) => peerControllers.elementAt(index).text = peer);
+    peers.peer.forEachIndexed((index, peer) => peerControllers.elementAt(index).text = peer);
     loadPeersAction.complete(true);
   }
 
@@ -99,9 +98,7 @@ class NetworkPageState extends State<NetworkPage> {
                 children: [
                   if (_data.showTor)
                     SimpleSwitch(
-                      text: _data.torIsActive
-                          ? texts.network_tor_disable
-                          : texts.network_tor_enable,
+                      text: _data.torIsActive ? texts.network_tor_disable : texts.network_tor_enable,
                       switchValue: _data.torIsActive,
                       onChanged: _torSwitchChanged,
                     ),
@@ -168,8 +165,7 @@ class NetworkPageState extends State<NetworkPage> {
 
   bool _areNodesDistinct(String value) {
     return peerControllers[0].text.isNotEmpty &&
-        peerControllers[0].text.toLowerCase().trim() ==
-            value.toLowerCase().trim();
+        peerControllers[0].text.toLowerCase().trim() == value.toLowerCase().trim();
   }
 
   void _resetNodes() async {
@@ -177,8 +173,7 @@ class NetworkPageState extends State<NetworkPage> {
     final nodeIsValid = await _testNode();
     if (nodeIsValid) {
       await _breezLib.setPeers([]);
-      peerControllers = List<TextEditingController>.generate(
-          2, (_) => TextEditingController());
+      peerControllers = List<TextEditingController>.generate(2, (_) => TextEditingController());
       await _loadPeers();
       setState(() {});
       _promptForRestart();
@@ -284,9 +279,7 @@ class NetworkPageState extends State<NetworkPage> {
             context,
             null,
             Text(
-              value
-                  ? texts.network_tor_enable_error
-                  : texts.network_tor_disable,
+              value ? texts.network_tor_enable_error : texts.network_tor_disable,
               style: themeData.dialogTheme.contentTextStyle,
             ),
           );
@@ -374,9 +367,7 @@ class _TestingPeerDialogState extends State<_TestingPeerDialog> {
       onWillPop: () => Future.value(_allowPop),
       child: createAnimatedLoaderDialog(
         context,
-        widget.peer.isNotEmpty
-            ? "${texts.network_testing_node}: ${widget.peer}"
-            : texts.network_testing_node,
+        widget.peer.isNotEmpty ? "${texts.network_testing_node}: ${widget.peer}" : texts.network_testing_node,
         withOKButton: false,
       ),
     );
@@ -387,8 +378,7 @@ class _SetTorActiveDialog extends StatefulWidget {
   final Future testFuture;
   final bool enable;
 
-  const _SetTorActiveDialog({Key key, this.testFuture, this.enable})
-      : super(key: key);
+  const _SetTorActiveDialog({Key key, this.testFuture, this.enable}) : super(key: key);
 
   @override
   State<StatefulWidget> createState() {
@@ -414,10 +404,7 @@ class _SetTorActiveDialogState extends State<_SetTorActiveDialog> {
     return WillPopScope(
         onWillPop: () => Future.value(_allowPop),
         child: createAnimatedLoaderDialog(
-            context,
-            widget.enable
-                ? texts.network_tor_enabling
-                : texts.network_tor_disabling,
+            context, widget.enable ? texts.network_tor_enabling : texts.network_tor_disabling,
             withOKButton: false));
   }
 }

--- a/lib/routes/order_card/order_card_page.dart
+++ b/lib/routes/order_card/order_card_page.dart
@@ -111,9 +111,7 @@ class OrderCardPageState extends State<OrderCardPage> {
         }
       }
 
-      if (_statesShow.isNotEmpty &&
-          !_statesShow.contains(inputText) &&
-          _stateFocusNode.hasFocus) {
+      if (_statesShow.isNotEmpty && !_statesShow.contains(inputText) && _stateFocusNode.hasFocus) {
         _statesShow.sort();
         setState(() {
           _autoValidateState = AutovalidateMode.disabled;
@@ -143,9 +141,7 @@ class OrderCardPageState extends State<OrderCardPage> {
       _countriesShow.clear();
       _countriesJSON.forEach(_iterateMapEntryGetCountriesShow);
 
-      if (_countriesShow.isNotEmpty &&
-          !_countriesShow.contains(inputText) &&
-          _countryFocusNode.hasFocus) {
+      if (_countriesShow.isNotEmpty && !_countriesShow.contains(inputText) && _countryFocusNode.hasFocus) {
         _countriesShow.sort();
         setState(() {
           _autoValidateCountry = AutovalidateMode.disabled;
@@ -171,24 +167,21 @@ class OrderCardPageState extends State<OrderCardPage> {
 
   void _onChangeZip() {
     setState(() {
-      _autoValidateZip =
-          (_zipController.text.isNotEmpty && !_zipFocusNode.hasFocus)
-              ? AutovalidateMode.always
-              : AutovalidateMode.disabled;
+      _autoValidateZip = (_zipController.text.isNotEmpty && !_zipFocusNode.hasFocus)
+          ? AutovalidateMode.always
+          : AutovalidateMode.disabled;
     });
   }
 
   void _iterateMapEntryGetCountriesShow(key, value) {
     String inputText = _countryController.text;
-    if (value.length >= inputText.length &&
-        value.toLowerCase().startsWith(inputText.toLowerCase())) {
+    if (value.length >= inputText.length && value.toLowerCase().startsWith(inputText.toLowerCase())) {
       _countriesShow.add(value);
     }
   }
 
   void _iterateMapEntryGetCountryShort(key, value) {
-    if (value.toString().toLowerCase() ==
-        _countryController.text.toLowerCase()) {
+    if (value.toString().toLowerCase() == _countryController.text.toLowerCase()) {
       _userCountryShort = key;
     }
   }
@@ -200,11 +193,7 @@ class OrderCardPageState extends State<OrderCardPage> {
     Uri uri = Uri.http(
       "api.ipstack.com",
       "check",
-      {
-        "access_key": "025a14ce39e8588578966edfe7e7d70a",
-        "output": "json",
-        "fields": "country_code"
-      },
+      {"access_key": "025a14ce39e8588578966edfe7e7d70a", "output": "json", "fields": "country_code"},
     );
     final response = await http.get(uri);
     if (response.statusCode == 200) {
@@ -392,9 +381,7 @@ class OrderCardPageState extends State<OrderCardPage> {
         automaticallyImplyLeading: false,
         leading: _showLeadingButton(showSkip),
         title: Text(
-          showSkip
-              ? texts.order_card_action_order_breez_card
-              : texts.order_card_action_order_card,
+          showSkip ? texts.order_card_action_order_breez_card : texts.order_card_action_order_card,
         ),
         actions: _showSkipButton(showSkip),
       ),
@@ -432,8 +419,7 @@ class OrderCardPageState extends State<OrderCardPage> {
                                   Container(
                                     padding: const EdgeInsets.only(top: 19.0),
                                     child: Row(
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.start,
+                                      crossAxisAlignment: CrossAxisAlignment.start,
                                       children: [
                                         _country(context),
                                         _zipCode(context),
@@ -602,11 +588,9 @@ class OrderCardPageState extends State<OrderCardPage> {
             _data.state = value;
           },
           validator: (value) {
-            if (value.isEmpty &&
-                _specialCountriesShort.contains(_userCountryShort)) {
+            if (value.isEmpty && _specialCountriesShort.contains(_userCountryShort)) {
               return texts.order_card_country_state_empty;
-            } else if (_specialCountriesShort.contains(_userCountryShort) &&
-                _checkStates(value)) {
+            } else if (_specialCountriesShort.contains(_userCountryShort) && _checkStates(value)) {
               return texts.order_card_country_state_invalid;
             }
             return null;

--- a/lib/routes/payment_options/payment_options_page.dart
+++ b/lib/routes/payment_options/payment_options_page.dart
@@ -76,9 +76,7 @@ class _PaymentOptionsPageState extends State<PaymentOptionsPage> {
         leading: const backBtn.BackButton(),
         title: Text(texts.payment_options_title),
       ),
-      body: (_loadingOverride || _loadingBaseFee || _loadingProportionalFee)
-          ? Container()
-          : _body(context),
+      body: (_loadingOverride || _loadingBaseFee || _loadingProportionalFee) ? Container() : _body(context),
     );
   }
 
@@ -148,8 +146,7 @@ class _PaymentOptionsPageState extends State<PaymentOptionsPage> {
             child: Form(
               child: TextFormField(
                 enabled: _overriding,
-                keyboardType:
-                    const TextInputType.numberWithOptions(decimal: false),
+                keyboardType: const TextInputType.numberWithOptions(decimal: false),
                 inputFormatters: [
                   FilteringTextInputFormatter.digitsOnly,
                 ],
@@ -362,8 +359,7 @@ class _PaymentOptionsPageState extends State<PaymentOptionsPage> {
     _closeKeyboard();
 
     final options = AppBlocsProvider.of<PaymentOptionsBloc>(context);
-    var updatePaymentProportionalFeeAction =
-        UpdatePaymentProportionalFee(_proportionalFee);
+    var updatePaymentProportionalFeeAction = UpdatePaymentProportionalFee(_proportionalFee);
     var updatePaymentBaseFeeAction = UpdatePaymentBaseFee(_baseFee);
     final overridePaymentFeeAction = OverridePaymentFee(_overriding);
     options.actionsSink.add(updatePaymentProportionalFeeAction);

--- a/lib/routes/podcast/boost.dart
+++ b/lib/routes/podcast/boost.dart
@@ -137,8 +137,7 @@ class BoostWidget extends StatelessWidget {
                             builder: (c) => CustomAmountDialog(
                               userModel.paymentOptions.customBoostValue,
                               userModel.paymentOptions.presetBoostAmountsList,
-                              (boostAmount) =>
-                                  _setBoostAmount(userBloc, boostAmount),
+                              (boostAmount) => _setBoostAmount(userBloc, boostAmount),
                             ),
                           ),
                         ),

--- a/lib/routes/podcast/boost_message_dialog.dart
+++ b/lib/routes/podcast/boost_message_dialog.dart
@@ -119,8 +119,7 @@ class BoostMessageDialogState extends State<BoostMessageDialog> {
         ),
       ),
     ];
-    if (_amountKey.currentState?.validate() ??
-        _amountController.text.isNotEmpty) {
+    if (_amountKey.currentState?.validate() ?? _amountController.text.isNotEmpty) {
       actions.add(
         TextButton(
           onPressed: () {

--- a/lib/routes/podcast/confetti.dart
+++ b/lib/routes/podcast/confetti.dart
@@ -29,13 +29,7 @@ class Confetti extends StatelessWidget {
       // start again as soon as the animation is finished
       shouldLoop: false,
       // manually specify the colors to be used
-      colors: const [
-        Colors.green,
-        Colors.blue,
-        Colors.pink,
-        Colors.orange,
-        Colors.purple
-      ],
+      colors: const [Colors.green, Colors.blue, Colors.pink, Colors.orange, Colors.purple],
     );
   }
 }

--- a/lib/routes/podcast/payment_adjuster.dart
+++ b/lib/routes/podcast/payment_adjuster.dart
@@ -49,8 +49,7 @@ class PaymentAdjuster extends StatelessWidget {
                     builder: (c) => CustomAmountDialog(
                       userModel.paymentOptions.customSatsPerMinValue,
                       userModel.paymentOptions.presetSatsPerMinuteAmountsList,
-                      (satsPerMinute) =>
-                          userBloc.userActionsSink.add(SetPaymentOptions(
+                      (satsPerMinute) => userBloc.userActionsSink.add(SetPaymentOptions(
                         userModel.paymentOptions.copyWith(
                           preferredSatsPerMinValue: satsPerMinute,
                           customSatsPerMinValue: satsPerMinute,

--- a/lib/routes/podcast/podcast_clip/custom_clips_duration_dialog.dart
+++ b/lib/routes/podcast/podcast_clip/custom_clips_duration_dialog.dart
@@ -7,8 +7,7 @@ class CustomClipsDurationDialog extends StatefulWidget {
   const CustomClipsDurationDialog({Key key}) : super(key: key);
 
   @override
-  State<CustomClipsDurationDialog> createState() =>
-      _CustomClipsDurationDialogState();
+  State<CustomClipsDurationDialog> createState() => _CustomClipsDurationDialogState();
 }
 
 class _CustomClipsDurationDialogState extends State<CustomClipsDurationDialog> {

--- a/lib/routes/podcast/podcast_clip/podcast_clip_detail_bottom_sheet.dart
+++ b/lib/routes/podcast/podcast_clip/podcast_clip_detail_bottom_sheet.dart
@@ -24,12 +24,10 @@ class PodcastClipDetailBottomSheet extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  State<PodcastClipDetailBottomSheet> createState() =>
-      _PodcastClipDetailBottomSheetState();
+  State<PodcastClipDetailBottomSheet> createState() => _PodcastClipDetailBottomSheetState();
 }
 
-class _PodcastClipDetailBottomSheetState
-    extends State<PodcastClipDetailBottomSheet> {
+class _PodcastClipDetailBottomSheetState extends State<PodcastClipDetailBottomSheet> {
   @override
   Widget build(BuildContext context) {
     final podcastClipBloc = AppBlocsProvider.of<PodcastClipBloc>(context);
@@ -116,28 +114,21 @@ class _PodcastClipDetailBottomSheetState
                           ),
                         ),
                         const Spacer(),
-                        clipDetailSnapshot.data.podcastClipState ==
-                                PodcastClipState.IDLE
+                        clipDetailSnapshot.data.podcastClipState == PodcastClipState.IDLE
                             ? TextButton(
                                 onPressed: () async {
-                                  podcastClipBloc.setPodcastState(
-                                      PodcastClipState.FETCHING_IMAGE);
-                                  Episode e =
-                                      clipDetailSnapshot.data.episodeDetails;
+                                  podcastClipBloc.setPodcastState(PodcastClipState.FETCHING_IMAGE);
+                                  Episode e = clipDetailSnapshot.data.episodeDetails;
                                   var image = NetworkImage(e.imageUrl);
 
-                                  image
-                                      .resolve(const ImageConfiguration())
-                                      .addListener(
+                                  image.resolve(const ImageConfiguration()).addListener(
                                     ImageStreamListener(
                                       (info, call) async {
                                         try {
                                           Uint8List screenShotImage =
-                                              await ScreenshotController()
-                                                  .captureFromWidget(
+                                              await ScreenshotController().captureFromWidget(
                                             _imageWidget(
-                                              episodeDetails: clipDetailSnapshot
-                                                  .data.episodeDetails,
+                                              episodeDetails: clipDetailSnapshot.data.episodeDetails,
                                             ),
                                             context: context,
                                             delay: const Duration(
@@ -271,10 +262,7 @@ class _PodcastClipDetailBottomSheetState
         gradient: LinearGradient(
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
-          colors: [
-            breezTheme.BreezColors.blue[500],
-            breezTheme.BreezColors.blue[500].withOpacity(0.5)
-          ],
+          colors: [breezTheme.BreezColors.blue[500], breezTheme.BreezColors.blue[500].withOpacity(0.5)],
         ),
       ),
       padding: const EdgeInsets.only(left: 20, right: 20, top: 20, bottom: 28),
@@ -349,6 +337,5 @@ class _PodcastClipDetailBottomSheetState
     );
   }
 
-  String _formatDuration(Duration d) =>
-      d.toString().split('.').first.padLeft(8, "0");
+  String _formatDuration(Duration d) => d.toString().split('.').first.padLeft(8, "0");
 }

--- a/lib/routes/podcast/podcast_index_api.dart
+++ b/lib/routes/podcast/podcast_index_api.dart
@@ -101,10 +101,8 @@ class PodcastIndexAPI extends PodcastApi {
 
   @override
   void addClientAuthorityBytes(List<int> certificateAuthorityBytes) {
-    if (_certificateAuthorityBytes.isNotEmpty &&
-        _defaultSecurityContext == null) {
-      SecurityContext.defaultContext
-          .setTrustedCertificatesBytes(_certificateAuthorityBytes);
+    if (_certificateAuthorityBytes.isNotEmpty && _defaultSecurityContext == null) {
+      SecurityContext.defaultContext.setTrustedCertificatesBytes(_certificateAuthorityBytes);
       _defaultSecurityContext = SecurityContext.defaultContext;
     }
   }

--- a/lib/routes/podcast/podcast_loader.dart
+++ b/lib/routes/podcast/podcast_loader.dart
@@ -12,14 +12,10 @@ import 'package:podcast_search/podcast_search.dart';
 
 const PODCAST_INDEX_KEY = "XXWQEGULBJABVHZUM8NF";
 const PODCAST_INDEX_SECRET = "KZ2uy4upvq4t3e\$m\$3r2TeFS2fEpFTAaF92xcNdX";
-const BYFEED_API_ENDPOINT =
-    'https://api.podcastindex.org/api/1.0/podcasts/byfeedurl';
-const EPISODES_BYFEED_API_ENDPOINT =
-    'https://api.podcastindex.org/api/1.0/episodes/byfeedurl';
-const EPISODES_BYGUID_API_ENDPOINT =
-    'https://api.podcastindex.org/api/1.0/episodes/byguid';
-const VALUE_BYGUID_API_ENDPOINT =
-    'https://api.podcastindex.org/api/1.0/value/byepisodeguid';
+const BYFEED_API_ENDPOINT = 'https://api.podcastindex.org/api/1.0/podcasts/byfeedurl';
+const EPISODES_BYFEED_API_ENDPOINT = 'https://api.podcastindex.org/api/1.0/episodes/byfeedurl';
+const EPISODES_BYGUID_API_ENDPOINT = 'https://api.podcastindex.org/api/1.0/episodes/byguid';
+const VALUE_BYGUID_API_ENDPOINT = 'https://api.podcastindex.org/api/1.0/value/byepisodeguid';
 
 class PodcastIndexClient {
   static Dio _createClient() {

--- a/lib/routes/podcast/podcast_page.dart
+++ b/lib/routes/podcast/podcast_page.dart
@@ -61,8 +61,8 @@ class AnytimePodcastApp extends StatefulWidget {
 
   AnytimePodcastApp(this.mobileSettingsService, this.repository, this.child)
       : podcastApi = PodcastIndexAPI() {
-    downloadService = MobileDownloadService(
-        repository: repository, downloadManager: AnytimeDownloadManager());
+    downloadService =
+        MobileDownloadService(repository: repository, downloadManager: AnytimeDownloadManager());
     podcastService = MobilePodcastService(
         api: podcastApi,
         repository: repository,
@@ -72,8 +72,7 @@ class AnytimePodcastApp extends StatefulWidget {
         repository: repository,
         podcastService: podcastService,
         settingsService: mobileSettingsService,
-        loadEpisodeMetadata: (episode) =>
-            metadataLoader.loadEpisodeMetadata(episode: episode));
+        loadEpisodeMetadata: (episode) => metadataLoader.loadEpisodeMetadata(episode: episode));
     settingsBloc = SettingsBloc(mobileSettingsService);
   }
 
@@ -90,9 +89,7 @@ class AnytimePodcastAppState extends State<AnytimePodcastApp> {
 
     widget.settingsBloc.settings.listen((event) {
       setState(() {
-        var newTheme = event.theme == 'dark'
-            ? Themes.darkTheme().themeData
-            : Themes.lightTheme().themeData;
+        var newTheme = event.theme == 'dark' ? Themes.darkTheme().themeData : Themes.lightTheme().themeData;
 
         /// Only update the theme if it has changed.
         if (newTheme != theme) {
@@ -162,8 +159,7 @@ class AnytimePodcastAppState extends State<AnytimePodcastApp> {
           dispose: (_, value) => value.dispose(),
         ),
         Provider<AudioBloc>(
-          create: (_) =>
-              AudioBloc(audioPlayerService: widget.audioPlayerService),
+          create: (_) => AudioBloc(audioPlayerService: widget.audioPlayerService),
           dispose: (_, value) => value.dispose(),
         ),
         Provider<SettingsBloc>(
@@ -234,14 +230,12 @@ class NowPlayingTransportState extends State<NowPlayingTransport> {
               List<Widget> widgets = [];
               widgets.add(const Divider(height: 0.0, thickness: 1));
               // We'll also show add funds message if user tries to boost and has no balance
-              if (snapshot.data.balance <
-                  userModel.paymentOptions.preferredSatsPerMinValue) {
+              if (snapshot.data.balance < userModel.paymentOptions.preferredSatsPerMinValue) {
                 widgets.add(AddFundsMessage(accountModel: snapshot.data));
                 widgets.add(const Divider(height: 0.0, thickness: 1));
               }
               widgets.add(WithConfettiPaymentEffect(
-                  type: PaymentEventType.StreamCompleted,
-                  child: PlayerPositionControls()));
+                  type: PaymentEventType.StreamCompleted, child: PlayerPositionControls()));
               widgets.add(PlayerTransportControls());
               widgets.add(const Padding(
                 padding: EdgeInsets.only(top: 8.0, bottom: 24.0),
@@ -278,19 +272,14 @@ WidgetBuilder errorPlaceholderBuilder() {
   return builder;
 }
 
-WidgetBuilder sharePodcastButtonBuilder(
-    String podcastTitle, String podcastURL) {
-  builder(BuildContext context) =>
-      SharePodcastButton(podcastTitle: podcastTitle, podcastURL: podcastURL);
+WidgetBuilder sharePodcastButtonBuilder(String podcastTitle, String podcastURL) {
+  builder(BuildContext context) => SharePodcastButton(podcastTitle: podcastTitle, podcastURL: podcastURL);
   return builder;
 }
 
-WidgetBuilder shareEpisodeButtonBuilder(String podcastTitle, String podcastURL,
-    String episodeTitle, String episodeID) {
+WidgetBuilder shareEpisodeButtonBuilder(
+    String podcastTitle, String podcastURL, String episodeTitle, String episodeID) {
   builder(BuildContext context) => ShareEpisodeButton(
-      podcastTitle: podcastTitle,
-      podcastURL: podcastURL,
-      episodeTitle: episodeTitle,
-      episodeID: episodeID);
+      podcastTitle: podcastTitle, podcastURL: podcastURL, episodeTitle: episodeTitle, episodeID: episodeID);
   return builder;
 }

--- a/lib/routes/podcast/speed_selector.dart
+++ b/lib/routes/podcast/speed_selector.dart
@@ -72,9 +72,7 @@ class SpeedSelectorWidgetState extends State<SpeedSelectorWidget> {
           ),
           child: Text(
             texts.podcast_speed_selector_speed(
-              speed % 1 == 0
-                  ? speed.toStringAsFixed(0).toString()
-                  : speed.toString(),
+              speed % 1 == 0 ? speed.toStringAsFixed(0).toString() : speed.toString(),
             ),
             style: TextStyle(
               fontSize: 14.0,
@@ -155,9 +153,7 @@ class SpeedSliderState extends State<SpeedSlider> {
           padding: const EdgeInsets.only(top: 16.0),
           child: Text(
             texts.podcast_speed_selector_speed(
-              speed % 1 == 0
-                  ? speed.toStringAsFixed(0).toString()
-                  : speed.toString(),
+              speed % 1 == 0 ? speed.toStringAsFixed(0).toString() : speed.toString(),
             ),
             style: themeData.primaryTextTheme.headlineSmall,
           ),

--- a/lib/routes/podcast/speed_selector.dart
+++ b/lib/routes/podcast/speed_selector.dart
@@ -29,11 +29,10 @@ class SpeedSelectorWidgetState extends State<SpeedSelectorWidget> {
 
   @override
   void initState() {
+    super.initState();
     var settingsBloc = Provider.of<SettingsBloc>(context, listen: false);
 
     speed = settingsBloc.currentSettings.playbackSpeed;
-
-    super.initState();
   }
 
   @override
@@ -107,13 +106,12 @@ class SpeedSliderState extends State<SpeedSlider> {
 
   @override
   void initState() {
+    super.initState();
     final settingsBloc = Provider.of<SettingsBloc>(context, listen: false);
 
     speed = settingsBloc.currentSettings.playbackSpeed;
     trimSilence = settingsBloc.currentSettings.trimSilence;
     volumeBoost = settingsBloc.currentSettings.volumeBoost;
-
-    super.initState();
   }
 
   @override

--- a/lib/routes/podcast/theme.dart
+++ b/lib/routes/podcast/theme.dart
@@ -6,8 +6,7 @@ import 'package:breez/theme_data.dart' as theme;
 import 'package:flutter/material.dart';
 
 Widget withBreezTheme(BuildContext context, Widget child) {
-  UserProfileBloc userProfileBloc =
-      AppBlocsProvider.of<UserProfileBloc>(context);
+  UserProfileBloc userProfileBloc = AppBlocsProvider.of<UserProfileBloc>(context);
   return StreamBuilder<BreezUserModel>(
     stream: userProfileBloc.userStream,
     builder: (context, snapshot) {
@@ -57,45 +56,34 @@ Widget withPodcastTheme(BreezUserModel user, Widget child) {
               hintColor: const Color(0x8a000000),
               dialogTheme: currentTheme.dialogTheme,
               buttonTheme: Themes.lightTheme().themeData.buttonTheme.copyWith(
-                    colorScheme: Themes.lightTheme()
-                        .themeData
-                        .buttonTheme
-                        .colorScheme
-                        .copyWith(
-                            primary:
-                                currentTheme.primaryTextTheme.labelLarge.color,
-                            onPrimary: const Color.fromRGBO(0, 133, 251, 1.0),
-                            onSecondary:
-                                const Color.fromRGBO(178, 241, 255, 1.0),
-                            onSurface: Colors.blueGrey),
+                    colorScheme: Themes.lightTheme().themeData.buttonTheme.colorScheme.copyWith(
+                        primary: currentTheme.primaryTextTheme.labelLarge.color,
+                        onPrimary: const Color.fromRGBO(0, 133, 251, 1.0),
+                        onSecondary: const Color.fromRGBO(178, 241, 255, 1.0),
+                        onSurface: Colors.blueGrey),
                   ),
-              primaryTextTheme:
-                  Typography.material2018(platform: TargetPlatform.android)
-                      .black
-                      .apply(fontFamily: 'IBMPlexSans')
-                      .copyWith(
-                        labelLarge: currentTheme.primaryTextTheme.labelLarge,
-                      ),
-              textTheme: Typography.material2018(
-                      platform: TargetPlatform.android)
+              primaryTextTheme: Typography.material2018(platform: TargetPlatform.android)
+                  .black
+                  .apply(fontFamily: 'IBMPlexSans')
+                  .copyWith(
+                    labelLarge: currentTheme.primaryTextTheme.labelLarge,
+                  ),
+              textTheme: Typography.material2018(platform: TargetPlatform.android)
                   .black
                   .apply(
                     fontFamily: 'IBMPlexSans',
                   )
                   .copyWith(
-                    labelLarge: Typography.material2018(
-                            platform: TargetPlatform.android)
+                    labelLarge: Typography.material2018(platform: TargetPlatform.android)
                         .black
                         .labelLarge
                         .copyWith(color: const Color.fromRGBO(5, 93, 235, 1.0)),
-                    titleLarge: Typography.material2018(
-                            platform: TargetPlatform.android)
+                    titleLarge: Typography.material2018(platform: TargetPlatform.android)
                         .black
                         .titleLarge
                         .copyWith(fontWeight: FontWeight.w400, fontSize: 14.3),
                   ),
-              primaryIconTheme:
-                  const IconThemeData(color: Color.fromRGBO(0, 133, 251, 1.0)),
+              primaryIconTheme: const IconThemeData(color: Color.fromRGBO(0, 133, 251, 1.0)),
               iconTheme: const IconThemeData(color: Colors.white, size: 32.0),
               bottomSheetTheme: BottomSheetThemeData(
                 backgroundColor: currentTheme.scaffoldBackgroundColor,
@@ -112,8 +100,7 @@ Widget withPodcastTheme(BreezUserModel user, Widget child) {
                 background: Color(0xFFf3f8fc),
               ).copyWith(error: const Color(0xffffe685)),
               switchTheme: SwitchThemeData(
-                thumbColor: MaterialStateProperty.resolveWith<Color>(
-                    (Set<MaterialState> states) {
+                thumbColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
                   if (states.contains(MaterialState.disabled)) {
                     return null;
                   }
@@ -122,8 +109,7 @@ Widget withPodcastTheme(BreezUserModel user, Widget child) {
                   }
                   return null;
                 }),
-                trackColor: MaterialStateProperty.resolveWith<Color>(
-                    (Set<MaterialState> states) {
+                trackColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
                   if (states.contains(MaterialState.disabled)) {
                     return null;
                   }
@@ -134,8 +120,7 @@ Widget withPodcastTheme(BreezUserModel user, Widget child) {
                 }),
               ),
               radioTheme: currentTheme.radioTheme.copyWith(
-                fillColor: MaterialStateProperty.resolveWith<Color>(
-                    (Set<MaterialState> states) {
+                fillColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
                   if (states.contains(MaterialState.disabled)) {
                     return null;
                   }
@@ -146,8 +131,7 @@ Widget withPodcastTheme(BreezUserModel user, Widget child) {
                 }),
               ),
               checkboxTheme: CheckboxThemeData(
-                fillColor: MaterialStateProperty.resolveWith<Color>(
-                    (Set<MaterialState> states) {
+                fillColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
                   if (states.contains(MaterialState.disabled)) {
                     return null;
                   }
@@ -190,31 +174,23 @@ Widget withPodcastTheme(BreezUserModel user, Widget child) {
               hintColor: const Color(0x80ffffff),
               dialogTheme: currentTheme.dialogTheme,
               buttonTheme: Themes.darkTheme().themeData.buttonTheme.copyWith(
-                    colorScheme: Themes.darkTheme()
-                        .themeData
-                        .buttonTheme
-                        .colorScheme
-                        .copyWith(
-                            primary:
-                                currentTheme.primaryTextTheme.labelLarge.color,
-                            onPrimary: Colors.white,
-                            onSecondary: const Color(0xFF0085fb),
-                            onSurface: const Color(0x77ffffff)),
+                    colorScheme: Themes.darkTheme().themeData.buttonTheme.colorScheme.copyWith(
+                        primary: currentTheme.primaryTextTheme.labelLarge.color,
+                        onPrimary: Colors.white,
+                        onSecondary: const Color(0xFF0085fb),
+                        onSurface: const Color(0x77ffffff)),
                   ),
-              primaryTextTheme:
-                  Typography.material2018(platform: TargetPlatform.android)
-                      .white
-                      .apply(fontFamily: 'IBMPlexSans')
-                      .copyWith(
-                        labelLarge: currentTheme.primaryTextTheme.labelLarge,
-                      ),
-              textTheme: Typography.material2018(
-                      platform: TargetPlatform.android)
+              primaryTextTheme: Typography.material2018(platform: TargetPlatform.android)
                   .white
                   .apply(fontFamily: 'IBMPlexSans')
                   .copyWith(
-                    titleLarge: Typography.material2018(
-                            platform: TargetPlatform.android)
+                    labelLarge: currentTheme.primaryTextTheme.labelLarge,
+                  ),
+              textTheme: Typography.material2018(platform: TargetPlatform.android)
+                  .white
+                  .apply(fontFamily: 'IBMPlexSans')
+                  .copyWith(
+                    titleLarge: Typography.material2018(platform: TargetPlatform.android)
                         .white
                         .titleLarge
                         .copyWith(fontWeight: FontWeight.w400, fontSize: 14.3),
@@ -234,8 +210,7 @@ Widget withPodcastTheme(BreezUserModel user, Widget child) {
                 background: Color(0xFF152a3d),
               ).copyWith(error: const Color(0xFFeddc97)),
               switchTheme: SwitchThemeData(
-                thumbColor: MaterialStateProperty.resolveWith<Color>(
-                    (Set<MaterialState> states) {
+                thumbColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
                   if (states.contains(MaterialState.disabled)) {
                     return null;
                   }
@@ -244,8 +219,7 @@ Widget withPodcastTheme(BreezUserModel user, Widget child) {
                   }
                   return null;
                 }),
-                trackColor: MaterialStateProperty.resolveWith<Color>(
-                    (Set<MaterialState> states) {
+                trackColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
                   if (states.contains(MaterialState.disabled)) {
                     return null;
                   }
@@ -256,8 +230,7 @@ Widget withPodcastTheme(BreezUserModel user, Widget child) {
                 }),
               ),
               radioTheme: currentTheme.radioTheme.copyWith(
-                fillColor: MaterialStateProperty.resolveWith<Color>(
-                    (Set<MaterialState> states) {
+                fillColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
                   if (states.contains(MaterialState.disabled)) {
                     return null;
                   }
@@ -268,8 +241,7 @@ Widget withPodcastTheme(BreezUserModel user, Widget child) {
                 }),
               ),
               checkboxTheme: CheckboxThemeData(
-                fillColor: MaterialStateProperty.resolveWith<Color>(
-                    (Set<MaterialState> states) {
+                fillColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
                   if (states.contains(MaterialState.disabled)) {
                     return null;
                   }

--- a/lib/routes/podcast/transport_controls.dart
+++ b/lib/routes/podcast/transport_controls.dart
@@ -199,46 +199,49 @@ class _PlayButton extends StatelessWidget {
 
     // in case we are buffering show progress indicator.
     final translations = L.of(context);
-    if (buffering) {
-      return Tooltip(
+
+    return Stack(
+      alignment: AlignmentDirectional.center,
+      children: [
+        if (buffering)
+          SpinKitRing(
+            lineWidth: 2.0,
+            color: themeData.colorScheme.secondary,
+            size: 84,
+          ),
+        if (!buffering)
+          const SizedBox(
+            height: 84,
+            width: 84,
+          ),
+        Tooltip(
           message: playing ? translations.pause_button_label : translations.play_button_label,
           child: TextButton(
             style: TextButton.styleFrom(
-              shape: const CircleBorder(),
+              shape: CircleBorder(
+                side: BorderSide(color: themeData.highlightColor, width: 0.0),
+              ),
+              backgroundColor: themeData.primaryColor,
+              padding: const EdgeInsets.all(8.0),
             ),
-            onPressed: null,
-            child: SpinKitRing(
-              lineWidth: 2.0,
-              color: themeData.colorScheme.secondary,
-              size: 60,
+            onPressed: buffering
+                ? null
+                : () {
+                    if (playing) {
+                      onPause();
+                    } else {
+                      onPlay();
+                    }
+                  },
+            child: AnimatedIcon(
+              size: 60.0,
+              icon: AnimatedIcons.play_pause,
+              color: Colors.white,
+              progress: playPauseController,
             ),
-          ));
-    }
-
-    return Tooltip(
-      message: playing ? translations.pause_button_label : translations.play_button_label,
-      child: TextButton(
-        style: TextButton.styleFrom(
-          shape: CircleBorder(
-            side: BorderSide(color: themeData.highlightColor, width: 0.0),
           ),
-          backgroundColor: themeData.primaryColor,
-          padding: const EdgeInsets.all(8.0),
         ),
-        onPressed: () {
-          if (playing) {
-            onPause();
-          } else {
-            onPlay();
-          }
-        },
-        child: AnimatedIcon(
-          size: 60.0,
-          icon: AnimatedIcons.play_pause,
-          color: Colors.white,
-          progress: playPauseController,
-        ),
-      ),
+      ],
     );
   }
 }

--- a/lib/routes/podcast/transport_controls.dart
+++ b/lib/routes/podcast/transport_controls.dart
@@ -114,9 +114,7 @@ class PlayerTransportControlsState extends State<PlayerTransportControls>
                 Expanded(flex: 1, child: Container()),
                 IconButton(
                   onPressed: () {
-                    return snapshot.data == AudioState.buffering
-                        ? null
-                        : _rewind(audioBloc);
+                    return snapshot.data == AudioState.buffering ? null : _rewind(audioBloc);
                   },
                   tooltip: L.of(context).rewind_button_label,
                   padding: const EdgeInsets.all(0.0),
@@ -140,9 +138,7 @@ class PlayerTransportControlsState extends State<PlayerTransportControls>
                 Expanded(flex: 1, child: Container()),
                 IconButton(
                   onPressed: () {
-                    return snapshot.data == AudioState.buffering
-                        ? null
-                        : _fastForward(audioBloc);
+                    return snapshot.data == AudioState.buffering ? null : _fastForward(audioBloc);
                   },
                   padding: const EdgeInsets.all(0.0),
                   icon: SvgPicture.asset(
@@ -191,12 +187,7 @@ class _PlayButton extends StatelessWidget {
   final Function() onPause;
   final AnimationController playPauseController;
 
-  const _PlayButton(
-      {Key key,
-      this.audioState,
-      this.onPlay,
-      this.onPause,
-      this.playPauseController})
+  const _PlayButton({Key key, this.audioState, this.onPlay, this.onPause, this.playPauseController})
       : super(key: key);
 
   @override
@@ -210,9 +201,7 @@ class _PlayButton extends StatelessWidget {
     final translations = L.of(context);
     if (buffering) {
       return Tooltip(
-          message: playing
-              ? translations.pause_button_label
-              : translations.play_button_label,
+          message: playing ? translations.pause_button_label : translations.play_button_label,
           child: TextButton(
             style: TextButton.styleFrom(
               shape: const CircleBorder(),
@@ -227,9 +216,7 @@ class _PlayButton extends StatelessWidget {
     }
 
     return Tooltip(
-      message: playing
-          ? translations.pause_button_label
-          : translations.play_button_label,
+      message: playing ? translations.pause_button_label : translations.play_button_label,
       child: TextButton(
         style: TextButton.styleFrom(
           shape: CircleBorder(

--- a/lib/routes/podcast_history/podcast_history.dart
+++ b/lib/routes/podcast_history/podcast_history.dart
@@ -42,6 +42,7 @@ class PodcastHistoryPageState extends State<PodcastHistoryPage> {
 
   @override
   Future<void> didChangeDependencies() async {
+    super.didChangeDependencies();
     final podcastHistoryBloc = AppBlocsProvider.of<PodcastHistoryBloc>(context);
     PodcastHistoryTimeRange timeRange =
         await podcastHistoryBloc.getPodcastHistoryTimeRageFromLocalDb();
@@ -50,8 +51,6 @@ class PodcastHistoryPageState extends State<PodcastHistoryPage> {
       startDate: timeRange.startDate,
       endDate: timeRange.endDate,
     );
-
-    super.didChangeDependencies();
   }
 
   @override

--- a/lib/routes/podcast_history/podcast_history.dart
+++ b/lib/routes/podcast_history/podcast_history.dart
@@ -44,8 +44,7 @@ class PodcastHistoryPageState extends State<PodcastHistoryPage> {
   Future<void> didChangeDependencies() async {
     super.didChangeDependencies();
     final podcastHistoryBloc = AppBlocsProvider.of<PodcastHistoryBloc>(context);
-    PodcastHistoryTimeRange timeRange =
-        await podcastHistoryBloc.getPodcastHistoryTimeRageFromLocalDb();
+    PodcastHistoryTimeRange timeRange = await podcastHistoryBloc.getPodcastHistoryTimeRageFromLocalDb();
 
     podcastHistoryBloc.fetchPodcastHistory(
       startDate: timeRange.startDate,
@@ -84,8 +83,7 @@ class PodcastHistoryPageState extends State<PodcastHistoryPage> {
                     height: 24.0,
                   ),
                   onSelected: (value) {
-                    podcastHistoryBloc.actionsSink
-                        .add(UpdatePodcastHistoryTimeRange(value));
+                    podcastHistoryBloc.actionsSink.add(UpdatePodcastHistoryTimeRange(value));
                   },
                   itemBuilder: (ctx) => [
                     PodcastHistoryTimeRange.weekly(),
@@ -152,34 +150,27 @@ class PodcastHistoryPageState extends State<PodcastHistoryPage> {
                                 builder: (context, snapshot) {
                                   return snapshot.data != null
                                       ? Row(
-                                          mainAxisAlignment:
-                                              MainAxisAlignment.spaceBetween,
+                                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
                                           children: [
                                             _PodcastStatItem(
                                               svg: "src/icon/schedule_icon.svg",
                                               label:
                                                   '${_podcastListingTimeMap(durationInMins: snapshot.data.totalDurationInMinsSum)["unit"]} listened',
                                               value: _podcastListingTimeMap(
-                                                durationInMins: snapshot.data
-                                                    .totalDurationInMinsSum,
+                                                durationInMins: snapshot.data.totalDurationInMinsSum,
                                               )["value"],
                                             ),
                                             _PodcastStatItem(
                                               svg: "src/icon/satoshi_icon.svg",
-                                              label: texts
-                                                  .podcast_history_sats_streamed,
+                                              label: texts.podcast_history_sats_streamed,
                                               value: _getCompactNumber(
-                                                snapshot
-                                                    .data.totalSatsStreamedSum,
+                                                snapshot.data.totalSatsStreamedSum,
                                               ),
                                             ),
                                             _PodcastStatItem(
-                                              svg:
-                                                  "src/icon/rocket_launch_icon.svg",
-                                              label: texts
-                                                  .podcast_history_boostagrams_sent,
-                                              value: _getCompactNumber(snapshot
-                                                  .data.totalBoostagramSentSum),
+                                              svg: "src/icon/rocket_launch_icon.svg",
+                                              label: texts.podcast_history_boostagrams_sent,
+                                              value: _getCompactNumber(snapshot.data.totalBoostagramSentSum),
                                             ),
                                           ],
                                         )
@@ -205,18 +196,13 @@ class PodcastHistoryPageState extends State<PodcastHistoryPage> {
                                           : theme.BreezColors.white[400],
                                     ),
                                     onSelected: (value) {
-                                      podcastHistoryBloc
-                                          .updateSortOption(value);
+                                      podcastHistoryBloc.updateSortOption(value);
                                     },
                                     itemBuilder: (ctx) => [
-                                      PodcastHistorySortEnum
-                                          .SORT_RECENTLY_HEARD,
-                                      PodcastHistorySortEnum
-                                          .SORT_DURATION_DESCENDING,
-                                      PodcastHistorySortEnum
-                                          .SORT_SATS_DESCENDING,
-                                      PodcastHistorySortEnum
-                                          .SORT_BOOSTS_DESCENDING,
+                                      PodcastHistorySortEnum.SORT_RECENTLY_HEARD,
+                                      PodcastHistorySortEnum.SORT_DURATION_DESCENDING,
+                                      PodcastHistorySortEnum.SORT_SATS_DESCENDING,
+                                      PodcastHistorySortEnum.SORT_BOOSTS_DESCENDING,
                                     ]
                                         .map(
                                           (e) => _listSortDropdownItem(
@@ -263,10 +249,8 @@ class PodcastHistoryPageState extends State<PodcastHistoryPage> {
                                 ),
                                 Padding(
                                   padding: EdgeInsets.only(
-                                    bottom:
-                                        MediaQuery.of(context).size.height / 25,
-                                    top: MediaQuery.of(context).size.height /
-                                        2.82,
+                                    bottom: MediaQuery.of(context).size.height / 25,
+                                    top: MediaQuery.of(context).size.height / 2.82,
                                   ),
                                   child: SubmitButton(
                                     texts.podcast_history_open_podcast_button,
@@ -313,8 +297,7 @@ class PodcastHistoryPageState extends State<PodcastHistoryPage> {
       await imagePath.writeAsBytes(image);
       await Share.shareXFiles(
         [XFile(imagePath.path)],
-        text:
-            "My $appBarDisplayString in Breez ⚡ Download here: https://breez.technology",
+        text: "My $appBarDisplayString in Breez ⚡ Download here: https://breez.technology",
       );
     }
   }
@@ -392,35 +375,27 @@ Widget _getPodcastHistoryList({
         //This enables sharing of up to 5 podcasts
         int podcastHistoryLength = 0;
         if (getScreenshotWidget) {
-          podcastHistoryLength =
-              podcastHistoryListSnapshot.data.podcastHistoryList.length <= 5
-                  ? podcastHistoryListSnapshot.data.podcastHistoryList.length
-                  : 5;
+          podcastHistoryLength = podcastHistoryListSnapshot.data.podcastHistoryList.length <= 5
+              ? podcastHistoryListSnapshot.data.podcastHistoryList.length
+              : 5;
         } else {
-          podcastHistoryLength =
-              podcastHistoryListSnapshot.data.podcastHistoryList.length;
+          podcastHistoryLength = podcastHistoryListSnapshot.data.podcastHistoryList.length;
         }
 
         return Column(
-          mainAxisSize:
-              getScreenshotWidget ? MainAxisSize.min : MainAxisSize.max,
+          mainAxisSize: getScreenshotWidget ? MainAxisSize.min : MainAxisSize.max,
           children: [
             for (var i = 0; i < podcastHistoryLength; i++)
               Padding(
                 padding: const EdgeInsets.only(bottom: 12),
                 child: _PodcastListTile(
-                  podcastUrl: podcastHistoryListSnapshot
-                      .data.podcastHistoryList[i].podcastUrl,
-                  title: podcastHistoryListSnapshot
-                      .data.podcastHistoryList[i].podcastName,
-                  sats: _getCompactNumber(podcastHistoryListSnapshot
-                      .data.podcastHistoryList[i].satsSpent),
-                  boostagrams: _getCompactNumber(podcastHistoryListSnapshot
-                      .data.podcastHistoryList[i].boostagramsSent),
-                  durationInMins: podcastHistoryListSnapshot
-                      .data.podcastHistoryList[i].durationInMins,
-                  imageUrl: podcastHistoryListSnapshot
-                      .data.podcastHistoryList[i].podcastImageUrl,
+                  podcastUrl: podcastHistoryListSnapshot.data.podcastHistoryList[i].podcastUrl,
+                  title: podcastHistoryListSnapshot.data.podcastHistoryList[i].podcastName,
+                  sats: _getCompactNumber(podcastHistoryListSnapshot.data.podcastHistoryList[i].satsSpent),
+                  boostagrams: _getCompactNumber(
+                      podcastHistoryListSnapshot.data.podcastHistoryList[i].boostagramsSent),
+                  durationInMins: podcastHistoryListSnapshot.data.podcastHistoryList[i].durationInMins,
+                  imageUrl: podcastHistoryListSnapshot.data.podcastHistoryList[i].podcastImageUrl,
                 ),
               ),
           ],
@@ -532,9 +507,7 @@ class _PodcastStatItem extends StatelessWidget {
             height: 16,
             width: 36,
             colorFilter: ColorFilter.mode(
-              theme.themeId != "BLUE"
-                  ? Colors.white
-                  : theme.BreezColors.white[400],
+              theme.themeId != "BLUE" ? Colors.white : theme.BreezColors.white[400],
               BlendMode.srcATop,
             ),
           ),
@@ -649,8 +622,7 @@ class _PodcastListTile extends StatelessWidget {
                                 const SizedBox(width: 4),
                                 Text(
                                   _podcastListingTimeString(
-                                    podcastListeningTimeMap:
-                                        _podcastListingTimeMap(
+                                    podcastListeningTimeMap: _podcastListingTimeMap(
                                       durationInMins: durationInMins,
                                     ),
                                   ),
@@ -674,8 +646,7 @@ class _PodcastListTile extends StatelessWidget {
                           padding: const EdgeInsets.only(right: 16),
                           child: Text(
                             "$sats sats",
-                            style: themeData.primaryTextTheme.displaySmall
-                                .copyWith(
+                            style: themeData.primaryTextTheme.displaySmall.copyWith(
                               fontSize: 16,
                               color: Colors.white,
                               fontWeight: FontWeight.w500,
@@ -701,10 +672,7 @@ Map<String, String> _podcastListingTimeMap({
   if (durationInMins < 1) {
     return {"value": "${(durationInMins * 60).toInt()}", "unit": "secs"};
   } else if (durationInMins >= 60) {
-    return {
-      "value": "${_truncateDecimals(durationInMins / 60, 2)}",
-      "unit": "hours"
-    };
+    return {"value": "${_truncateDecimals(durationInMins / 60, 2)}", "unit": "hours"};
   } else {
     return {"value": "${(durationInMins).toInt()}", "unit": "mins"};
   }
@@ -735,9 +703,8 @@ class _BubblePainterPodcastHistory extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     final size = MediaQuery.of(context).size;
     final bubblePaint = Paint()
-      ..color = theme.themeId == "BLUE"
-          ? Colors.white.withOpacity(0.3)
-          : const Color(0xff4D88EC).withOpacity(0.2)
+      ..color =
+          theme.themeId == "BLUE" ? Colors.white.withOpacity(0.3) : const Color(0xff4D88EC).withOpacity(0.2)
       ..style = PaintingStyle.fill;
     const bubbleRadius = 12.0;
     final height = size.height - kToolbarHeight;

--- a/lib/routes/qr_scan.dart
+++ b/lib/routes/qr_scan.dart
@@ -117,8 +117,7 @@ class ImagePickerButton extends StatelessWidget {
       onPressed: () async {
         final scaffoldMessenger = ScaffoldMessenger.of(context);
         final picker = ImagePicker();
-        XFile pickedFile =
-            await picker.pickImage(source: ImageSource.gallery).catchError(
+        XFile pickedFile = await picker.pickImage(source: ImageSource.gallery).catchError(
           (err) {
             _log.warning("Failed to pick image", err);
           },

--- a/lib/routes/security_pin/backup_phrase/backup_phrase_confirmation_page.dart
+++ b/lib/routes/security_pin/backup_phrase/backup_phrase_confirmation_page.dart
@@ -12,12 +12,10 @@ import 'generate_backup_phrase_page.dart';
 
 class BackupPhraseGeneratorConfirmationPage extends StatefulWidget {
   @override
-  BackupPhraseGeneratorConfirmationPageState createState() =>
-      BackupPhraseGeneratorConfirmationPageState();
+  BackupPhraseGeneratorConfirmationPageState createState() => BackupPhraseGeneratorConfirmationPageState();
 }
 
-class BackupPhraseGeneratorConfirmationPageState
-    extends State<BackupPhraseGeneratorConfirmationPage> {
+class BackupPhraseGeneratorConfirmationPageState extends State<BackupPhraseGeneratorConfirmationPage> {
   bool _isUnderstood = false;
 
   @override

--- a/lib/routes/security_pin/backup_phrase/generate_backup_phrase_page.dart
+++ b/lib/routes/security_pin/backup_phrase/generate_backup_phrase_page.dart
@@ -18,8 +18,7 @@ class GenerateBackupPhrasePage extends StatefulWidget {
   );
 
   @override
-  GenerateBackupPhrasePageState createState() =>
-      GenerateBackupPhrasePageState();
+  GenerateBackupPhrasePageState createState() => GenerateBackupPhrasePageState();
 }
 
 class GenerateBackupPhrasePageState extends State<GenerateBackupPhrasePage> {

--- a/lib/routes/security_pin/backup_phrase/generate_backup_phrase_page.dart
+++ b/lib/routes/security_pin/backup_phrase/generate_backup_phrase_page.dart
@@ -28,8 +28,8 @@ class GenerateBackupPhrasePageState extends State<GenerateBackupPhrasePage> {
 
   @override
   void initState() {
-    _mnemonicsList = widget.mnemonics.split(" ");
     super.initState();
+    _mnemonicsList = widget.mnemonics.split(" ");
   }
 
   @override

--- a/lib/routes/security_pin/backup_phrase/verify_backup_phrase_page.dart
+++ b/lib/routes/security_pin/backup_phrase/verify_backup_phrase_page.dart
@@ -70,10 +70,10 @@ class VerifyBackupPhrasePageState extends State<VerifyBackupPhrasePage> {
 
   @override
   void initState() {
+    super.initState();
     _mnemonicsList = widget._mnemonics.split(" ");
     _hasError = false;
     _selectIndexes();
-    super.initState();
   }
 
   Widget _buildBackupBtn(

--- a/lib/routes/security_pin/backup_phrase/verify_backup_phrase_page.dart
+++ b/lib/routes/security_pin/backup_phrase/verify_backup_phrase_page.dart
@@ -146,17 +146,15 @@ class VerifyBackupPhrasePageState extends State<VerifyBackupPhrasePage> {
             style: theme.FieldTextStyle.textStyle,
             validator: (text) {
               if (text.isEmpty ||
-                  text.toLowerCase().trim() !=
-                      _mnemonicsList[_randomlySelectedIndexes[index]]) {
+                  text.toLowerCase().trim() != _mnemonicsList[_randomlySelectedIndexes[index]]) {
                 setState(() {
                   _hasError = true;
                 });
               }
               return null;
             },
-            onEditingComplete: () => (index == 2)
-                ? FocusScope.of(context).unfocus()
-                : FocusScope.of(context).nextFocus(),
+            onEditingComplete: () =>
+                (index == 2) ? FocusScope.of(context).unfocus() : FocusScope.of(context).nextFocus(),
           ),
         );
       },

--- a/lib/routes/security_pin/remote_server_auth/models/remote_server_models.dart
+++ b/lib/routes/security_pin/remote_server_auth/models/remote_server_models.dart
@@ -1,12 +1,6 @@
 import 'package:breez/bloc/backup/backup_model.dart';
 
-enum DiscoverResult {
-  SUCCESS,
-  INVALID_URL,
-  INVALID_AUTH,
-  METHOD_NOT_FOUND,
-  BACKUP_NOT_FOUND
-}
+enum DiscoverResult { SUCCESS, INVALID_URL, INVALID_AUTH, METHOD_NOT_FOUND, BACKUP_NOT_FOUND }
 
 class DiscoveryResult {
   final RemoteServerAuthData authData;

--- a/lib/routes/security_pin/remote_server_auth/remote_server_auth.dart
+++ b/lib/routes/security_pin/remote_server_auth/remote_server_auth.dart
@@ -128,9 +128,7 @@ class RemoteServerAuthPageState extends State<RemoteServerAuthPage> {
         padding: const EdgeInsets.only(bottom: 0.0),
         child: SingleButtonBottomBar(
           stickToBottom: true,
-          text: widget.restore
-              ? texts.remote_server_action_restore
-              : texts.remote_server_action_save,
+          text: widget.restore ? texts.remote_server_action_restore : texts.remote_server_action_save,
           onPressed: () async {
             Uri uri = Uri.parse(_urlController.text);
             bool hasError = (await _handleConnectionWarnings(uri) == false);
@@ -165,8 +163,7 @@ class RemoteServerAuthPageState extends State<RemoteServerAuthPage> {
     bool isAndroid = Platform.isAndroid;
     bool resolvedConnectionWarnings = true;
     if (isAndroid && uri.host.endsWith('onion') && torBloc.torConfig == null) {
-      resolvedConnectionWarnings =
-          await _handleEnableTor(resolvedConnectionWarnings);
+      resolvedConnectionWarnings = await _handleEnableTor(resolvedConnectionWarnings);
     }
     if ((!uri.host.endsWith('.onion') && uri.scheme == 'http')) {
       resolvedConnectionWarnings = await _handleNonSecureConnection();
@@ -184,8 +181,7 @@ class RemoteServerAuthPageState extends State<RemoteServerAuthPage> {
         texts.remote_server_warning_onion_message,
         style: Theme.of(context).dialogTheme.contentTextStyle,
       ),
-      optionText:
-          texts.remote_server_onion_warning_dialog_default_action_cancel,
+      optionText: texts.remote_server_onion_warning_dialog_default_action_cancel,
       optionFunc: () {
         resolvedConnectionWarnings = false;
         Navigator.pop(context);
@@ -276,8 +272,7 @@ class RemoteServerAuthPageState extends State<RemoteServerAuthPage> {
     while (true) {
       var testedUrl = Uri.parse(testedAuthData.url);
       var result = await discoverURLInternal(testedAuthData);
-      if (result.authError == DiscoverResult.SUCCESS ||
-          result.authError == DiscoverResult.INVALID_AUTH) {
+      if (result.authError == DiscoverResult.SUCCESS || result.authError == DiscoverResult.INVALID_AUTH) {
         return result;
       }
 
@@ -307,12 +302,10 @@ class RemoteServerAuthPageState extends State<RemoteServerAuthPage> {
     }
   }
 
-  Future<DiscoveryResult> discoverURLInternal(
-      RemoteServerAuthData authData) async {
+  Future<DiscoveryResult> discoverURLInternal(RemoteServerAuthData authData) async {
     // First we try to use the path the user inserted
     var result = await testAuthData(authData);
-    if (result == DiscoverResult.SUCCESS ||
-        result == DiscoverResult.INVALID_AUTH) {
+    if (result == DiscoverResult.SUCCESS || result == DiscoverResult.INVALID_AUTH) {
       return DiscoveryResult(authData, result);
     }
 
@@ -320,18 +313,13 @@ class RemoteServerAuthPageState extends State<RemoteServerAuthPage> {
     // since the user might accidentally insert a wrong path we'll reconstruct
     // the url to be the short url+remote.php/webdav.
     Uri uri = Uri.parse(authData.url); // + "remote.php/webdav/";
-    final nextCloudURL = Uri(
-            scheme: uri.scheme,
-            host: uri.host,
-            port: uri.port,
-            path: "remote.php/webdav/")
-        .toString();
+    final nextCloudURL =
+        Uri(scheme: uri.scheme, host: uri.host, port: uri.port, path: "remote.php/webdav/").toString();
     if (authData.url == nextCloudURL) {
       return DiscoveryResult(authData, result);
     }
     result = await testAuthData(authData.copyWith(url: nextCloudURL));
-    if (result == DiscoverResult.SUCCESS ||
-        result == DiscoverResult.INVALID_AUTH) {
+    if (result == DiscoverResult.SUCCESS || result == DiscoverResult.INVALID_AUTH) {
       return DiscoveryResult(authData.copyWith(url: nextCloudURL), result);
     }
     return DiscoveryResult(authData, result);

--- a/lib/routes/security_pin/security_and_backup/backup_tiles/generate_backup_phrase_tile.dart
+++ b/lib/routes/security_pin/security_and_backup/backup_tiles/generate_backup_phrase_tile.dart
@@ -21,8 +21,7 @@ class GenerateBackupPhraseTile extends StatefulWidget {
   });
 
   @override
-  State<GenerateBackupPhraseTile> createState() =>
-      _GenerateBackupPhraseTileState();
+  State<GenerateBackupPhraseTile> createState() => _GenerateBackupPhraseTileState();
 }
 
 class _GenerateBackupPhraseTileState extends State<GenerateBackupPhraseTile> {

--- a/lib/routes/security_pin/security_and_backup/backup_tiles/remote_server_credentials_tile.dart
+++ b/lib/routes/security_pin/security_and_backup/backup_tiles/remote_server_credentials_tile.dart
@@ -13,12 +13,10 @@ class RemoteServerCredentialsTile extends StatefulWidget {
   });
 
   @override
-  State<RemoteServerCredentialsTile> createState() =>
-      _RemoteServerCredentialsTileState();
+  State<RemoteServerCredentialsTile> createState() => _RemoteServerCredentialsTileState();
 }
 
-class _RemoteServerCredentialsTileState
-    extends State<RemoteServerCredentialsTile> {
+class _RemoteServerCredentialsTileState extends State<RemoteServerCredentialsTile> {
   @override
   Widget build(BuildContext context) {
     return ListTile(

--- a/lib/routes/security_pin/security_and_backup/security_and_backup_page.dart
+++ b/lib/routes/security_pin/security_and_backup/security_and_backup_page.dart
@@ -45,8 +45,7 @@ class SecurityAndBackupPage extends StatefulWidget {
   }
 }
 
-class SecurityAndBackupPageState extends State<SecurityAndBackupPage>
-    with WidgetsBindingObserver {
+class SecurityAndBackupPageState extends State<SecurityAndBackupPage> with WidgetsBindingObserver {
   StreamSubscription<BackupState> _backupInProgressSubscription;
   bool _showingBackupDialog = false;
   final _autoSizeGroup = AutoSizeGroup();
@@ -98,9 +97,8 @@ class SecurityAndBackupPageState extends State<SecurityAndBackupPage>
     /// Subscribing to backups in progress such as here will also block the UI
     /// for other sources of backups outside this page such as
     /// receiving an onchain payment.
-    _backupInProgressSubscription = widget.backupBloc.backupStateStream
-        .where((s) => s.inProgress)
-        .listen((s) async {
+    _backupInProgressSubscription =
+        widget.backupBloc.backupStateStream.where((s) => s.inProgress).listen((s) async {
       setState(() {
         _subscribedToBackupState = true;
       });
@@ -169,8 +167,8 @@ class SecurityAndBackupPageState extends State<SecurityAndBackupPage>
                   }
 
                   final backupSettings = backupSnapshot.data;
-                  final isRemoteServer = (backupSettings != null &&
-                      backupSettings.backupProvider?.isRemoteServer == true);
+                  final isRemoteServer =
+                      (backupSettings != null && backupSettings.backupProvider?.isRemoteServer == true);
 
                   return ListView(
                     children: [
@@ -192,14 +190,12 @@ class SecurityAndBackupPageState extends State<SecurityAndBackupPage>
                           autoSizeGroup: _autoSizeGroup,
                           changePin: _updateSecurityModel,
                         ),
-                        if (_localAuthenticationOption !=
-                            LocalAuthenticationOption.NONE) ...[
+                        if (_localAuthenticationOption != LocalAuthenticationOption.NONE) ...[
                           const Divider(),
                           EnableBiometricAuthTile(
                             userProfileBloc: widget.userProfileBloc,
                             autoSizeGroup: _autoSizeGroup,
-                            localAuthenticationOption:
-                                _localAuthenticationOption,
+                            localAuthenticationOption: _localAuthenticationOption,
                             changeBiometricAuth: _updateSecurityModel,
                           ),
                         ]

--- a/lib/routes/security_pin/security_and_backup/security_tiles/enable_biometric_auth_tile.dart
+++ b/lib/routes/security_pin/security_and_backup/security_tiles/enable_biometric_auth_tile.dart
@@ -23,8 +23,7 @@ class EnableBiometricAuthTile extends StatefulWidget {
   });
 
   @override
-  State<EnableBiometricAuthTile> createState() =>
-      _EnableBiometricAuthTileState();
+  State<EnableBiometricAuthTile> createState() => _EnableBiometricAuthTileState();
 }
 
 class _EnableBiometricAuthTileState extends State<EnableBiometricAuthTile> {

--- a/lib/routes/security_pin/security_and_backup/security_tiles/enable_pin_tile.dart
+++ b/lib/routes/security_pin/security_and_backup/security_tiles/enable_pin_tile.dart
@@ -52,9 +52,7 @@ class _EnablePinTileState extends State<EnablePinTile> {
                 ),
           switchValue: securityModel.requiresPin,
           group: securityModel.requiresPin ? widget.autoSizeGroup : null,
-          onTap: securityModel.requiresPin
-              ? null
-              : () => _onChangePinSelected(securityModel),
+          onTap: securityModel.requiresPin ? null : () => _onChangePinSelected(securityModel),
           onChanged: (bool value) async {
             if (mounted) {
               await _resetSecurityModel();

--- a/lib/routes/settings/pos_settings_page.dart
+++ b/lib/routes/settings/pos_settings_page.dart
@@ -67,8 +67,7 @@ class PosSettingsPageState extends State<_PosSettingsPage> {
     super.initState();
     final user = widget.currentProfile;
     _timeoutValue = user.cancellationTimeoutValue;
-    _cancellationTimeoutController.text =
-        user.cancellationTimeoutValue.toStringAsFixed(0);
+    _cancellationTimeoutController.text = user.cancellationTimeoutValue.toStringAsFixed(0);
     _addressLine1Controller.text = user.businessAddress?.addressLine1 ?? "";
     _addressLine2Controller.text = user.businessAddress?.addressLine2 ?? "";
     _defaultNoteController.text = user.defaultPosNote;
@@ -135,8 +134,7 @@ class PosSettingsPageState extends State<_PosSettingsPage> {
                       Padding(
                         padding: const EdgeInsets.only(left: 8.0, right: 16.0),
                         child: Text(
-                          num.parse(_cancellationTimeoutController.text)
-                              .toStringAsFixed(0),
+                          num.parse(_cancellationTimeoutController.text).toStringAsFixed(0),
                           style: const TextStyle(
                             color: Colors.white,
                             fontSize: 12.4,

--- a/lib/routes/splash_page.dart
+++ b/lib/routes/splash_page.dart
@@ -28,9 +28,7 @@ class SplashPageState extends State<SplashPage> {
     final navigator = Navigator.of(context);
     SharedPreferences prefs = await SharedPreferences.getInstance();
     bool isFirstRun = (prefs.getBool('isFirstRun') ?? true);
-    if (widget._user.registered == null ||
-        widget._user.registered == false ||
-        isFirstRun) {
+    if (widget._user.registered == null || widget._user.registered == false || isFirstRun) {
       prefs.setBool('isFirstRun', false);
       _startTime();
     } else {

--- a/lib/routes/spontaneous_payment/spontaneous_payment_page.dart
+++ b/lib/routes/spontaneous_payment/spontaneous_payment_page.dart
@@ -45,12 +45,12 @@ class SpontaneousPaymentPageState extends State<SpontaneousPaymentPage> {
 
   @override
   void initState() {
+    super.initState();
     _doneAction = KeyboardDoneAction(<FocusNode>[_amountFocusNode]);
     Future.delayed(
       const Duration(milliseconds: 200),
       () => FocusScope.of(context).requestFocus(_amountFocusNode),
     );
-    super.initState();
   }
 
   @override

--- a/lib/routes/sync_progress_dialog.dart
+++ b/lib/routes/sync_progress_dialog.dart
@@ -30,8 +30,7 @@ class SyncProgressDialogState extends State<SyncProgressDialog> {
     if (_accountBloc == null && widget.closeOnSync) {
       _accountBloc = AppBlocsProvider.of<AccountBloc>(context);
       _accountBloc.accountStream
-          .firstWhere((a) => a?.syncedToChain == true && a.serverReady,
-              orElse: () => null)
+          .firstWhere((a) => a?.syncedToChain == true && a.serverReady, orElse: () => null)
           .then((a) {
         if (mounted) {
           Navigator.of(context).pop(true);
@@ -59,9 +58,7 @@ class SyncProgressDialogState extends State<SyncProgressDialog> {
             color: widget.progressColor ?? themeData.textTheme.labelLarge.color,
             size: 100.0,
             value: acc.serverReady ? acc.syncProgress : null,
-            title: acc.serverReady
-                ? texts.sync_progress_server_ready
-                : texts.sync_progress_waiting_network,
+            title: acc.serverReady ? texts.sync_progress_server_ready : texts.sync_progress_waiting_network,
           ),
         );
       },

--- a/lib/routes/transactions/pos_payment_item.dart
+++ b/lib/routes/transactions/pos_payment_item.dart
@@ -84,9 +84,7 @@ class PosPaymentItem extends StatelessWidget {
       isSent || isWithdrawal
           ? texts.pos_transactions_item_negative(value)
           : texts.pos_transactions_item_positive(value),
-      style: isSent
-          ? theme.posWithdrawalTransactionAmountStyle
-          : theme.transactionAmountStyle,
+      style: isSent ? theme.posWithdrawalTransactionAmountStyle : theme.transactionAmountStyle,
     );
   }
 

--- a/lib/routes/transactions/pos_transactions_page.dart
+++ b/lib/routes/transactions/pos_transactions_page.dart
@@ -33,11 +33,11 @@ class PosTransactionsPageState extends State<PosTransactionsPage> {
 
   @override
   void didChangeDependencies() {
+    super.didChangeDependencies();
     if (!_isInit) {
       _accountBloc = AppBlocsProvider.of<AccountBloc>(context);
       _isInit = true;
     }
-    super.didChangeDependencies();
   }
 
   @override

--- a/lib/routes/transactions/pos_transactions_page.dart
+++ b/lib/routes/transactions/pos_transactions_page.dart
@@ -275,9 +275,7 @@ class PosTransactionsPageState extends State<PosTransactionsPage> {
   }
 
   Widget _buildDateFilterChip(PaymentFilterModel filter) {
-    return (filter.startDate != null && filter.endDate != null)
-        ? _filterChip(filter)
-        : Container();
+    return (filter.startDate != null && filter.endDate != null) ? _filterChip(filter) : Container();
   }
 
   Widget _filterChip(PaymentFilterModel filter) {

--- a/lib/routes/transfer_funds_in_progress_dialog.dart
+++ b/lib/routes/transfer_funds_in_progress_dialog.dart
@@ -26,8 +26,7 @@ class _TransferFundsInProgressDialog extends StatefulWidget {
   }
 }
 
-class _TransferFundsInProgressDialogState
-    extends State<_TransferFundsInProgressDialog> {
+class _TransferFundsInProgressDialogState extends State<_TransferFundsInProgressDialog> {
   StreamSubscription<AccountModel> _stateSubscription;
   ModalRoute _currentRoute;
 

--- a/lib/routes/unexpected_error_dialog.dart
+++ b/lib/routes/unexpected_error_dialog.dart
@@ -139,14 +139,10 @@ void listenUnexpectedError(
               ],
             ),
           ),
-          okText: allowRetry
-              ? texts.unexpected_error_action_try_again
-              : texts.unexpected_error_action_just_exit,
-          okFunc: allowRetry
-              ? () => accountBloc.userActionsSink.add(RestartDaemon())
-              : () => exit(0),
-          optionText:
-              allowRetry ? texts.unexpected_error_action_exit_for_retry : null,
+          okText:
+              allowRetry ? texts.unexpected_error_action_try_again : texts.unexpected_error_action_just_exit,
+          okFunc: allowRetry ? () => accountBloc.userActionsSink.add(RestartDaemon()) : () => exit(0),
+          optionText: allowRetry ? texts.unexpected_error_action_exit_for_retry : null,
           optionFunc: () => exit(0),
           disableBack: true,
         );

--- a/lib/routes/withdraw_funds/reverse_swap_confirmation.dart
+++ b/lib/routes/withdraw_funds/reverse_swap_confirmation.dart
@@ -23,8 +23,9 @@ class ReverseSwapConfirmation extends StatefulWidget {
   final ReverseSwapRequest swap;
   final ReverseSwapBloc bloc;
   final Function() onPrevious;
-  final Future Function(String address, Int64 toSend, Int64 boltzFees,
-      Int64 claimFees, Int64 received, String feesHash) onFeeConfirmed;
+  final Future Function(
+          String address, Int64 toSend, Int64 boltzFees, Int64 claimFees, Int64 received, String feesHash)
+      onFeeConfirmed;
 
   const ReverseSwapConfirmation({
     Key key,
@@ -71,9 +72,7 @@ class ReverseSwapConfirmationState extends State<ReverseSwapConfirmation> {
           key: (e) => e,
           value: (e) {
             final toSend = widget.swap.amount;
-            final boltzFees = Int64(
-                    (toSend.toDouble() * widget.swap.policy.percentage / 100)
-                        .ceil()) +
+            final boltzFees = Int64((toSend.toDouble() * widget.swap.policy.percentage / 100).ceil()) +
                 widget.swap.policy.lockup;
             final received = toSend - boltzFees - feeEstimates.fees[e];
             return ReverseSwapAmounts(
@@ -91,10 +90,9 @@ class ReverseSwapConfirmationState extends State<ReverseSwapConfirmation> {
           value: (e) {
             final received = widget.swap.amount;
             final p = widget.swap.policy.percentage / 100;
-            final boltzFees = Int64(
-                ((received + feeEstimates.fees[e]).toDouble() * p / (1 - p) +
-                        widget.swap.policy.lockup.toDouble() / (1 - p))
-                    .ceil());
+            final boltzFees = Int64(((received + feeEstimates.fees[e]).toDouble() * p / (1 - p) +
+                    widget.swap.policy.lockup.toDouble() / (1 - p))
+                .ceil());
             final toSend = received + boltzFees + feeEstimates.fees[e];
 
             return ReverseSwapAmounts(
@@ -132,10 +130,9 @@ class ReverseSwapConfirmationState extends State<ReverseSwapConfirmation> {
 
     final accountBloc = AppBlocsProvider.of<AccountBloc>(context);
 
-    final rsAmounts =
-        (feeOptions != null && feeOptions[selectedFeeIndex] != null)
-            ? amounts[feeOptions[selectedFeeIndex].confirmationTarget]
-            : null;
+    final rsAmounts = (feeOptions != null && feeOptions[selectedFeeIndex] != null)
+        ? amounts[feeOptions[selectedFeeIndex].confirmationTarget]
+        : null;
 
     return Scaffold(
       appBar: AppBar(

--- a/lib/routes/withdraw_funds/reverse_swap_page.dart
+++ b/lib/routes/withdraw_funds/reverse_swap_page.dart
@@ -291,9 +291,7 @@ class UnconfirmedChannels extends StatelessWidget {
       padding: const EdgeInsets.only(top: 48, left: 16, right: 16),
       child: AnimatedCrossFade(
         duration: const Duration(milliseconds: 300),
-        crossFadeState: accountModel.synced
-            ? CrossFadeState.showSecond
-            : CrossFadeState.showFirst,
+        crossFadeState: accountModel.synced ? CrossFadeState.showSecond : CrossFadeState.showFirst,
         firstChild: Column(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/lib/routes/withdraw_funds/sweep_all_coins_confirmation.dart
+++ b/lib/routes/withdraw_funds/sweep_all_coins_confirmation.dart
@@ -56,10 +56,8 @@ class SweepAllCoinsConfirmationState extends State<SweepAllCoinsConfirmation> {
       _log.info("Sweep all coins response: $r");
       SweepAllCoinsTxs response = r as SweepAllCoinsTxs;
       _sweepAmount = response.amount;
-      List<int> targetConfirmations = response.transactions.keys.toList()
-        ..sort();
-      List<int> trimmedTargetConfirmations =
-          targetConfirmations.reversed.toList();
+      List<int> targetConfirmations = response.transactions.keys.toList()..sort();
+      List<int> trimmedTargetConfirmations = targetConfirmations.reversed.toList();
       _log.info("Sweep all coins amount $_sweepAmount"
           "confirmations: ${trimmedTargetConfirmations.logDescription((e) => e.toString())}");
       if (trimmedTargetConfirmations.length > 3) {
@@ -72,17 +70,13 @@ class SweepAllCoinsConfirmationState extends State<SweepAllCoinsConfirmation> {
         ];
       }
 
-      transactions = trimmedTargetConfirmations
-          .map((index) => response.transactions[index])
-          .toList();
+      transactions = trimmedTargetConfirmations.map((index) => response.transactions[index]).toList();
       _log.info("Sweep all coins transactions: "
           "${transactions.logDescription((e) => e.txHash)}");
 
-      feeOptions =
-          List.generate(trimmedTargetConfirmations.length, (index) => index)
-              .map((index) => FeeOption(transactions[index].fees.toInt(),
-                  trimmedTargetConfirmations[index]))
-              .toList();
+      feeOptions = List.generate(trimmedTargetConfirmations.length, (index) => index)
+          .map((index) => FeeOption(transactions[index].fees.toInt(), trimmedTargetConfirmations[index]))
+          .toList();
       if (feeOptions.isNotEmpty) {
         setState(() {
           _showConfirm = true;
@@ -132,14 +126,12 @@ class SweepAllCoinsConfirmationState extends State<SweepAllCoinsConfirmation> {
                 );
               }
 
-              if (futureSnapshot.connectionState != ConnectionState.done ||
-                  acc == null) {
+              if (futureSnapshot.connectionState != ConnectionState.done || acc == null) {
                 _log.info("Waiting ${futureSnapshot.connectionState} $acc");
                 return const SizedBox();
               }
 
-              if (feeOptions == null ||
-                  feeOptions.where((f) => f != null).isEmpty) {
+              if (feeOptions == null || feeOptions.where((f) => f != null).isEmpty) {
                 _log.info("No fees");
                 return _ErrorMessage(
                   message: texts.sweep_all_coins_error_amount_small,

--- a/lib/routes/withdraw_funds/unexpected_funds.dart
+++ b/lib/routes/withdraw_funds/unexpected_funds.dart
@@ -96,8 +96,7 @@ class UnexpectedFundsState extends State<UnexpectedFunds> {
                         _log.info("onConfirm: ${txDetails.txHash}}");
                         var action = PublishTransaction(txDetails.txBytes);
                         accountBloc.userActionsSink.add(action);
-                        return action.future
-                            .then((value) => Navigator.of(context).pop());
+                        return action.future.then((value) => Navigator.of(context).pop());
                       },
                       onPrevious: () {
                         _log.info("onPrevious");

--- a/lib/routes/withdraw_funds/withdraw_funds_page.dart
+++ b/lib/routes/withdraw_funds/withdraw_funds_page.dart
@@ -135,8 +135,7 @@ class WithdrawFundsPageState extends State<WithdrawFundsPage> {
               focusNode: _amountFocusNode,
               controller: _amountController,
               validatorFn: (amount) {
-                String err =
-                    acc.validateOutgoingPayment(amount, autoFilled: _isMax);
+                String err = acc.validateOutgoingPayment(amount, autoFilled: _isMax);
                 if (err == null) {
                   if (amount < widget.policy.minValue) {
                     err = texts.withdraw_funds_error_min_value(
@@ -241,8 +240,7 @@ class WithdrawFundsPageState extends State<WithdrawFundsPage> {
                             children: [
                               Loader(
                                 strokeWidth: 2.0,
-                                color: themeData.colorScheme.onSurface
-                                    .withOpacity(0.5),
+                                color: themeData.colorScheme.onSurface.withOpacity(0.5),
                               ),
                             ],
                           ),

--- a/lib/services/background_task.dart
+++ b/lib/services/background_task.dart
@@ -2,10 +2,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 class BackgroundTaskService {
-  static const _methodChannel =
-      MethodChannel('com.breez.client/background_task');
-  static const _eventsChannel =
-      EventChannel('com.breez.client/background_task_notifications');
+  static const _methodChannel = MethodChannel('com.breez.client/background_task');
+  static const _eventsChannel = EventChannel('com.breez.client/background_task_notifications');
 
   final Map<dynamic, Function()> _tasksCallbacks = <dynamic, Function()>{};
 

--- a/lib/services/breez_server/generated/breez.pb.dart
+++ b/lib/services/breez_server/generated/breez.pb.dart
@@ -15,11 +15,16 @@ import 'breez.pbenum.dart';
 export 'breez.pbenum.dart';
 
 class SignUrlRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SignUrlRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'base_url', protoName: 'baseUrl')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'query_string', protoName: 'queryString')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SignUrlRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'base_url',
+        protoName: 'baseUrl')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'query_string',
+        protoName: 'queryString')
+    ..hasRequiredFields = false;
 
   SignUrlRequest._() : super();
   factory SignUrlRequest({
@@ -35,31 +40,38 @@ class SignUrlRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory SignUrlRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory SignUrlRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory SignUrlRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory SignUrlRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   SignUrlRequest clone() => SignUrlRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  SignUrlRequest copyWith(void Function(SignUrlRequest) updates) => super.copyWith((message) => updates(message as SignUrlRequest)) as SignUrlRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  SignUrlRequest copyWith(void Function(SignUrlRequest) updates) =>
+      super.copyWith((message) => updates(message as SignUrlRequest))
+          as SignUrlRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SignUrlRequest create() => SignUrlRequest._();
   SignUrlRequest createEmptyInstance() => create();
   static $pb.PbList<SignUrlRequest> createRepeated() => $pb.PbList<SignUrlRequest>();
   @$core.pragma('dart2js:noInline')
-  static SignUrlRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignUrlRequest>(create);
+  static SignUrlRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignUrlRequest>(create);
   static SignUrlRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get baseUrl => $_getSZ(0);
   @$pb.TagNumber(1)
-  set baseUrl($core.String v) { $_setString(0, v); }
+  set baseUrl($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasBaseUrl() => $_has(0);
   @$pb.TagNumber(1)
@@ -68,7 +80,10 @@ class SignUrlRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get queryString => $_getSZ(1);
   @$pb.TagNumber(2)
-  set queryString($core.String v) { $_setString(1, v); }
+  set queryString($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasQueryString() => $_has(1);
   @$pb.TagNumber(2)
@@ -76,10 +91,14 @@ class SignUrlRequest extends $pb.GeneratedMessage {
 }
 
 class SignUrlResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SignUrlResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'full_url', protoName: 'fullUrl')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SignUrlResponse',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'full_url',
+        protoName: 'fullUrl')
+    ..hasRequiredFields = false;
 
   SignUrlResponse._() : super();
   factory SignUrlResponse({
@@ -91,31 +110,38 @@ class SignUrlResponse extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory SignUrlResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory SignUrlResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory SignUrlResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory SignUrlResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   SignUrlResponse clone() => SignUrlResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  SignUrlResponse copyWith(void Function(SignUrlResponse) updates) => super.copyWith((message) => updates(message as SignUrlResponse)) as SignUrlResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  SignUrlResponse copyWith(void Function(SignUrlResponse) updates) =>
+      super.copyWith((message) => updates(message as SignUrlResponse))
+          as SignUrlResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SignUrlResponse create() => SignUrlResponse._();
   SignUrlResponse createEmptyInstance() => create();
   static $pb.PbList<SignUrlResponse> createRepeated() => $pb.PbList<SignUrlResponse>();
   @$core.pragma('dart2js:noInline')
-  static SignUrlResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignUrlResponse>(create);
+  static SignUrlResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SignUrlResponse>(create);
   static SignUrlResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get fullUrl => $_getSZ(0);
   @$pb.TagNumber(1)
-  set fullUrl($core.String v) { $_setString(0, v); }
+  set fullUrl($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasFullUrl() => $_has(0);
   @$pb.TagNumber(1)
@@ -123,11 +149,16 @@ class SignUrlResponse extends $pb.GeneratedMessage {
 }
 
 class InactiveNotifyRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'InactiveNotifyRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..a<$core.List<$core.int>>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pubkey', $pb.PbFieldType.OY)
-    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'days', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'InactiveNotifyRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pubkey', $pb.PbFieldType.OY)
+    ..a<$core.int>(
+        2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'days', $pb.PbFieldType.O3)
+    ..hasRequiredFields = false;
 
   InactiveNotifyRequest._() : super();
   factory InactiveNotifyRequest({
@@ -143,31 +174,39 @@ class InactiveNotifyRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory InactiveNotifyRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory InactiveNotifyRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory InactiveNotifyRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory InactiveNotifyRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   InactiveNotifyRequest clone() => InactiveNotifyRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  InactiveNotifyRequest copyWith(void Function(InactiveNotifyRequest) updates) => super.copyWith((message) => updates(message as InactiveNotifyRequest)) as InactiveNotifyRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  InactiveNotifyRequest copyWith(void Function(InactiveNotifyRequest) updates) =>
+      super.copyWith((message) => updates(message as InactiveNotifyRequest))
+          as InactiveNotifyRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static InactiveNotifyRequest create() => InactiveNotifyRequest._();
   InactiveNotifyRequest createEmptyInstance() => create();
   static $pb.PbList<InactiveNotifyRequest> createRepeated() => $pb.PbList<InactiveNotifyRequest>();
   @$core.pragma('dart2js:noInline')
-  static InactiveNotifyRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<InactiveNotifyRequest>(create);
+  static InactiveNotifyRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<InactiveNotifyRequest>(create);
   static InactiveNotifyRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get pubkey => $_getN(0);
   @$pb.TagNumber(1)
-  set pubkey($core.List<$core.int> v) { $_setBytes(0, v); }
+  set pubkey($core.List<$core.int> v) {
+    $_setBytes(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasPubkey() => $_has(0);
   @$pb.TagNumber(1)
@@ -176,7 +215,10 @@ class InactiveNotifyRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get days => $_getIZ(1);
   @$pb.TagNumber(2)
-  set days($core.int v) { $_setSignedInt32(1, v); }
+  set days($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasDays() => $_has(1);
   @$pb.TagNumber(2)
@@ -184,40 +226,54 @@ class InactiveNotifyRequest extends $pb.GeneratedMessage {
 }
 
 class InactiveNotifyResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'InactiveNotifyResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'InactiveNotifyResponse',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   InactiveNotifyResponse._() : super();
   factory InactiveNotifyResponse() => create();
-  factory InactiveNotifyResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory InactiveNotifyResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory InactiveNotifyResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory InactiveNotifyResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   InactiveNotifyResponse clone() => InactiveNotifyResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  InactiveNotifyResponse copyWith(void Function(InactiveNotifyResponse) updates) => super.copyWith((message) => updates(message as InactiveNotifyResponse)) as InactiveNotifyResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  InactiveNotifyResponse copyWith(void Function(InactiveNotifyResponse) updates) =>
+      super.copyWith((message) => updates(message as InactiveNotifyResponse))
+          as InactiveNotifyResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static InactiveNotifyResponse create() => InactiveNotifyResponse._();
   InactiveNotifyResponse createEmptyInstance() => create();
   static $pb.PbList<InactiveNotifyResponse> createRepeated() => $pb.PbList<InactiveNotifyResponse>();
   @$core.pragma('dart2js:noInline')
-  static InactiveNotifyResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<InactiveNotifyResponse>(create);
+  static InactiveNotifyResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<InactiveNotifyResponse>(create);
   static InactiveNotifyResponse? _defaultInstance;
 }
 
 class RegisterPaymentNotificationRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RegisterPaymentNotificationRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'RegisterPaymentNotificationRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lspId')
-    ..a<$core.List<$core.int>>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'blob', $pb.PbFieldType.OY)
-    ..hasRequiredFields = false
-  ;
+    ..a<$core.List<$core.int>>(
+        2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'blob', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
 
   RegisterPaymentNotificationRequest._() : super();
   factory RegisterPaymentNotificationRequest({
@@ -233,31 +289,40 @@ class RegisterPaymentNotificationRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RegisterPaymentNotificationRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RegisterPaymentNotificationRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RegisterPaymentNotificationRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RegisterPaymentNotificationRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RegisterPaymentNotificationRequest clone() => RegisterPaymentNotificationRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RegisterPaymentNotificationRequest copyWith(void Function(RegisterPaymentNotificationRequest) updates) => super.copyWith((message) => updates(message as RegisterPaymentNotificationRequest)) as RegisterPaymentNotificationRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RegisterPaymentNotificationRequest copyWith(void Function(RegisterPaymentNotificationRequest) updates) =>
+      super.copyWith((message) => updates(message as RegisterPaymentNotificationRequest))
+          as RegisterPaymentNotificationRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RegisterPaymentNotificationRequest create() => RegisterPaymentNotificationRequest._();
   RegisterPaymentNotificationRequest createEmptyInstance() => create();
-  static $pb.PbList<RegisterPaymentNotificationRequest> createRepeated() => $pb.PbList<RegisterPaymentNotificationRequest>();
+  static $pb.PbList<RegisterPaymentNotificationRequest> createRepeated() =>
+      $pb.PbList<RegisterPaymentNotificationRequest>();
   @$core.pragma('dart2js:noInline')
-  static RegisterPaymentNotificationRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterPaymentNotificationRequest>(create);
+  static RegisterPaymentNotificationRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterPaymentNotificationRequest>(create);
   static RegisterPaymentNotificationRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get lspId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set lspId($core.String v) { $_setString(0, v); }
+  set lspId($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasLspId() => $_has(0);
   @$pb.TagNumber(1)
@@ -266,7 +331,10 @@ class RegisterPaymentNotificationRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.List<$core.int> get blob => $_getN(1);
   @$pb.TagNumber(2)
-  set blob($core.List<$core.int> v) { $_setBytes(1, v); }
+  set blob($core.List<$core.int> v) {
+    $_setBytes(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasBlob() => $_has(1);
   @$pb.TagNumber(2)
@@ -274,40 +342,58 @@ class RegisterPaymentNotificationRequest extends $pb.GeneratedMessage {
 }
 
 class RegisterPaymentNotificationResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RegisterPaymentNotificationResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'RegisterPaymentNotificationResponse',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   RegisterPaymentNotificationResponse._() : super();
   factory RegisterPaymentNotificationResponse() => create();
-  factory RegisterPaymentNotificationResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RegisterPaymentNotificationResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  RegisterPaymentNotificationResponse clone() => RegisterPaymentNotificationResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RegisterPaymentNotificationResponse copyWith(void Function(RegisterPaymentNotificationResponse) updates) => super.copyWith((message) => updates(message as RegisterPaymentNotificationResponse)) as RegisterPaymentNotificationResponse; // ignore: deprecated_member_use
+  factory RegisterPaymentNotificationResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RegisterPaymentNotificationResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  RegisterPaymentNotificationResponse clone() =>
+      RegisterPaymentNotificationResponse()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RegisterPaymentNotificationResponse copyWith(void Function(RegisterPaymentNotificationResponse) updates) =>
+      super.copyWith((message) => updates(message as RegisterPaymentNotificationResponse))
+          as RegisterPaymentNotificationResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RegisterPaymentNotificationResponse create() => RegisterPaymentNotificationResponse._();
   RegisterPaymentNotificationResponse createEmptyInstance() => create();
-  static $pb.PbList<RegisterPaymentNotificationResponse> createRepeated() => $pb.PbList<RegisterPaymentNotificationResponse>();
+  static $pb.PbList<RegisterPaymentNotificationResponse> createRepeated() =>
+      $pb.PbList<RegisterPaymentNotificationResponse>();
   @$core.pragma('dart2js:noInline')
-  static RegisterPaymentNotificationResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterPaymentNotificationResponse>(create);
+  static RegisterPaymentNotificationResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterPaymentNotificationResponse>(create);
   static RegisterPaymentNotificationResponse? _defaultInstance;
 }
 
 class RemovePaymentNotificationRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RemovePaymentNotificationRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'RemovePaymentNotificationRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lspId')
-    ..a<$core.List<$core.int>>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'blob', $pb.PbFieldType.OY)
-    ..hasRequiredFields = false
-  ;
+    ..a<$core.List<$core.int>>(
+        2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'blob', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
 
   RemovePaymentNotificationRequest._() : super();
   factory RemovePaymentNotificationRequest({
@@ -323,31 +409,40 @@ class RemovePaymentNotificationRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RemovePaymentNotificationRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RemovePaymentNotificationRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RemovePaymentNotificationRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RemovePaymentNotificationRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RemovePaymentNotificationRequest clone() => RemovePaymentNotificationRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RemovePaymentNotificationRequest copyWith(void Function(RemovePaymentNotificationRequest) updates) => super.copyWith((message) => updates(message as RemovePaymentNotificationRequest)) as RemovePaymentNotificationRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RemovePaymentNotificationRequest copyWith(void Function(RemovePaymentNotificationRequest) updates) =>
+      super.copyWith((message) => updates(message as RemovePaymentNotificationRequest))
+          as RemovePaymentNotificationRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RemovePaymentNotificationRequest create() => RemovePaymentNotificationRequest._();
   RemovePaymentNotificationRequest createEmptyInstance() => create();
-  static $pb.PbList<RemovePaymentNotificationRequest> createRepeated() => $pb.PbList<RemovePaymentNotificationRequest>();
+  static $pb.PbList<RemovePaymentNotificationRequest> createRepeated() =>
+      $pb.PbList<RemovePaymentNotificationRequest>();
   @$core.pragma('dart2js:noInline')
-  static RemovePaymentNotificationRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemovePaymentNotificationRequest>(create);
+  static RemovePaymentNotificationRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemovePaymentNotificationRequest>(create);
   static RemovePaymentNotificationRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get lspId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set lspId($core.String v) { $_setString(0, v); }
+  set lspId($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasLspId() => $_has(0);
   @$pb.TagNumber(1)
@@ -356,7 +451,10 @@ class RemovePaymentNotificationRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.List<$core.int> get blob => $_getN(1);
   @$pb.TagNumber(2)
-  set blob($core.List<$core.int> v) { $_setBytes(1, v); }
+  set blob($core.List<$core.int> v) {
+    $_setBytes(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasBlob() => $_has(1);
   @$pb.TagNumber(2)
@@ -364,68 +462,90 @@ class RemovePaymentNotificationRequest extends $pb.GeneratedMessage {
 }
 
 class RemovePaymentNotificationResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RemovePaymentNotificationResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'RemovePaymentNotificationResponse',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   RemovePaymentNotificationResponse._() : super();
   factory RemovePaymentNotificationResponse() => create();
-  factory RemovePaymentNotificationResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RemovePaymentNotificationResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RemovePaymentNotificationResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RemovePaymentNotificationResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RemovePaymentNotificationResponse clone() => RemovePaymentNotificationResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RemovePaymentNotificationResponse copyWith(void Function(RemovePaymentNotificationResponse) updates) => super.copyWith((message) => updates(message as RemovePaymentNotificationResponse)) as RemovePaymentNotificationResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RemovePaymentNotificationResponse copyWith(void Function(RemovePaymentNotificationResponse) updates) =>
+      super.copyWith((message) => updates(message as RemovePaymentNotificationResponse))
+          as RemovePaymentNotificationResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RemovePaymentNotificationResponse create() => RemovePaymentNotificationResponse._();
   RemovePaymentNotificationResponse createEmptyInstance() => create();
-  static $pb.PbList<RemovePaymentNotificationResponse> createRepeated() => $pb.PbList<RemovePaymentNotificationResponse>();
+  static $pb.PbList<RemovePaymentNotificationResponse> createRepeated() =>
+      $pb.PbList<RemovePaymentNotificationResponse>();
   @$core.pragma('dart2js:noInline')
-  static RemovePaymentNotificationResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemovePaymentNotificationResponse>(create);
+  static RemovePaymentNotificationResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemovePaymentNotificationResponse>(create);
   static RemovePaymentNotificationResponse? _defaultInstance;
 }
 
 class ReceiverInfoRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReceiverInfoRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReceiverInfoRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   ReceiverInfoRequest._() : super();
   factory ReceiverInfoRequest() => create();
-  factory ReceiverInfoRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ReceiverInfoRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ReceiverInfoRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ReceiverInfoRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ReceiverInfoRequest clone() => ReceiverInfoRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ReceiverInfoRequest copyWith(void Function(ReceiverInfoRequest) updates) => super.copyWith((message) => updates(message as ReceiverInfoRequest)) as ReceiverInfoRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ReceiverInfoRequest copyWith(void Function(ReceiverInfoRequest) updates) =>
+      super.copyWith((message) => updates(message as ReceiverInfoRequest))
+          as ReceiverInfoRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReceiverInfoRequest create() => ReceiverInfoRequest._();
   ReceiverInfoRequest createEmptyInstance() => create();
   static $pb.PbList<ReceiverInfoRequest> createRepeated() => $pb.PbList<ReceiverInfoRequest>();
   @$core.pragma('dart2js:noInline')
-  static ReceiverInfoRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReceiverInfoRequest>(create);
+  static ReceiverInfoRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReceiverInfoRequest>(create);
   static ReceiverInfoRequest? _defaultInstance;
 }
 
 class ReceiverInfoReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReceiverInfoReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReceiverInfoReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pubkey')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   ReceiverInfoReply._() : super();
   factory ReceiverInfoReply({
@@ -437,31 +557,39 @@ class ReceiverInfoReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ReceiverInfoReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ReceiverInfoReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ReceiverInfoReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ReceiverInfoReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ReceiverInfoReply clone() => ReceiverInfoReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ReceiverInfoReply copyWith(void Function(ReceiverInfoReply) updates) => super.copyWith((message) => updates(message as ReceiverInfoReply)) as ReceiverInfoReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ReceiverInfoReply copyWith(void Function(ReceiverInfoReply) updates) =>
+      super.copyWith((message) => updates(message as ReceiverInfoReply))
+          as ReceiverInfoReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReceiverInfoReply create() => ReceiverInfoReply._();
   ReceiverInfoReply createEmptyInstance() => create();
   static $pb.PbList<ReceiverInfoReply> createRepeated() => $pb.PbList<ReceiverInfoReply>();
   @$core.pragma('dart2js:noInline')
-  static ReceiverInfoReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReceiverInfoReply>(create);
+  static ReceiverInfoReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReceiverInfoReply>(create);
   static ReceiverInfoReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get pubkey => $_getSZ(0);
   @$pb.TagNumber(1)
-  set pubkey($core.String v) { $_setString(0, v); }
+  set pubkey($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasPubkey() => $_has(0);
   @$pb.TagNumber(1)
@@ -469,40 +597,51 @@ class ReceiverInfoReply extends $pb.GeneratedMessage {
 }
 
 class RatesRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RatesRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RatesRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   RatesRequest._() : super();
   factory RatesRequest() => create();
-  factory RatesRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RatesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RatesRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RatesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RatesRequest clone() => RatesRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RatesRequest copyWith(void Function(RatesRequest) updates) => super.copyWith((message) => updates(message as RatesRequest)) as RatesRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RatesRequest copyWith(void Function(RatesRequest) updates) =>
+      super.copyWith((message) => updates(message as RatesRequest))
+          as RatesRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RatesRequest create() => RatesRequest._();
   RatesRequest createEmptyInstance() => create();
   static $pb.PbList<RatesRequest> createRepeated() => $pb.PbList<RatesRequest>();
   @$core.pragma('dart2js:noInline')
-  static RatesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatesRequest>(create);
+  static RatesRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatesRequest>(create);
   static RatesRequest? _defaultInstance;
 }
 
 class Rate extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Rate', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Rate',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'coin')
-    ..a<$core.double>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'value', $pb.PbFieldType.OD)
-    ..hasRequiredFields = false
-  ;
+    ..a<$core.double>(
+        2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'value', $pb.PbFieldType.OD)
+    ..hasRequiredFields = false;
 
   Rate._() : super();
   factory Rate({
@@ -518,18 +657,19 @@ class Rate extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory Rate.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Rate.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory Rate.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Rate.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   Rate clone() => Rate()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Rate copyWith(void Function(Rate) updates) => super.copyWith((message) => updates(message as Rate)) as Rate; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Rate copyWith(void Function(Rate) updates) =>
+      super.copyWith((message) => updates(message as Rate)) as Rate; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Rate create() => Rate._();
@@ -542,7 +682,10 @@ class Rate extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get coin => $_getSZ(0);
   @$pb.TagNumber(1)
-  set coin($core.String v) { $_setString(0, v); }
+  set coin($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasCoin() => $_has(0);
   @$pb.TagNumber(1)
@@ -551,7 +694,10 @@ class Rate extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.double get value => $_getN(1);
   @$pb.TagNumber(2)
-  set value($core.double v) { $_setDouble(1, v); }
+  set value($core.double v) {
+    $_setDouble(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasValue() => $_has(1);
   @$pb.TagNumber(2)
@@ -559,10 +705,15 @@ class Rate extends $pb.GeneratedMessage {
 }
 
 class RatesReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RatesReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..pc<Rate>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'rates', $pb.PbFieldType.PM, subBuilder: Rate.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RatesReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..pc<Rate>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'rates', $pb.PbFieldType.PM,
+        subBuilder: Rate.create)
+    ..hasRequiredFields = false;
 
   RatesReply._() : super();
   factory RatesReply({
@@ -574,25 +725,29 @@ class RatesReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RatesReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RatesReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RatesReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RatesReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RatesReply clone() => RatesReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RatesReply copyWith(void Function(RatesReply) updates) => super.copyWith((message) => updates(message as RatesReply)) as RatesReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RatesReply copyWith(void Function(RatesReply) updates) =>
+      super.copyWith((message) => updates(message as RatesReply))
+          as RatesReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RatesReply create() => RatesReply._();
   RatesReply createEmptyInstance() => create();
   static $pb.PbList<RatesReply> createRepeated() => $pb.PbList<RatesReply>();
   @$core.pragma('dart2js:noInline')
-  static RatesReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatesReply>(create);
+  static RatesReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatesReply>(create);
   static RatesReply? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -600,10 +755,13 @@ class RatesReply extends $pb.GeneratedMessage {
 }
 
 class LSPListRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LSPListRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LSPListRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pubkey')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   LSPListRequest._() : super();
   factory LSPListRequest({
@@ -615,31 +773,38 @@ class LSPListRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory LSPListRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory LSPListRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory LSPListRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LSPListRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   LSPListRequest clone() => LSPListRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  LSPListRequest copyWith(void Function(LSPListRequest) updates) => super.copyWith((message) => updates(message as LSPListRequest)) as LSPListRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  LSPListRequest copyWith(void Function(LSPListRequest) updates) =>
+      super.copyWith((message) => updates(message as LSPListRequest))
+          as LSPListRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LSPListRequest create() => LSPListRequest._();
   LSPListRequest createEmptyInstance() => create();
   static $pb.PbList<LSPListRequest> createRepeated() => $pb.PbList<LSPListRequest>();
   @$core.pragma('dart2js:noInline')
-  static LSPListRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LSPListRequest>(create);
+  static LSPListRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LSPListRequest>(create);
   static LSPListRequest? _defaultInstance;
 
   @$pb.TagNumber(2)
   $core.String get pubkey => $_getSZ(0);
   @$pb.TagNumber(2)
-  set pubkey($core.String v) { $_setString(0, v); }
+  set pubkey($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasPubkey() => $_has(0);
   @$pb.TagNumber(2)
@@ -647,24 +812,35 @@ class LSPListRequest extends $pb.GeneratedMessage {
 }
 
 class LSPInformation extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LSPInformation', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LSPInformation',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'widget_url')
     ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pubkey')
     ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'host')
     ..aInt64(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'channel_capacity')
-    ..a<$core.int>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'target_conf', $pb.PbFieldType.O3)
+    ..a<$core.int>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'target_conf',
+        $pb.PbFieldType.O3)
     ..aInt64(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'base_fee_msat')
-    ..a<$core.double>(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'fee_rate', $pb.PbFieldType.OD)
-    ..a<$core.int>(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'time_lock_delta', $pb.PbFieldType.OU3)
+    ..a<$core.double>(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'fee_rate',
+        $pb.PbFieldType.OD)
+    ..a<$core.int>(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'time_lock_delta',
+        $pb.PbFieldType.OU3)
     ..aInt64(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'min_htlc_msat')
     ..aInt64(11, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'channelFeePermyriad')
-    ..a<$core.List<$core.int>>(12, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lspPubkey', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(12,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lspPubkey', $pb.PbFieldType.OY)
     ..aInt64(13, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxInactiveDuration')
     ..aInt64(14, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'channelMinimumFeeMsat')
-    ..pc<OpeningFeeParams>(15, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'openingFeeParamsMenu', $pb.PbFieldType.PM, subBuilder: OpeningFeeParams.create)
-    ..hasRequiredFields = false
-  ;
+    ..pc<OpeningFeeParams>(
+        15,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'openingFeeParamsMenu',
+        $pb.PbFieldType.PM,
+        subBuilder: OpeningFeeParams.create)
+    ..hasRequiredFields = false;
 
   LSPInformation._() : super();
   factory LSPInformation({
@@ -678,13 +854,10 @@ class LSPInformation extends $pb.GeneratedMessage {
     $core.double? feeRate,
     $core.int? timeLockDelta,
     $fixnum.Int64? minHtlcMsat,
-  @$core.Deprecated('This field is deprecated.')
-    $fixnum.Int64? channelFeePermyriad,
+    @$core.Deprecated('This field is deprecated.') $fixnum.Int64? channelFeePermyriad,
     $core.List<$core.int>? lspPubkey,
-  @$core.Deprecated('This field is deprecated.')
-    $fixnum.Int64? maxInactiveDuration,
-  @$core.Deprecated('This field is deprecated.')
-    $fixnum.Int64? channelMinimumFeeMsat,
+    @$core.Deprecated('This field is deprecated.') $fixnum.Int64? maxInactiveDuration,
+    @$core.Deprecated('This field is deprecated.') $fixnum.Int64? channelMinimumFeeMsat,
     $core.Iterable<OpeningFeeParams>? openingFeeParamsMenu,
   }) {
     final _result = create();
@@ -738,31 +911,38 @@ class LSPInformation extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory LSPInformation.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory LSPInformation.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory LSPInformation.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LSPInformation.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   LSPInformation clone() => LSPInformation()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  LSPInformation copyWith(void Function(LSPInformation) updates) => super.copyWith((message) => updates(message as LSPInformation)) as LSPInformation; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  LSPInformation copyWith(void Function(LSPInformation) updates) =>
+      super.copyWith((message) => updates(message as LSPInformation))
+          as LSPInformation; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LSPInformation create() => LSPInformation._();
   LSPInformation createEmptyInstance() => create();
   static $pb.PbList<LSPInformation> createRepeated() => $pb.PbList<LSPInformation>();
   @$core.pragma('dart2js:noInline')
-  static LSPInformation getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LSPInformation>(create);
+  static LSPInformation getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LSPInformation>(create);
   static LSPInformation? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) { $_setString(0, v); }
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -771,7 +951,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get widgetUrl => $_getSZ(1);
   @$pb.TagNumber(2)
-  set widgetUrl($core.String v) { $_setString(1, v); }
+  set widgetUrl($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasWidgetUrl() => $_has(1);
   @$pb.TagNumber(2)
@@ -780,7 +963,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get pubkey => $_getSZ(2);
   @$pb.TagNumber(3)
-  set pubkey($core.String v) { $_setString(2, v); }
+  set pubkey($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasPubkey() => $_has(2);
   @$pb.TagNumber(3)
@@ -789,7 +975,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get host => $_getSZ(3);
   @$pb.TagNumber(4)
-  set host($core.String v) { $_setString(3, v); }
+  set host($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasHost() => $_has(3);
   @$pb.TagNumber(4)
@@ -798,7 +987,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $fixnum.Int64 get channelCapacity => $_getI64(4);
   @$pb.TagNumber(5)
-  set channelCapacity($fixnum.Int64 v) { $_setInt64(4, v); }
+  set channelCapacity($fixnum.Int64 v) {
+    $_setInt64(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasChannelCapacity() => $_has(4);
   @$pb.TagNumber(5)
@@ -807,7 +999,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.int get targetConf => $_getIZ(5);
   @$pb.TagNumber(6)
-  set targetConf($core.int v) { $_setSignedInt32(5, v); }
+  set targetConf($core.int v) {
+    $_setSignedInt32(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasTargetConf() => $_has(5);
   @$pb.TagNumber(6)
@@ -816,7 +1011,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $fixnum.Int64 get baseFeeMsat => $_getI64(6);
   @$pb.TagNumber(7)
-  set baseFeeMsat($fixnum.Int64 v) { $_setInt64(6, v); }
+  set baseFeeMsat($fixnum.Int64 v) {
+    $_setInt64(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasBaseFeeMsat() => $_has(6);
   @$pb.TagNumber(7)
@@ -825,7 +1023,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.double get feeRate => $_getN(7);
   @$pb.TagNumber(8)
-  set feeRate($core.double v) { $_setDouble(7, v); }
+  set feeRate($core.double v) {
+    $_setDouble(7, v);
+  }
+
   @$pb.TagNumber(8)
   $core.bool hasFeeRate() => $_has(7);
   @$pb.TagNumber(8)
@@ -834,7 +1035,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.int get timeLockDelta => $_getIZ(8);
   @$pb.TagNumber(9)
-  set timeLockDelta($core.int v) { $_setUnsignedInt32(8, v); }
+  set timeLockDelta($core.int v) {
+    $_setUnsignedInt32(8, v);
+  }
+
   @$pb.TagNumber(9)
   $core.bool hasTimeLockDelta() => $_has(8);
   @$pb.TagNumber(9)
@@ -843,7 +1047,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $fixnum.Int64 get minHtlcMsat => $_getI64(9);
   @$pb.TagNumber(10)
-  set minHtlcMsat($fixnum.Int64 v) { $_setInt64(9, v); }
+  set minHtlcMsat($fixnum.Int64 v) {
+    $_setInt64(9, v);
+  }
+
   @$pb.TagNumber(10)
   $core.bool hasMinHtlcMsat() => $_has(9);
   @$pb.TagNumber(10)
@@ -854,7 +1061,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   $fixnum.Int64 get channelFeePermyriad => $_getI64(10);
   @$core.Deprecated('This field is deprecated.')
   @$pb.TagNumber(11)
-  set channelFeePermyriad($fixnum.Int64 v) { $_setInt64(10, v); }
+  set channelFeePermyriad($fixnum.Int64 v) {
+    $_setInt64(10, v);
+  }
+
   @$core.Deprecated('This field is deprecated.')
   @$pb.TagNumber(11)
   $core.bool hasChannelFeePermyriad() => $_has(10);
@@ -865,7 +1075,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(12)
   $core.List<$core.int> get lspPubkey => $_getN(11);
   @$pb.TagNumber(12)
-  set lspPubkey($core.List<$core.int> v) { $_setBytes(11, v); }
+  set lspPubkey($core.List<$core.int> v) {
+    $_setBytes(11, v);
+  }
+
   @$pb.TagNumber(12)
   $core.bool hasLspPubkey() => $_has(11);
   @$pb.TagNumber(12)
@@ -876,7 +1089,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   $fixnum.Int64 get maxInactiveDuration => $_getI64(12);
   @$core.Deprecated('This field is deprecated.')
   @$pb.TagNumber(13)
-  set maxInactiveDuration($fixnum.Int64 v) { $_setInt64(12, v); }
+  set maxInactiveDuration($fixnum.Int64 v) {
+    $_setInt64(12, v);
+  }
+
   @$core.Deprecated('This field is deprecated.')
   @$pb.TagNumber(13)
   $core.bool hasMaxInactiveDuration() => $_has(12);
@@ -889,7 +1105,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   $fixnum.Int64 get channelMinimumFeeMsat => $_getI64(13);
   @$core.Deprecated('This field is deprecated.')
   @$pb.TagNumber(14)
-  set channelMinimumFeeMsat($fixnum.Int64 v) { $_setInt64(13, v); }
+  set channelMinimumFeeMsat($fixnum.Int64 v) {
+    $_setInt64(13, v);
+  }
+
   @$core.Deprecated('This field is deprecated.')
   @$pb.TagNumber(14)
   $core.bool hasChannelMinimumFeeMsat() => $_has(13);
@@ -902,15 +1121,25 @@ class LSPInformation extends $pb.GeneratedMessage {
 }
 
 class OpeningFeeParams extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'OpeningFeeParams', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..a<$fixnum.Int64>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'minMsat', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
-    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'proportional', $pb.PbFieldType.OU3)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'OpeningFeeParams',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'minMsat',
+        $pb.PbFieldType.OU6,
+        defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'proportional',
+        $pb.PbFieldType.OU3)
     ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'validUntil')
-    ..a<$core.int>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxIdleTime', $pb.PbFieldType.OU3)
-    ..a<$core.int>(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxClientToSelfDelay', $pb.PbFieldType.OU3)
+    ..a<$core.int>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxIdleTime',
+        $pb.PbFieldType.OU3)
+    ..a<$core.int>(
+        5,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxClientToSelfDelay',
+        $pb.PbFieldType.OU3)
     ..aOS(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'promise')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   OpeningFeeParams._() : super();
   factory OpeningFeeParams({
@@ -942,31 +1171,39 @@ class OpeningFeeParams extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory OpeningFeeParams.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory OpeningFeeParams.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory OpeningFeeParams.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory OpeningFeeParams.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   OpeningFeeParams clone() => OpeningFeeParams()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  OpeningFeeParams copyWith(void Function(OpeningFeeParams) updates) => super.copyWith((message) => updates(message as OpeningFeeParams)) as OpeningFeeParams; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  OpeningFeeParams copyWith(void Function(OpeningFeeParams) updates) =>
+      super.copyWith((message) => updates(message as OpeningFeeParams))
+          as OpeningFeeParams; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static OpeningFeeParams create() => OpeningFeeParams._();
   OpeningFeeParams createEmptyInstance() => create();
   static $pb.PbList<OpeningFeeParams> createRepeated() => $pb.PbList<OpeningFeeParams>();
   @$core.pragma('dart2js:noInline')
-  static OpeningFeeParams getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OpeningFeeParams>(create);
+  static OpeningFeeParams getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OpeningFeeParams>(create);
   static OpeningFeeParams? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get minMsat => $_getI64(0);
   @$pb.TagNumber(1)
-  set minMsat($fixnum.Int64 v) { $_setInt64(0, v); }
+  set minMsat($fixnum.Int64 v) {
+    $_setInt64(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasMinMsat() => $_has(0);
   @$pb.TagNumber(1)
@@ -975,7 +1212,10 @@ class OpeningFeeParams extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get proportional => $_getIZ(1);
   @$pb.TagNumber(2)
-  set proportional($core.int v) { $_setUnsignedInt32(1, v); }
+  set proportional($core.int v) {
+    $_setUnsignedInt32(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasProportional() => $_has(1);
   @$pb.TagNumber(2)
@@ -984,7 +1224,10 @@ class OpeningFeeParams extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get validUntil => $_getSZ(2);
   @$pb.TagNumber(3)
-  set validUntil($core.String v) { $_setString(2, v); }
+  set validUntil($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasValidUntil() => $_has(2);
   @$pb.TagNumber(3)
@@ -993,7 +1236,10 @@ class OpeningFeeParams extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.int get maxIdleTime => $_getIZ(3);
   @$pb.TagNumber(4)
-  set maxIdleTime($core.int v) { $_setUnsignedInt32(3, v); }
+  set maxIdleTime($core.int v) {
+    $_setUnsignedInt32(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasMaxIdleTime() => $_has(3);
   @$pb.TagNumber(4)
@@ -1002,7 +1248,10 @@ class OpeningFeeParams extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.int get maxClientToSelfDelay => $_getIZ(4);
   @$pb.TagNumber(5)
-  set maxClientToSelfDelay($core.int v) { $_setUnsignedInt32(4, v); }
+  set maxClientToSelfDelay($core.int v) {
+    $_setUnsignedInt32(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasMaxClientToSelfDelay() => $_has(4);
   @$pb.TagNumber(5)
@@ -1011,7 +1260,10 @@ class OpeningFeeParams extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.String get promise => $_getSZ(5);
   @$pb.TagNumber(6)
-  set promise($core.String v) { $_setString(5, v); }
+  set promise($core.String v) {
+    $_setString(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasPromise() => $_has(5);
   @$pb.TagNumber(6)
@@ -1019,10 +1271,19 @@ class OpeningFeeParams extends $pb.GeneratedMessage {
 }
 
 class LSPListReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LSPListReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..m<$core.String, LSPInformation>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lsps', entryClassName: 'LSPListReply.LspsEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OM, valueCreator: LSPInformation.create, packageName: const $pb.PackageName('breez'))
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LSPListReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..m<$core.String, LSPInformation>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lsps',
+        entryClassName: 'LSPListReply.LspsEntry',
+        keyFieldType: $pb.PbFieldType.OS,
+        valueFieldType: $pb.PbFieldType.OM,
+        valueCreator: LSPInformation.create,
+        packageName: const $pb.PackageName('breez'))
+    ..hasRequiredFields = false;
 
   LSPListReply._() : super();
   factory LSPListReply({
@@ -1034,25 +1295,29 @@ class LSPListReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory LSPListReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory LSPListReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory LSPListReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LSPListReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   LSPListReply clone() => LSPListReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  LSPListReply copyWith(void Function(LSPListReply) updates) => super.copyWith((message) => updates(message as LSPListReply)) as LSPListReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  LSPListReply copyWith(void Function(LSPListReply) updates) =>
+      super.copyWith((message) => updates(message as LSPListReply))
+          as LSPListReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LSPListReply create() => LSPListReply._();
   LSPListReply createEmptyInstance() => create();
   static $pb.PbList<LSPListReply> createRepeated() => $pb.PbList<LSPListReply>();
   @$core.pragma('dart2js:noInline')
-  static LSPListReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LSPListReply>(create);
+  static LSPListReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LSPListReply>(create);
   static LSPListReply? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -1060,11 +1325,15 @@ class LSPListReply extends $pb.GeneratedMessage {
 }
 
 class RegisterPaymentRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RegisterPaymentRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RegisterPaymentRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lspId')
-    ..a<$core.List<$core.int>>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'blob', $pb.PbFieldType.OY)
-    ..hasRequiredFields = false
-  ;
+    ..a<$core.List<$core.int>>(
+        3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'blob', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
 
   RegisterPaymentRequest._() : super();
   factory RegisterPaymentRequest({
@@ -1080,31 +1349,39 @@ class RegisterPaymentRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RegisterPaymentRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RegisterPaymentRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RegisterPaymentRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RegisterPaymentRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RegisterPaymentRequest clone() => RegisterPaymentRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RegisterPaymentRequest copyWith(void Function(RegisterPaymentRequest) updates) => super.copyWith((message) => updates(message as RegisterPaymentRequest)) as RegisterPaymentRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RegisterPaymentRequest copyWith(void Function(RegisterPaymentRequest) updates) =>
+      super.copyWith((message) => updates(message as RegisterPaymentRequest))
+          as RegisterPaymentRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RegisterPaymentRequest create() => RegisterPaymentRequest._();
   RegisterPaymentRequest createEmptyInstance() => create();
   static $pb.PbList<RegisterPaymentRequest> createRepeated() => $pb.PbList<RegisterPaymentRequest>();
   @$core.pragma('dart2js:noInline')
-  static RegisterPaymentRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterPaymentRequest>(create);
+  static RegisterPaymentRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterPaymentRequest>(create);
   static RegisterPaymentRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get lspId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set lspId($core.String v) { $_setString(0, v); }
+  set lspId($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasLspId() => $_has(0);
   @$pb.TagNumber(1)
@@ -1113,7 +1390,10 @@ class RegisterPaymentRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.List<$core.int> get blob => $_getN(1);
   @$pb.TagNumber(3)
-  set blob($core.List<$core.int> v) { $_setBytes(1, v); }
+  set blob($core.List<$core.int> v) {
+    $_setBytes(1, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasBlob() => $_has(1);
   @$pb.TagNumber(3)
@@ -1121,40 +1401,52 @@ class RegisterPaymentRequest extends $pb.GeneratedMessage {
 }
 
 class RegisterPaymentReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RegisterPaymentReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RegisterPaymentReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   RegisterPaymentReply._() : super();
   factory RegisterPaymentReply() => create();
-  factory RegisterPaymentReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RegisterPaymentReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RegisterPaymentReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RegisterPaymentReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RegisterPaymentReply clone() => RegisterPaymentReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RegisterPaymentReply copyWith(void Function(RegisterPaymentReply) updates) => super.copyWith((message) => updates(message as RegisterPaymentReply)) as RegisterPaymentReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RegisterPaymentReply copyWith(void Function(RegisterPaymentReply) updates) =>
+      super.copyWith((message) => updates(message as RegisterPaymentReply))
+          as RegisterPaymentReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RegisterPaymentReply create() => RegisterPaymentReply._();
   RegisterPaymentReply createEmptyInstance() => create();
   static $pb.PbList<RegisterPaymentReply> createRepeated() => $pb.PbList<RegisterPaymentReply>();
   @$core.pragma('dart2js:noInline')
-  static RegisterPaymentReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterPaymentReply>(create);
+  static RegisterPaymentReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterPaymentReply>(create);
   static RegisterPaymentReply? _defaultInstance;
 }
 
 class CheckChannelsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CheckChannelsRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CheckChannelsRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lspId')
-    ..a<$core.List<$core.int>>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'blob', $pb.PbFieldType.OY)
-    ..hasRequiredFields = false
-  ;
+    ..a<$core.List<$core.int>>(
+        2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'blob', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
 
   CheckChannelsRequest._() : super();
   factory CheckChannelsRequest({
@@ -1170,31 +1462,39 @@ class CheckChannelsRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory CheckChannelsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory CheckChannelsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory CheckChannelsRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory CheckChannelsRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   CheckChannelsRequest clone() => CheckChannelsRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  CheckChannelsRequest copyWith(void Function(CheckChannelsRequest) updates) => super.copyWith((message) => updates(message as CheckChannelsRequest)) as CheckChannelsRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  CheckChannelsRequest copyWith(void Function(CheckChannelsRequest) updates) =>
+      super.copyWith((message) => updates(message as CheckChannelsRequest))
+          as CheckChannelsRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CheckChannelsRequest create() => CheckChannelsRequest._();
   CheckChannelsRequest createEmptyInstance() => create();
   static $pb.PbList<CheckChannelsRequest> createRepeated() => $pb.PbList<CheckChannelsRequest>();
   @$core.pragma('dart2js:noInline')
-  static CheckChannelsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CheckChannelsRequest>(create);
+  static CheckChannelsRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CheckChannelsRequest>(create);
   static CheckChannelsRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get lspId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set lspId($core.String v) { $_setString(0, v); }
+  set lspId($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasLspId() => $_has(0);
   @$pb.TagNumber(1)
@@ -1203,7 +1503,10 @@ class CheckChannelsRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.List<$core.int> get blob => $_getN(1);
   @$pb.TagNumber(2)
-  set blob($core.List<$core.int> v) { $_setBytes(1, v); }
+  set blob($core.List<$core.int> v) {
+    $_setBytes(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasBlob() => $_has(1);
   @$pb.TagNumber(2)
@@ -1211,10 +1514,14 @@ class CheckChannelsRequest extends $pb.GeneratedMessage {
 }
 
 class CheckChannelsReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CheckChannelsReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..a<$core.List<$core.int>>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'blob', $pb.PbFieldType.OY)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CheckChannelsReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(
+        2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'blob', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
 
   CheckChannelsReply._() : super();
   factory CheckChannelsReply({
@@ -1226,31 +1533,39 @@ class CheckChannelsReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory CheckChannelsReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory CheckChannelsReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory CheckChannelsReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory CheckChannelsReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   CheckChannelsReply clone() => CheckChannelsReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  CheckChannelsReply copyWith(void Function(CheckChannelsReply) updates) => super.copyWith((message) => updates(message as CheckChannelsReply)) as CheckChannelsReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  CheckChannelsReply copyWith(void Function(CheckChannelsReply) updates) =>
+      super.copyWith((message) => updates(message as CheckChannelsReply))
+          as CheckChannelsReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CheckChannelsReply create() => CheckChannelsReply._();
   CheckChannelsReply createEmptyInstance() => create();
   static $pb.PbList<CheckChannelsReply> createRepeated() => $pb.PbList<CheckChannelsReply>();
   @$core.pragma('dart2js:noInline')
-  static CheckChannelsReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CheckChannelsReply>(create);
+  static CheckChannelsReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CheckChannelsReply>(create);
   static CheckChannelsReply? _defaultInstance;
 
   @$pb.TagNumber(2)
   $core.List<$core.int> get blob => $_getN(0);
   @$pb.TagNumber(2)
-  set blob($core.List<$core.int> v) { $_setBytes(0, v); }
+  set blob($core.List<$core.int> v) {
+    $_setBytes(0, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasBlob() => $_has(0);
   @$pb.TagNumber(2)
@@ -1258,11 +1573,15 @@ class CheckChannelsReply extends $pb.GeneratedMessage {
 }
 
 class Captcha extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Captcha', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Captcha',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'id')
-    ..a<$core.List<$core.int>>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'image', $pb.PbFieldType.OY)
-    ..hasRequiredFields = false
-  ;
+    ..a<$core.List<$core.int>>(
+        2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'image', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
 
   Captcha._() : super();
   factory Captcha({
@@ -1278,18 +1597,20 @@ class Captcha extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory Captcha.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Captcha.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory Captcha.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Captcha.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   Captcha clone() => Captcha()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Captcha copyWith(void Function(Captcha) updates) => super.copyWith((message) => updates(message as Captcha)) as Captcha; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Captcha copyWith(void Function(Captcha) updates) =>
+      super.copyWith((message) => updates(message as Captcha)) as Captcha; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Captcha create() => Captcha._();
@@ -1302,7 +1623,10 @@ class Captcha extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) { $_setString(0, v); }
+  set id($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
@@ -1311,7 +1635,10 @@ class Captcha extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.List<$core.int> get image => $_getN(1);
   @$pb.TagNumber(2)
-  set image($core.List<$core.int> v) { $_setBytes(1, v); }
+  set image($core.List<$core.int> v) {
+    $_setBytes(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasImage() => $_has(1);
   @$pb.TagNumber(2)
@@ -1319,10 +1646,14 @@ class Captcha extends $pb.GeneratedMessage {
 }
 
 class UpdateChannelPolicyRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'UpdateChannelPolicyRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pubKey', protoName: 'pubKey')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'UpdateChannelPolicyRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pubKey',
+        protoName: 'pubKey')
+    ..hasRequiredFields = false;
 
   UpdateChannelPolicyRequest._() : super();
   factory UpdateChannelPolicyRequest({
@@ -1334,31 +1665,39 @@ class UpdateChannelPolicyRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory UpdateChannelPolicyRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory UpdateChannelPolicyRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory UpdateChannelPolicyRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory UpdateChannelPolicyRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   UpdateChannelPolicyRequest clone() => UpdateChannelPolicyRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  UpdateChannelPolicyRequest copyWith(void Function(UpdateChannelPolicyRequest) updates) => super.copyWith((message) => updates(message as UpdateChannelPolicyRequest)) as UpdateChannelPolicyRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  UpdateChannelPolicyRequest copyWith(void Function(UpdateChannelPolicyRequest) updates) =>
+      super.copyWith((message) => updates(message as UpdateChannelPolicyRequest))
+          as UpdateChannelPolicyRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static UpdateChannelPolicyRequest create() => UpdateChannelPolicyRequest._();
   UpdateChannelPolicyRequest createEmptyInstance() => create();
   static $pb.PbList<UpdateChannelPolicyRequest> createRepeated() => $pb.PbList<UpdateChannelPolicyRequest>();
   @$core.pragma('dart2js:noInline')
-  static UpdateChannelPolicyRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UpdateChannelPolicyRequest>(create);
+  static UpdateChannelPolicyRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UpdateChannelPolicyRequest>(create);
   static UpdateChannelPolicyRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get pubKey => $_getSZ(0);
   @$pb.TagNumber(1)
-  set pubKey($core.String v) { $_setString(0, v); }
+  set pubKey($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasPubKey() => $_has(0);
   @$pb.TagNumber(1)
@@ -1366,42 +1705,57 @@ class UpdateChannelPolicyRequest extends $pb.GeneratedMessage {
 }
 
 class UpdateChannelPolicyReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'UpdateChannelPolicyReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'UpdateChannelPolicyReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   UpdateChannelPolicyReply._() : super();
   factory UpdateChannelPolicyReply() => create();
-  factory UpdateChannelPolicyReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory UpdateChannelPolicyReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory UpdateChannelPolicyReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory UpdateChannelPolicyReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   UpdateChannelPolicyReply clone() => UpdateChannelPolicyReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  UpdateChannelPolicyReply copyWith(void Function(UpdateChannelPolicyReply) updates) => super.copyWith((message) => updates(message as UpdateChannelPolicyReply)) as UpdateChannelPolicyReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  UpdateChannelPolicyReply copyWith(void Function(UpdateChannelPolicyReply) updates) =>
+      super.copyWith((message) => updates(message as UpdateChannelPolicyReply))
+          as UpdateChannelPolicyReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static UpdateChannelPolicyReply create() => UpdateChannelPolicyReply._();
   UpdateChannelPolicyReply createEmptyInstance() => create();
   static $pb.PbList<UpdateChannelPolicyReply> createRepeated() => $pb.PbList<UpdateChannelPolicyReply>();
   @$core.pragma('dart2js:noInline')
-  static UpdateChannelPolicyReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UpdateChannelPolicyReply>(create);
+  static UpdateChannelPolicyReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UpdateChannelPolicyReply>(create);
   static UpdateChannelPolicyReply? _defaultInstance;
 }
 
 class AddFundInitRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddFundInitRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'nodeID', protoName: 'nodeID')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'notificationToken', protoName: 'notificationToken')
-    ..a<$core.List<$core.int>>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pubkey', $pb.PbFieldType.OY)
-    ..a<$core.List<$core.int>>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'hash', $pb.PbFieldType.OY)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddFundInitRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'nodeID',
+        protoName: 'nodeID')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'notificationToken',
+        protoName: 'notificationToken')
+    ..a<$core.List<$core.int>>(
+        3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pubkey', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(
+        4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'hash', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
 
   AddFundInitRequest._() : super();
   factory AddFundInitRequest({
@@ -1425,31 +1779,39 @@ class AddFundInitRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory AddFundInitRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory AddFundInitRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory AddFundInitRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory AddFundInitRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   AddFundInitRequest clone() => AddFundInitRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  AddFundInitRequest copyWith(void Function(AddFundInitRequest) updates) => super.copyWith((message) => updates(message as AddFundInitRequest)) as AddFundInitRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  AddFundInitRequest copyWith(void Function(AddFundInitRequest) updates) =>
+      super.copyWith((message) => updates(message as AddFundInitRequest))
+          as AddFundInitRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AddFundInitRequest create() => AddFundInitRequest._();
   AddFundInitRequest createEmptyInstance() => create();
   static $pb.PbList<AddFundInitRequest> createRepeated() => $pb.PbList<AddFundInitRequest>();
   @$core.pragma('dart2js:noInline')
-  static AddFundInitRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundInitRequest>(create);
+  static AddFundInitRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundInitRequest>(create);
   static AddFundInitRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get nodeID => $_getSZ(0);
   @$pb.TagNumber(1)
-  set nodeID($core.String v) { $_setString(0, v); }
+  set nodeID($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasNodeID() => $_has(0);
   @$pb.TagNumber(1)
@@ -1458,7 +1820,10 @@ class AddFundInitRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get notificationToken => $_getSZ(1);
   @$pb.TagNumber(2)
-  set notificationToken($core.String v) { $_setString(1, v); }
+  set notificationToken($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasNotificationToken() => $_has(1);
   @$pb.TagNumber(2)
@@ -1467,7 +1832,10 @@ class AddFundInitRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.List<$core.int> get pubkey => $_getN(2);
   @$pb.TagNumber(3)
-  set pubkey($core.List<$core.int> v) { $_setBytes(2, v); }
+  set pubkey($core.List<$core.int> v) {
+    $_setBytes(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasPubkey() => $_has(2);
   @$pb.TagNumber(3)
@@ -1476,7 +1844,10 @@ class AddFundInitRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.List<$core.int> get hash => $_getN(3);
   @$pb.TagNumber(4)
-  set hash($core.List<$core.int> v) { $_setBytes(3, v); }
+  set hash($core.List<$core.int> v) {
+    $_setBytes(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasHash() => $_has(3);
   @$pb.TagNumber(4)
@@ -1484,16 +1855,25 @@ class AddFundInitRequest extends $pb.GeneratedMessage {
 }
 
 class AddFundInitReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddFundInitReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddFundInitReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'address')
-    ..a<$core.List<$core.int>>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pubkey', $pb.PbFieldType.OY)
-    ..aInt64(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lockHeight', protoName: 'lockHeight')
-    ..aInt64(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxAllowedDeposit', protoName: 'maxAllowedDeposit')
-    ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'errorMessage', protoName: 'errorMessage')
-    ..aInt64(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'requiredReserve', protoName: 'requiredReserve')
-    ..aInt64(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'minAllowedDeposit', protoName: 'minAllowedDeposit')
-    ..hasRequiredFields = false
-  ;
+    ..a<$core.List<$core.int>>(
+        2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pubkey', $pb.PbFieldType.OY)
+    ..aInt64(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lockHeight',
+        protoName: 'lockHeight')
+    ..aInt64(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxAllowedDeposit',
+        protoName: 'maxAllowedDeposit')
+    ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'errorMessage',
+        protoName: 'errorMessage')
+    ..aInt64(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'requiredReserve',
+        protoName: 'requiredReserve')
+    ..aInt64(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'minAllowedDeposit',
+        protoName: 'minAllowedDeposit')
+    ..hasRequiredFields = false;
 
   AddFundInitReply._() : super();
   factory AddFundInitReply({
@@ -1529,31 +1909,39 @@ class AddFundInitReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory AddFundInitReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory AddFundInitReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory AddFundInitReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory AddFundInitReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   AddFundInitReply clone() => AddFundInitReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  AddFundInitReply copyWith(void Function(AddFundInitReply) updates) => super.copyWith((message) => updates(message as AddFundInitReply)) as AddFundInitReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  AddFundInitReply copyWith(void Function(AddFundInitReply) updates) =>
+      super.copyWith((message) => updates(message as AddFundInitReply))
+          as AddFundInitReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AddFundInitReply create() => AddFundInitReply._();
   AddFundInitReply createEmptyInstance() => create();
   static $pb.PbList<AddFundInitReply> createRepeated() => $pb.PbList<AddFundInitReply>();
   @$core.pragma('dart2js:noInline')
-  static AddFundInitReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundInitReply>(create);
+  static AddFundInitReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundInitReply>(create);
   static AddFundInitReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) { $_setString(0, v); }
+  set address($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -1562,7 +1950,10 @@ class AddFundInitReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.List<$core.int> get pubkey => $_getN(1);
   @$pb.TagNumber(2)
-  set pubkey($core.List<$core.int> v) { $_setBytes(1, v); }
+  set pubkey($core.List<$core.int> v) {
+    $_setBytes(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasPubkey() => $_has(1);
   @$pb.TagNumber(2)
@@ -1571,7 +1962,10 @@ class AddFundInitReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get lockHeight => $_getI64(2);
   @$pb.TagNumber(3)
-  set lockHeight($fixnum.Int64 v) { $_setInt64(2, v); }
+  set lockHeight($fixnum.Int64 v) {
+    $_setInt64(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasLockHeight() => $_has(2);
   @$pb.TagNumber(3)
@@ -1580,7 +1974,10 @@ class AddFundInitReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get maxAllowedDeposit => $_getI64(3);
   @$pb.TagNumber(4)
-  set maxAllowedDeposit($fixnum.Int64 v) { $_setInt64(3, v); }
+  set maxAllowedDeposit($fixnum.Int64 v) {
+    $_setInt64(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasMaxAllowedDeposit() => $_has(3);
   @$pb.TagNumber(4)
@@ -1589,7 +1986,10 @@ class AddFundInitReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get errorMessage => $_getSZ(4);
   @$pb.TagNumber(5)
-  set errorMessage($core.String v) { $_setString(4, v); }
+  set errorMessage($core.String v) {
+    $_setString(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasErrorMessage() => $_has(4);
   @$pb.TagNumber(5)
@@ -1598,7 +1998,10 @@ class AddFundInitReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get requiredReserve => $_getI64(5);
   @$pb.TagNumber(6)
-  set requiredReserve($fixnum.Int64 v) { $_setInt64(5, v); }
+  set requiredReserve($fixnum.Int64 v) {
+    $_setInt64(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasRequiredReserve() => $_has(5);
   @$pb.TagNumber(6)
@@ -1607,7 +2010,10 @@ class AddFundInitReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $fixnum.Int64 get minAllowedDeposit => $_getI64(6);
   @$pb.TagNumber(7)
-  set minAllowedDeposit($fixnum.Int64 v) { $_setInt64(6, v); }
+  set minAllowedDeposit($fixnum.Int64 v) {
+    $_setInt64(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasMinAllowedDeposit() => $_has(6);
   @$pb.TagNumber(7)
@@ -1615,11 +2021,15 @@ class AddFundInitReply extends $pb.GeneratedMessage {
 }
 
 class AddFundStatusRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddFundStatusRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddFundStatusRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..pPS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'addresses')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'notificationToken', protoName: 'notificationToken')
-    ..hasRequiredFields = false
-  ;
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'notificationToken',
+        protoName: 'notificationToken')
+    ..hasRequiredFields = false;
 
   AddFundStatusRequest._() : super();
   factory AddFundStatusRequest({
@@ -1635,25 +2045,30 @@ class AddFundStatusRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory AddFundStatusRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory AddFundStatusRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory AddFundStatusRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory AddFundStatusRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   AddFundStatusRequest clone() => AddFundStatusRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  AddFundStatusRequest copyWith(void Function(AddFundStatusRequest) updates) => super.copyWith((message) => updates(message as AddFundStatusRequest)) as AddFundStatusRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  AddFundStatusRequest copyWith(void Function(AddFundStatusRequest) updates) =>
+      super.copyWith((message) => updates(message as AddFundStatusRequest))
+          as AddFundStatusRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AddFundStatusRequest create() => AddFundStatusRequest._();
   AddFundStatusRequest createEmptyInstance() => create();
   static $pb.PbList<AddFundStatusRequest> createRepeated() => $pb.PbList<AddFundStatusRequest>();
   @$core.pragma('dart2js:noInline')
-  static AddFundStatusRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundStatusRequest>(create);
+  static AddFundStatusRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundStatusRequest>(create);
   static AddFundStatusRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -1662,7 +2077,10 @@ class AddFundStatusRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get notificationToken => $_getSZ(1);
   @$pb.TagNumber(2)
-  set notificationToken($core.String v) { $_setString(1, v); }
+  set notificationToken($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasNotificationToken() => $_has(1);
   @$pb.TagNumber(2)
@@ -1670,13 +2088,19 @@ class AddFundStatusRequest extends $pb.GeneratedMessage {
 }
 
 class AddFundStatusReply_AddressStatus extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddFundStatusReply.AddressStatus', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'AddFundStatusReply.AddressStatus',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'tx')
     ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'amount')
     ..aOB(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'confirmed')
-    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'blockHash', protoName: 'blockHash')
-    ..hasRequiredFields = false
-  ;
+    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'blockHash',
+        protoName: 'blockHash')
+    ..hasRequiredFields = false;
 
   AddFundStatusReply_AddressStatus._() : super();
   factory AddFundStatusReply_AddressStatus({
@@ -1700,31 +2124,40 @@ class AddFundStatusReply_AddressStatus extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory AddFundStatusReply_AddressStatus.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory AddFundStatusReply_AddressStatus.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory AddFundStatusReply_AddressStatus.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory AddFundStatusReply_AddressStatus.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   AddFundStatusReply_AddressStatus clone() => AddFundStatusReply_AddressStatus()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  AddFundStatusReply_AddressStatus copyWith(void Function(AddFundStatusReply_AddressStatus) updates) => super.copyWith((message) => updates(message as AddFundStatusReply_AddressStatus)) as AddFundStatusReply_AddressStatus; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  AddFundStatusReply_AddressStatus copyWith(void Function(AddFundStatusReply_AddressStatus) updates) =>
+      super.copyWith((message) => updates(message as AddFundStatusReply_AddressStatus))
+          as AddFundStatusReply_AddressStatus; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AddFundStatusReply_AddressStatus create() => AddFundStatusReply_AddressStatus._();
   AddFundStatusReply_AddressStatus createEmptyInstance() => create();
-  static $pb.PbList<AddFundStatusReply_AddressStatus> createRepeated() => $pb.PbList<AddFundStatusReply_AddressStatus>();
+  static $pb.PbList<AddFundStatusReply_AddressStatus> createRepeated() =>
+      $pb.PbList<AddFundStatusReply_AddressStatus>();
   @$core.pragma('dart2js:noInline')
-  static AddFundStatusReply_AddressStatus getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundStatusReply_AddressStatus>(create);
+  static AddFundStatusReply_AddressStatus getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundStatusReply_AddressStatus>(create);
   static AddFundStatusReply_AddressStatus? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get tx => $_getSZ(0);
   @$pb.TagNumber(1)
-  set tx($core.String v) { $_setString(0, v); }
+  set tx($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasTx() => $_has(0);
   @$pb.TagNumber(1)
@@ -1733,7 +2166,10 @@ class AddFundStatusReply_AddressStatus extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amount => $_getI64(1);
   @$pb.TagNumber(2)
-  set amount($fixnum.Int64 v) { $_setInt64(1, v); }
+  set amount($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasAmount() => $_has(1);
   @$pb.TagNumber(2)
@@ -1742,7 +2178,10 @@ class AddFundStatusReply_AddressStatus extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get confirmed => $_getBF(2);
   @$pb.TagNumber(3)
-  set confirmed($core.bool v) { $_setBool(2, v); }
+  set confirmed($core.bool v) {
+    $_setBool(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasConfirmed() => $_has(2);
   @$pb.TagNumber(3)
@@ -1751,7 +2190,10 @@ class AddFundStatusReply_AddressStatus extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get blockHash => $_getSZ(3);
   @$pb.TagNumber(4)
-  set blockHash($core.String v) { $_setString(3, v); }
+  set blockHash($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasBlockHash() => $_has(3);
   @$pb.TagNumber(4)
@@ -1759,10 +2201,19 @@ class AddFundStatusReply_AddressStatus extends $pb.GeneratedMessage {
 }
 
 class AddFundStatusReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddFundStatusReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..m<$core.String, AddFundStatusReply_AddressStatus>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'statuses', entryClassName: 'AddFundStatusReply.StatusesEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OM, valueCreator: AddFundStatusReply_AddressStatus.create, packageName: const $pb.PackageName('breez'))
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddFundStatusReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..m<$core.String, AddFundStatusReply_AddressStatus>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'statuses',
+        entryClassName: 'AddFundStatusReply.StatusesEntry',
+        keyFieldType: $pb.PbFieldType.OS,
+        valueFieldType: $pb.PbFieldType.OM,
+        valueCreator: AddFundStatusReply_AddressStatus.create,
+        packageName: const $pb.PackageName('breez'))
+    ..hasRequiredFields = false;
 
   AddFundStatusReply._() : super();
   factory AddFundStatusReply({
@@ -1774,25 +2225,30 @@ class AddFundStatusReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory AddFundStatusReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory AddFundStatusReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory AddFundStatusReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory AddFundStatusReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   AddFundStatusReply clone() => AddFundStatusReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  AddFundStatusReply copyWith(void Function(AddFundStatusReply) updates) => super.copyWith((message) => updates(message as AddFundStatusReply)) as AddFundStatusReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  AddFundStatusReply copyWith(void Function(AddFundStatusReply) updates) =>
+      super.copyWith((message) => updates(message as AddFundStatusReply))
+          as AddFundStatusReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AddFundStatusReply create() => AddFundStatusReply._();
   AddFundStatusReply createEmptyInstance() => create();
   static $pb.PbList<AddFundStatusReply> createRepeated() => $pb.PbList<AddFundStatusReply>();
   @$core.pragma('dart2js:noInline')
-  static AddFundStatusReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundStatusReply>(create);
+  static AddFundStatusReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundStatusReply>(create);
   static AddFundStatusReply? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -1800,11 +2256,14 @@ class AddFundStatusReply extends $pb.GeneratedMessage {
 }
 
 class RemoveFundRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RemoveFundRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RemoveFundRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'address')
     ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'amount')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   RemoveFundRequest._() : super();
   factory RemoveFundRequest({
@@ -1820,31 +2279,39 @@ class RemoveFundRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RemoveFundRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RemoveFundRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RemoveFundRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RemoveFundRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RemoveFundRequest clone() => RemoveFundRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RemoveFundRequest copyWith(void Function(RemoveFundRequest) updates) => super.copyWith((message) => updates(message as RemoveFundRequest)) as RemoveFundRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RemoveFundRequest copyWith(void Function(RemoveFundRequest) updates) =>
+      super.copyWith((message) => updates(message as RemoveFundRequest))
+          as RemoveFundRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RemoveFundRequest create() => RemoveFundRequest._();
   RemoveFundRequest createEmptyInstance() => create();
   static $pb.PbList<RemoveFundRequest> createRepeated() => $pb.PbList<RemoveFundRequest>();
   @$core.pragma('dart2js:noInline')
-  static RemoveFundRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFundRequest>(create);
+  static RemoveFundRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFundRequest>(create);
   static RemoveFundRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) { $_setString(0, v); }
+  set address($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -1853,7 +2320,10 @@ class RemoveFundRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amount => $_getI64(1);
   @$pb.TagNumber(2)
-  set amount($fixnum.Int64 v) { $_setInt64(1, v); }
+  set amount($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasAmount() => $_has(1);
   @$pb.TagNumber(2)
@@ -1861,11 +2331,16 @@ class RemoveFundRequest extends $pb.GeneratedMessage {
 }
 
 class RemoveFundReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RemoveFundReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentRequest', protoName: 'paymentRequest')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'errorMessage', protoName: 'errorMessage')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RemoveFundReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentRequest',
+        protoName: 'paymentRequest')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'errorMessage',
+        protoName: 'errorMessage')
+    ..hasRequiredFields = false;
 
   RemoveFundReply._() : super();
   factory RemoveFundReply({
@@ -1881,31 +2356,38 @@ class RemoveFundReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RemoveFundReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RemoveFundReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RemoveFundReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RemoveFundReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RemoveFundReply clone() => RemoveFundReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RemoveFundReply copyWith(void Function(RemoveFundReply) updates) => super.copyWith((message) => updates(message as RemoveFundReply)) as RemoveFundReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RemoveFundReply copyWith(void Function(RemoveFundReply) updates) =>
+      super.copyWith((message) => updates(message as RemoveFundReply))
+          as RemoveFundReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RemoveFundReply create() => RemoveFundReply._();
   RemoveFundReply createEmptyInstance() => create();
   static $pb.PbList<RemoveFundReply> createRepeated() => $pb.PbList<RemoveFundReply>();
   @$core.pragma('dart2js:noInline')
-  static RemoveFundReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFundReply>(create);
+  static RemoveFundReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFundReply>(create);
   static RemoveFundReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get paymentRequest => $_getSZ(0);
   @$pb.TagNumber(1)
-  set paymentRequest($core.String v) { $_setString(0, v); }
+  set paymentRequest($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasPaymentRequest() => $_has(0);
   @$pb.TagNumber(1)
@@ -1914,7 +2396,10 @@ class RemoveFundReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get errorMessage => $_getSZ(1);
   @$pb.TagNumber(2)
-  set errorMessage($core.String v) { $_setString(1, v); }
+  set errorMessage($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasErrorMessage() => $_has(1);
   @$pb.TagNumber(2)
@@ -1922,10 +2407,13 @@ class RemoveFundReply extends $pb.GeneratedMessage {
 }
 
 class RedeemRemovedFundsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RedeemRemovedFundsRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RedeemRemovedFundsRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymenthash')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   RedeemRemovedFundsRequest._() : super();
   factory RedeemRemovedFundsRequest({
@@ -1937,31 +2425,39 @@ class RedeemRemovedFundsRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RedeemRemovedFundsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RedeemRemovedFundsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RedeemRemovedFundsRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RedeemRemovedFundsRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RedeemRemovedFundsRequest clone() => RedeemRemovedFundsRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RedeemRemovedFundsRequest copyWith(void Function(RedeemRemovedFundsRequest) updates) => super.copyWith((message) => updates(message as RedeemRemovedFundsRequest)) as RedeemRemovedFundsRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RedeemRemovedFundsRequest copyWith(void Function(RedeemRemovedFundsRequest) updates) =>
+      super.copyWith((message) => updates(message as RedeemRemovedFundsRequest))
+          as RedeemRemovedFundsRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RedeemRemovedFundsRequest create() => RedeemRemovedFundsRequest._();
   RedeemRemovedFundsRequest createEmptyInstance() => create();
   static $pb.PbList<RedeemRemovedFundsRequest> createRepeated() => $pb.PbList<RedeemRemovedFundsRequest>();
   @$core.pragma('dart2js:noInline')
-  static RedeemRemovedFundsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RedeemRemovedFundsRequest>(create);
+  static RedeemRemovedFundsRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RedeemRemovedFundsRequest>(create);
   static RedeemRemovedFundsRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get paymenthash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set paymenthash($core.String v) { $_setString(0, v); }
+  set paymenthash($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasPaymenthash() => $_has(0);
   @$pb.TagNumber(1)
@@ -1969,10 +2465,13 @@ class RedeemRemovedFundsRequest extends $pb.GeneratedMessage {
 }
 
 class RedeemRemovedFundsReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RedeemRemovedFundsReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RedeemRemovedFundsReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'txid')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   RedeemRemovedFundsReply._() : super();
   factory RedeemRemovedFundsReply({
@@ -1984,31 +2483,39 @@ class RedeemRemovedFundsReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RedeemRemovedFundsReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RedeemRemovedFundsReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RedeemRemovedFundsReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RedeemRemovedFundsReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RedeemRemovedFundsReply clone() => RedeemRemovedFundsReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RedeemRemovedFundsReply copyWith(void Function(RedeemRemovedFundsReply) updates) => super.copyWith((message) => updates(message as RedeemRemovedFundsReply)) as RedeemRemovedFundsReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RedeemRemovedFundsReply copyWith(void Function(RedeemRemovedFundsReply) updates) =>
+      super.copyWith((message) => updates(message as RedeemRemovedFundsReply))
+          as RedeemRemovedFundsReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RedeemRemovedFundsReply create() => RedeemRemovedFundsReply._();
   RedeemRemovedFundsReply createEmptyInstance() => create();
   static $pb.PbList<RedeemRemovedFundsReply> createRepeated() => $pb.PbList<RedeemRemovedFundsReply>();
   @$core.pragma('dart2js:noInline')
-  static RedeemRemovedFundsReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RedeemRemovedFundsReply>(create);
+  static RedeemRemovedFundsReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RedeemRemovedFundsReply>(create);
   static RedeemRemovedFundsReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) { $_setString(0, v); }
+  set txid($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -2016,10 +2523,14 @@ class RedeemRemovedFundsReply extends $pb.GeneratedMessage {
 }
 
 class GetSwapPaymentRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GetSwapPaymentRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentRequest', protoName: 'paymentRequest')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GetSwapPaymentRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentRequest',
+        protoName: 'paymentRequest')
+    ..hasRequiredFields = false;
 
   GetSwapPaymentRequest._() : super();
   factory GetSwapPaymentRequest({
@@ -2031,31 +2542,39 @@ class GetSwapPaymentRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory GetSwapPaymentRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GetSwapPaymentRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory GetSwapPaymentRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GetSwapPaymentRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GetSwapPaymentRequest clone() => GetSwapPaymentRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GetSwapPaymentRequest copyWith(void Function(GetSwapPaymentRequest) updates) => super.copyWith((message) => updates(message as GetSwapPaymentRequest)) as GetSwapPaymentRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GetSwapPaymentRequest copyWith(void Function(GetSwapPaymentRequest) updates) =>
+      super.copyWith((message) => updates(message as GetSwapPaymentRequest))
+          as GetSwapPaymentRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GetSwapPaymentRequest create() => GetSwapPaymentRequest._();
   GetSwapPaymentRequest createEmptyInstance() => create();
   static $pb.PbList<GetSwapPaymentRequest> createRepeated() => $pb.PbList<GetSwapPaymentRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetSwapPaymentRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSwapPaymentRequest>(create);
+  static GetSwapPaymentRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSwapPaymentRequest>(create);
   static GetSwapPaymentRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get paymentRequest => $_getSZ(0);
   @$pb.TagNumber(1)
-  set paymentRequest($core.String v) { $_setString(0, v); }
+  set paymentRequest($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasPaymentRequest() => $_has(0);
   @$pb.TagNumber(1)
@@ -2063,12 +2582,20 @@ class GetSwapPaymentRequest extends $pb.GeneratedMessage {
 }
 
 class GetSwapPaymentReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GetSwapPaymentReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentError', protoName: 'paymentError')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GetSwapPaymentReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentError',
+        protoName: 'paymentError')
     ..aOB(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'fundsExceededLimit')
-    ..e<GetSwapPaymentReply_SwapError>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'swapError', $pb.PbFieldType.OE, defaultOrMaker: GetSwapPaymentReply_SwapError.NO_ERROR, valueOf: GetSwapPaymentReply_SwapError.valueOf, enumValues: GetSwapPaymentReply_SwapError.values)
-    ..hasRequiredFields = false
-  ;
+    ..e<GetSwapPaymentReply_SwapError>(3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'swapError', $pb.PbFieldType.OE,
+        defaultOrMaker: GetSwapPaymentReply_SwapError.NO_ERROR,
+        valueOf: GetSwapPaymentReply_SwapError.valueOf,
+        enumValues: GetSwapPaymentReply_SwapError.values)
+    ..hasRequiredFields = false;
 
   GetSwapPaymentReply._() : super();
   factory GetSwapPaymentReply({
@@ -2088,31 +2615,39 @@ class GetSwapPaymentReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory GetSwapPaymentReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GetSwapPaymentReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory GetSwapPaymentReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GetSwapPaymentReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GetSwapPaymentReply clone() => GetSwapPaymentReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GetSwapPaymentReply copyWith(void Function(GetSwapPaymentReply) updates) => super.copyWith((message) => updates(message as GetSwapPaymentReply)) as GetSwapPaymentReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GetSwapPaymentReply copyWith(void Function(GetSwapPaymentReply) updates) =>
+      super.copyWith((message) => updates(message as GetSwapPaymentReply))
+          as GetSwapPaymentReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GetSwapPaymentReply create() => GetSwapPaymentReply._();
   GetSwapPaymentReply createEmptyInstance() => create();
   static $pb.PbList<GetSwapPaymentReply> createRepeated() => $pb.PbList<GetSwapPaymentReply>();
   @$core.pragma('dart2js:noInline')
-  static GetSwapPaymentReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSwapPaymentReply>(create);
+  static GetSwapPaymentReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetSwapPaymentReply>(create);
   static GetSwapPaymentReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get paymentError => $_getSZ(0);
   @$pb.TagNumber(1)
-  set paymentError($core.String v) { $_setString(0, v); }
+  set paymentError($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasPaymentError() => $_has(0);
   @$pb.TagNumber(1)
@@ -2121,7 +2656,10 @@ class GetSwapPaymentReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get fundsExceededLimit => $_getBF(1);
   @$pb.TagNumber(2)
-  set fundsExceededLimit($core.bool v) { $_setBool(1, v); }
+  set fundsExceededLimit($core.bool v) {
+    $_setBool(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasFundsExceededLimit() => $_has(1);
   @$pb.TagNumber(2)
@@ -2130,7 +2668,10 @@ class GetSwapPaymentReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   GetSwapPaymentReply_SwapError get swapError => $_getN(2);
   @$pb.TagNumber(3)
-  set swapError(GetSwapPaymentReply_SwapError v) { setField(3, v); }
+  set swapError(GetSwapPaymentReply_SwapError v) {
+    setField(3, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasSwapError() => $_has(2);
   @$pb.TagNumber(3)
@@ -2138,12 +2679,17 @@ class GetSwapPaymentReply extends $pb.GeneratedMessage {
 }
 
 class RedeemSwapPaymentRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RedeemSwapPaymentRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..a<$core.List<$core.int>>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'preimage', $pb.PbFieldType.OY)
-    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'targetConf', $pb.PbFieldType.O3)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RedeemSwapPaymentRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'preimage', $pb.PbFieldType.OY)
+    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'targetConf',
+        $pb.PbFieldType.O3)
     ..aInt64(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'satPerByte')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   RedeemSwapPaymentRequest._() : super();
   factory RedeemSwapPaymentRequest({
@@ -2163,31 +2709,39 @@ class RedeemSwapPaymentRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RedeemSwapPaymentRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RedeemSwapPaymentRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RedeemSwapPaymentRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RedeemSwapPaymentRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RedeemSwapPaymentRequest clone() => RedeemSwapPaymentRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RedeemSwapPaymentRequest copyWith(void Function(RedeemSwapPaymentRequest) updates) => super.copyWith((message) => updates(message as RedeemSwapPaymentRequest)) as RedeemSwapPaymentRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RedeemSwapPaymentRequest copyWith(void Function(RedeemSwapPaymentRequest) updates) =>
+      super.copyWith((message) => updates(message as RedeemSwapPaymentRequest))
+          as RedeemSwapPaymentRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RedeemSwapPaymentRequest create() => RedeemSwapPaymentRequest._();
   RedeemSwapPaymentRequest createEmptyInstance() => create();
   static $pb.PbList<RedeemSwapPaymentRequest> createRepeated() => $pb.PbList<RedeemSwapPaymentRequest>();
   @$core.pragma('dart2js:noInline')
-  static RedeemSwapPaymentRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RedeemSwapPaymentRequest>(create);
+  static RedeemSwapPaymentRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RedeemSwapPaymentRequest>(create);
   static RedeemSwapPaymentRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get preimage => $_getN(0);
   @$pb.TagNumber(1)
-  set preimage($core.List<$core.int> v) { $_setBytes(0, v); }
+  set preimage($core.List<$core.int> v) {
+    $_setBytes(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasPreimage() => $_has(0);
   @$pb.TagNumber(1)
@@ -2196,7 +2750,10 @@ class RedeemSwapPaymentRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get targetConf => $_getIZ(1);
   @$pb.TagNumber(2)
-  set targetConf($core.int v) { $_setSignedInt32(1, v); }
+  set targetConf($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasTargetConf() => $_has(1);
   @$pb.TagNumber(2)
@@ -2205,7 +2762,10 @@ class RedeemSwapPaymentRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get satPerByte => $_getI64(2);
   @$pb.TagNumber(3)
-  set satPerByte($fixnum.Int64 v) { $_setInt64(2, v); }
+  set satPerByte($fixnum.Int64 v) {
+    $_setInt64(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasSatPerByte() => $_has(2);
   @$pb.TagNumber(3)
@@ -2213,10 +2773,13 @@ class RedeemSwapPaymentRequest extends $pb.GeneratedMessage {
 }
 
 class RedeemSwapPaymentReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RedeemSwapPaymentReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RedeemSwapPaymentReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'txid')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   RedeemSwapPaymentReply._() : super();
   factory RedeemSwapPaymentReply({
@@ -2228,31 +2791,39 @@ class RedeemSwapPaymentReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RedeemSwapPaymentReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RedeemSwapPaymentReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RedeemSwapPaymentReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RedeemSwapPaymentReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RedeemSwapPaymentReply clone() => RedeemSwapPaymentReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RedeemSwapPaymentReply copyWith(void Function(RedeemSwapPaymentReply) updates) => super.copyWith((message) => updates(message as RedeemSwapPaymentReply)) as RedeemSwapPaymentReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RedeemSwapPaymentReply copyWith(void Function(RedeemSwapPaymentReply) updates) =>
+      super.copyWith((message) => updates(message as RedeemSwapPaymentReply))
+          as RedeemSwapPaymentReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RedeemSwapPaymentReply create() => RedeemSwapPaymentReply._();
   RedeemSwapPaymentReply createEmptyInstance() => create();
   static $pb.PbList<RedeemSwapPaymentReply> createRepeated() => $pb.PbList<RedeemSwapPaymentReply>();
   @$core.pragma('dart2js:noInline')
-  static RedeemSwapPaymentReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RedeemSwapPaymentReply>(create);
+  static RedeemSwapPaymentReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RedeemSwapPaymentReply>(create);
   static RedeemSwapPaymentReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) { $_setString(0, v); }
+  set txid($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -2260,11 +2831,16 @@ class RedeemSwapPaymentReply extends $pb.GeneratedMessage {
 }
 
 class RegisterRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RegisterRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deviceID', protoName: 'deviceID')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lightningID', protoName: 'lightningID')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RegisterRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deviceID',
+        protoName: 'deviceID')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lightningID',
+        protoName: 'lightningID')
+    ..hasRequiredFields = false;
 
   RegisterRequest._() : super();
   factory RegisterRequest({
@@ -2280,31 +2856,38 @@ class RegisterRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RegisterRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RegisterRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RegisterRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RegisterRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RegisterRequest clone() => RegisterRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RegisterRequest copyWith(void Function(RegisterRequest) updates) => super.copyWith((message) => updates(message as RegisterRequest)) as RegisterRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RegisterRequest copyWith(void Function(RegisterRequest) updates) =>
+      super.copyWith((message) => updates(message as RegisterRequest))
+          as RegisterRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RegisterRequest create() => RegisterRequest._();
   RegisterRequest createEmptyInstance() => create();
   static $pb.PbList<RegisterRequest> createRepeated() => $pb.PbList<RegisterRequest>();
   @$core.pragma('dart2js:noInline')
-  static RegisterRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterRequest>(create);
+  static RegisterRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterRequest>(create);
   static RegisterRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get deviceID => $_getSZ(0);
   @$pb.TagNumber(1)
-  set deviceID($core.String v) { $_setString(0, v); }
+  set deviceID($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasDeviceID() => $_has(0);
   @$pb.TagNumber(1)
@@ -2313,7 +2896,10 @@ class RegisterRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get lightningID => $_getSZ(1);
   @$pb.TagNumber(2)
-  set lightningID($core.String v) { $_setString(1, v); }
+  set lightningID($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasLightningID() => $_has(1);
   @$pb.TagNumber(2)
@@ -2321,10 +2907,14 @@ class RegisterRequest extends $pb.GeneratedMessage {
 }
 
 class RegisterReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RegisterReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'breezID', protoName: 'breezID')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RegisterReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'breezID',
+        protoName: 'breezID')
+    ..hasRequiredFields = false;
 
   RegisterReply._() : super();
   factory RegisterReply({
@@ -2336,31 +2926,38 @@ class RegisterReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RegisterReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RegisterReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RegisterReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RegisterReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RegisterReply clone() => RegisterReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RegisterReply copyWith(void Function(RegisterReply) updates) => super.copyWith((message) => updates(message as RegisterReply)) as RegisterReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RegisterReply copyWith(void Function(RegisterReply) updates) =>
+      super.copyWith((message) => updates(message as RegisterReply))
+          as RegisterReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RegisterReply create() => RegisterReply._();
   RegisterReply createEmptyInstance() => create();
   static $pb.PbList<RegisterReply> createRepeated() => $pb.PbList<RegisterReply>();
   @$core.pragma('dart2js:noInline')
-  static RegisterReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterReply>(create);
+  static RegisterReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterReply>(create);
   static RegisterReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get breezID => $_getSZ(0);
   @$pb.TagNumber(1)
-  set breezID($core.String v) { $_setString(0, v); }
+  set breezID($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasBreezID() => $_has(0);
   @$pb.TagNumber(1)
@@ -2368,13 +2965,17 @@ class RegisterReply extends $pb.GeneratedMessage {
 }
 
 class PaymentRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PaymentRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'breezID', protoName: 'breezID')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PaymentRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'breezID',
+        protoName: 'breezID')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'invoice')
     ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'payee')
     ..aInt64(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'amount')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   PaymentRequest._() : super();
   factory PaymentRequest({
@@ -2398,31 +2999,38 @@ class PaymentRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory PaymentRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PaymentRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory PaymentRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory PaymentRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   PaymentRequest clone() => PaymentRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  PaymentRequest copyWith(void Function(PaymentRequest) updates) => super.copyWith((message) => updates(message as PaymentRequest)) as PaymentRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  PaymentRequest copyWith(void Function(PaymentRequest) updates) =>
+      super.copyWith((message) => updates(message as PaymentRequest))
+          as PaymentRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PaymentRequest create() => PaymentRequest._();
   PaymentRequest createEmptyInstance() => create();
   static $pb.PbList<PaymentRequest> createRepeated() => $pb.PbList<PaymentRequest>();
   @$core.pragma('dart2js:noInline')
-  static PaymentRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PaymentRequest>(create);
+  static PaymentRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PaymentRequest>(create);
   static PaymentRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get breezID => $_getSZ(0);
   @$pb.TagNumber(1)
-  set breezID($core.String v) { $_setString(0, v); }
+  set breezID($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasBreezID() => $_has(0);
   @$pb.TagNumber(1)
@@ -2431,7 +3039,10 @@ class PaymentRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get invoice => $_getSZ(1);
   @$pb.TagNumber(2)
-  set invoice($core.String v) { $_setString(1, v); }
+  set invoice($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasInvoice() => $_has(1);
   @$pb.TagNumber(2)
@@ -2440,7 +3051,10 @@ class PaymentRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get payee => $_getSZ(2);
   @$pb.TagNumber(3)
-  set payee($core.String v) { $_setString(2, v); }
+  set payee($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasPayee() => $_has(2);
   @$pb.TagNumber(3)
@@ -2449,7 +3063,10 @@ class PaymentRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get amount => $_getI64(3);
   @$pb.TagNumber(4)
-  set amount($fixnum.Int64 v) { $_setInt64(3, v); }
+  set amount($fixnum.Int64 v) {
+    $_setInt64(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasAmount() => $_has(3);
   @$pb.TagNumber(4)
@@ -2457,10 +3074,13 @@ class PaymentRequest extends $pb.GeneratedMessage {
 }
 
 class InvoiceReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'InvoiceReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'InvoiceReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'Error', protoName: 'Error')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   InvoiceReply._() : super();
   factory InvoiceReply({
@@ -2472,31 +3092,38 @@ class InvoiceReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory InvoiceReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory InvoiceReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory InvoiceReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory InvoiceReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   InvoiceReply clone() => InvoiceReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  InvoiceReply copyWith(void Function(InvoiceReply) updates) => super.copyWith((message) => updates(message as InvoiceReply)) as InvoiceReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  InvoiceReply copyWith(void Function(InvoiceReply) updates) =>
+      super.copyWith((message) => updates(message as InvoiceReply))
+          as InvoiceReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static InvoiceReply create() => InvoiceReply._();
   InvoiceReply createEmptyInstance() => create();
   static $pb.PbList<InvoiceReply> createRepeated() => $pb.PbList<InvoiceReply>();
   @$core.pragma('dart2js:noInline')
-  static InvoiceReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<InvoiceReply>(create);
+  static InvoiceReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<InvoiceReply>(create);
   static InvoiceReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get error => $_getSZ(0);
   @$pb.TagNumber(1)
-  set error($core.String v) { $_setString(0, v); }
+  set error($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasError() => $_has(0);
   @$pb.TagNumber(1)
@@ -2504,10 +3131,14 @@ class InvoiceReply extends $pb.GeneratedMessage {
 }
 
 class UploadFileRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'UploadFileRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..a<$core.List<$core.int>>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'content', $pb.PbFieldType.OY)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'UploadFileRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'content', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
 
   UploadFileRequest._() : super();
   factory UploadFileRequest({
@@ -2519,31 +3150,39 @@ class UploadFileRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory UploadFileRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory UploadFileRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory UploadFileRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory UploadFileRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   UploadFileRequest clone() => UploadFileRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  UploadFileRequest copyWith(void Function(UploadFileRequest) updates) => super.copyWith((message) => updates(message as UploadFileRequest)) as UploadFileRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  UploadFileRequest copyWith(void Function(UploadFileRequest) updates) =>
+      super.copyWith((message) => updates(message as UploadFileRequest))
+          as UploadFileRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static UploadFileRequest create() => UploadFileRequest._();
   UploadFileRequest createEmptyInstance() => create();
   static $pb.PbList<UploadFileRequest> createRepeated() => $pb.PbList<UploadFileRequest>();
   @$core.pragma('dart2js:noInline')
-  static UploadFileRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UploadFileRequest>(create);
+  static UploadFileRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UploadFileRequest>(create);
   static UploadFileRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get content => $_getN(0);
   @$pb.TagNumber(1)
-  set content($core.List<$core.int> v) { $_setBytes(0, v); }
+  set content($core.List<$core.int> v) {
+    $_setBytes(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasContent() => $_has(0);
   @$pb.TagNumber(1)
@@ -2551,10 +3190,13 @@ class UploadFileRequest extends $pb.GeneratedMessage {
 }
 
 class UploadFileReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'UploadFileReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'UploadFileReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'url')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   UploadFileReply._() : super();
   factory UploadFileReply({
@@ -2566,31 +3208,38 @@ class UploadFileReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory UploadFileReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory UploadFileReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory UploadFileReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory UploadFileReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   UploadFileReply clone() => UploadFileReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  UploadFileReply copyWith(void Function(UploadFileReply) updates) => super.copyWith((message) => updates(message as UploadFileReply)) as UploadFileReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  UploadFileReply copyWith(void Function(UploadFileReply) updates) =>
+      super.copyWith((message) => updates(message as UploadFileReply))
+          as UploadFileReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static UploadFileReply create() => UploadFileReply._();
   UploadFileReply createEmptyInstance() => create();
   static $pb.PbList<UploadFileReply> createRepeated() => $pb.PbList<UploadFileReply>();
   @$core.pragma('dart2js:noInline')
-  static UploadFileReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UploadFileReply>(create);
+  static UploadFileReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UploadFileReply>(create);
   static UploadFileReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get url => $_getSZ(0);
   @$pb.TagNumber(1)
-  set url($core.String v) { $_setString(0, v); }
+  set url($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasUrl() => $_has(0);
   @$pb.TagNumber(1)
@@ -2598,39 +3247,49 @@ class UploadFileReply extends $pb.GeneratedMessage {
 }
 
 class PingRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PingRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PingRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   PingRequest._() : super();
   factory PingRequest() => create();
-  factory PingRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PingRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory PingRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory PingRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   PingRequest clone() => PingRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  PingRequest copyWith(void Function(PingRequest) updates) => super.copyWith((message) => updates(message as PingRequest)) as PingRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  PingRequest copyWith(void Function(PingRequest) updates) =>
+      super.copyWith((message) => updates(message as PingRequest))
+          as PingRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PingRequest create() => PingRequest._();
   PingRequest createEmptyInstance() => create();
   static $pb.PbList<PingRequest> createRepeated() => $pb.PbList<PingRequest>();
   @$core.pragma('dart2js:noInline')
-  static PingRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PingRequest>(create);
+  static PingRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PingRequest>(create);
   static PingRequest? _defaultInstance;
 }
 
 class PingReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PingReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PingReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'version')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   PingReply._() : super();
   factory PingReply({
@@ -2642,18 +3301,21 @@ class PingReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory PingReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PingReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory PingReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory PingReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   PingReply clone() => PingReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  PingReply copyWith(void Function(PingReply) updates) => super.copyWith((message) => updates(message as PingReply)) as PingReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  PingReply copyWith(void Function(PingReply) updates) =>
+      super.copyWith((message) => updates(message as PingReply))
+          as PingReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PingReply create() => PingReply._();
@@ -2666,7 +3328,10 @@ class PingReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get version => $_getSZ(0);
   @$pb.TagNumber(1)
-  set version($core.String v) { $_setString(0, v); }
+  set version($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasVersion() => $_has(0);
   @$pb.TagNumber(1)
@@ -2674,16 +3339,22 @@ class PingReply extends $pb.GeneratedMessage {
 }
 
 class OrderRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'OrderRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'FullName', protoName: 'FullName')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'Address', protoName: 'Address')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'OrderRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'FullName',
+        protoName: 'FullName')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'Address',
+        protoName: 'Address')
     ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'City', protoName: 'City')
     ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'State', protoName: 'State')
     ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'Zip', protoName: 'Zip')
-    ..aOS(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'Country', protoName: 'Country')
+    ..aOS(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'Country',
+        protoName: 'Country')
     ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'Email', protoName: 'Email')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   OrderRequest._() : super();
   factory OrderRequest({
@@ -2719,31 +3390,38 @@ class OrderRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory OrderRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory OrderRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory OrderRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory OrderRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   OrderRequest clone() => OrderRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  OrderRequest copyWith(void Function(OrderRequest) updates) => super.copyWith((message) => updates(message as OrderRequest)) as OrderRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  OrderRequest copyWith(void Function(OrderRequest) updates) =>
+      super.copyWith((message) => updates(message as OrderRequest))
+          as OrderRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static OrderRequest create() => OrderRequest._();
   OrderRequest createEmptyInstance() => create();
   static $pb.PbList<OrderRequest> createRepeated() => $pb.PbList<OrderRequest>();
   @$core.pragma('dart2js:noInline')
-  static OrderRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OrderRequest>(create);
+  static OrderRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OrderRequest>(create);
   static OrderRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get fullName => $_getSZ(0);
   @$pb.TagNumber(1)
-  set fullName($core.String v) { $_setString(0, v); }
+  set fullName($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasFullName() => $_has(0);
   @$pb.TagNumber(1)
@@ -2752,7 +3430,10 @@ class OrderRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get address => $_getSZ(1);
   @$pb.TagNumber(2)
-  set address($core.String v) { $_setString(1, v); }
+  set address($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasAddress() => $_has(1);
   @$pb.TagNumber(2)
@@ -2761,7 +3442,10 @@ class OrderRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get city => $_getSZ(2);
   @$pb.TagNumber(3)
-  set city($core.String v) { $_setString(2, v); }
+  set city($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasCity() => $_has(2);
   @$pb.TagNumber(3)
@@ -2770,7 +3454,10 @@ class OrderRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get state => $_getSZ(3);
   @$pb.TagNumber(4)
-  set state($core.String v) { $_setString(3, v); }
+  set state($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasState() => $_has(3);
   @$pb.TagNumber(4)
@@ -2779,7 +3466,10 @@ class OrderRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get zip => $_getSZ(4);
   @$pb.TagNumber(5)
-  set zip($core.String v) { $_setString(4, v); }
+  set zip($core.String v) {
+    $_setString(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasZip() => $_has(4);
   @$pb.TagNumber(5)
@@ -2788,7 +3478,10 @@ class OrderRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.String get country => $_getSZ(5);
   @$pb.TagNumber(6)
-  set country($core.String v) { $_setString(5, v); }
+  set country($core.String v) {
+    $_setString(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasCountry() => $_has(5);
   @$pb.TagNumber(6)
@@ -2797,7 +3490,10 @@ class OrderRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.String get email => $_getSZ(6);
   @$pb.TagNumber(7)
-  set email($core.String v) { $_setString(6, v); }
+  set email($core.String v) {
+    $_setString(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasEmail() => $_has(6);
   @$pb.TagNumber(7)
@@ -2805,43 +3501,56 @@ class OrderRequest extends $pb.GeneratedMessage {
 }
 
 class OrderReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'OrderReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'OrderReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   OrderReply._() : super();
   factory OrderReply() => create();
-  factory OrderReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory OrderReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory OrderReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory OrderReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   OrderReply clone() => OrderReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  OrderReply copyWith(void Function(OrderReply) updates) => super.copyWith((message) => updates(message as OrderReply)) as OrderReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  OrderReply copyWith(void Function(OrderReply) updates) =>
+      super.copyWith((message) => updates(message as OrderReply))
+          as OrderReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static OrderReply create() => OrderReply._();
   OrderReply createEmptyInstance() => create();
   static $pb.PbList<OrderReply> createRepeated() => $pb.PbList<OrderReply>();
   @$core.pragma('dart2js:noInline')
-  static OrderReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OrderReply>(create);
+  static OrderReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OrderReply>(create);
   static OrderReply? _defaultInstance;
 }
 
 class SetNodeInfoRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SetNodeInfoRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..a<$core.List<$core.int>>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pubkey', $pb.PbFieldType.OY)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SetNodeInfoRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pubkey', $pb.PbFieldType.OY)
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'key')
-    ..a<$core.List<$core.int>>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'value', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(
+        3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'value', $pb.PbFieldType.OY)
     ..aInt64(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'timestamp')
-    ..a<$core.List<$core.int>>(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'signature', $pb.PbFieldType.OY)
-    ..hasRequiredFields = false
-  ;
+    ..a<$core.List<$core.int>>(5,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'signature', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
 
   SetNodeInfoRequest._() : super();
   factory SetNodeInfoRequest({
@@ -2869,31 +3578,39 @@ class SetNodeInfoRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory SetNodeInfoRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory SetNodeInfoRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory SetNodeInfoRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory SetNodeInfoRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   SetNodeInfoRequest clone() => SetNodeInfoRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  SetNodeInfoRequest copyWith(void Function(SetNodeInfoRequest) updates) => super.copyWith((message) => updates(message as SetNodeInfoRequest)) as SetNodeInfoRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  SetNodeInfoRequest copyWith(void Function(SetNodeInfoRequest) updates) =>
+      super.copyWith((message) => updates(message as SetNodeInfoRequest))
+          as SetNodeInfoRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SetNodeInfoRequest create() => SetNodeInfoRequest._();
   SetNodeInfoRequest createEmptyInstance() => create();
   static $pb.PbList<SetNodeInfoRequest> createRepeated() => $pb.PbList<SetNodeInfoRequest>();
   @$core.pragma('dart2js:noInline')
-  static SetNodeInfoRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetNodeInfoRequest>(create);
+  static SetNodeInfoRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetNodeInfoRequest>(create);
   static SetNodeInfoRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get pubkey => $_getN(0);
   @$pb.TagNumber(1)
-  set pubkey($core.List<$core.int> v) { $_setBytes(0, v); }
+  set pubkey($core.List<$core.int> v) {
+    $_setBytes(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasPubkey() => $_has(0);
   @$pb.TagNumber(1)
@@ -2902,7 +3619,10 @@ class SetNodeInfoRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get key => $_getSZ(1);
   @$pb.TagNumber(2)
-  set key($core.String v) { $_setString(1, v); }
+  set key($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasKey() => $_has(1);
   @$pb.TagNumber(2)
@@ -2911,7 +3631,10 @@ class SetNodeInfoRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.List<$core.int> get value => $_getN(2);
   @$pb.TagNumber(3)
-  set value($core.List<$core.int> v) { $_setBytes(2, v); }
+  set value($core.List<$core.int> v) {
+    $_setBytes(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasValue() => $_has(2);
   @$pb.TagNumber(3)
@@ -2920,7 +3643,10 @@ class SetNodeInfoRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get timestamp => $_getI64(3);
   @$pb.TagNumber(4)
-  set timestamp($fixnum.Int64 v) { $_setInt64(3, v); }
+  set timestamp($fixnum.Int64 v) {
+    $_setInt64(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasTimestamp() => $_has(3);
   @$pb.TagNumber(4)
@@ -2929,7 +3655,10 @@ class SetNodeInfoRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.List<$core.int> get signature => $_getN(4);
   @$pb.TagNumber(5)
-  set signature($core.List<$core.int> v) { $_setBytes(4, v); }
+  set signature($core.List<$core.int> v) {
+    $_setBytes(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasSignature() => $_has(4);
   @$pb.TagNumber(5)
@@ -2937,40 +3666,52 @@ class SetNodeInfoRequest extends $pb.GeneratedMessage {
 }
 
 class SetNodeInfoResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SetNodeInfoResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SetNodeInfoResponse',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   SetNodeInfoResponse._() : super();
   factory SetNodeInfoResponse() => create();
-  factory SetNodeInfoResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory SetNodeInfoResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory SetNodeInfoResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory SetNodeInfoResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   SetNodeInfoResponse clone() => SetNodeInfoResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  SetNodeInfoResponse copyWith(void Function(SetNodeInfoResponse) updates) => super.copyWith((message) => updates(message as SetNodeInfoResponse)) as SetNodeInfoResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  SetNodeInfoResponse copyWith(void Function(SetNodeInfoResponse) updates) =>
+      super.copyWith((message) => updates(message as SetNodeInfoResponse))
+          as SetNodeInfoResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SetNodeInfoResponse create() => SetNodeInfoResponse._();
   SetNodeInfoResponse createEmptyInstance() => create();
   static $pb.PbList<SetNodeInfoResponse> createRepeated() => $pb.PbList<SetNodeInfoResponse>();
   @$core.pragma('dart2js:noInline')
-  static SetNodeInfoResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetNodeInfoResponse>(create);
+  static SetNodeInfoResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SetNodeInfoResponse>(create);
   static SetNodeInfoResponse? _defaultInstance;
 }
 
 class GetNodeInfoRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GetNodeInfoRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..a<$core.List<$core.int>>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pubkey', $pb.PbFieldType.OY)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GetNodeInfoRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pubkey', $pb.PbFieldType.OY)
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'key')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   GetNodeInfoRequest._() : super();
   factory GetNodeInfoRequest({
@@ -2986,31 +3727,39 @@ class GetNodeInfoRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory GetNodeInfoRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GetNodeInfoRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory GetNodeInfoRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GetNodeInfoRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GetNodeInfoRequest clone() => GetNodeInfoRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GetNodeInfoRequest copyWith(void Function(GetNodeInfoRequest) updates) => super.copyWith((message) => updates(message as GetNodeInfoRequest)) as GetNodeInfoRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GetNodeInfoRequest copyWith(void Function(GetNodeInfoRequest) updates) =>
+      super.copyWith((message) => updates(message as GetNodeInfoRequest))
+          as GetNodeInfoRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GetNodeInfoRequest create() => GetNodeInfoRequest._();
   GetNodeInfoRequest createEmptyInstance() => create();
   static $pb.PbList<GetNodeInfoRequest> createRepeated() => $pb.PbList<GetNodeInfoRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetNodeInfoRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNodeInfoRequest>(create);
+  static GetNodeInfoRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNodeInfoRequest>(create);
   static GetNodeInfoRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get pubkey => $_getN(0);
   @$pb.TagNumber(1)
-  set pubkey($core.List<$core.int> v) { $_setBytes(0, v); }
+  set pubkey($core.List<$core.int> v) {
+    $_setBytes(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasPubkey() => $_has(0);
   @$pb.TagNumber(1)
@@ -3019,7 +3768,10 @@ class GetNodeInfoRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get key => $_getSZ(1);
   @$pb.TagNumber(2)
-  set key($core.String v) { $_setString(1, v); }
+  set key($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasKey() => $_has(1);
   @$pb.TagNumber(2)
@@ -3027,12 +3779,17 @@ class GetNodeInfoRequest extends $pb.GeneratedMessage {
 }
 
 class GetNodeInfoResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GetNodeInfoResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..a<$core.List<$core.int>>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'value', $pb.PbFieldType.OY)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GetNodeInfoResponse',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'value', $pb.PbFieldType.OY)
     ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'timestamp')
-    ..a<$core.List<$core.int>>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'signature', $pb.PbFieldType.OY)
-    ..hasRequiredFields = false
-  ;
+    ..a<$core.List<$core.int>>(3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'signature', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
 
   GetNodeInfoResponse._() : super();
   factory GetNodeInfoResponse({
@@ -3052,31 +3809,39 @@ class GetNodeInfoResponse extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory GetNodeInfoResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GetNodeInfoResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory GetNodeInfoResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GetNodeInfoResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GetNodeInfoResponse clone() => GetNodeInfoResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GetNodeInfoResponse copyWith(void Function(GetNodeInfoResponse) updates) => super.copyWith((message) => updates(message as GetNodeInfoResponse)) as GetNodeInfoResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GetNodeInfoResponse copyWith(void Function(GetNodeInfoResponse) updates) =>
+      super.copyWith((message) => updates(message as GetNodeInfoResponse))
+          as GetNodeInfoResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GetNodeInfoResponse create() => GetNodeInfoResponse._();
   GetNodeInfoResponse createEmptyInstance() => create();
   static $pb.PbList<GetNodeInfoResponse> createRepeated() => $pb.PbList<GetNodeInfoResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetNodeInfoResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNodeInfoResponse>(create);
+  static GetNodeInfoResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNodeInfoResponse>(create);
   static GetNodeInfoResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get value => $_getN(0);
   @$pb.TagNumber(1)
-  set value($core.List<$core.int> v) { $_setBytes(0, v); }
+  set value($core.List<$core.int> v) {
+    $_setBytes(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
@@ -3085,7 +3850,10 @@ class GetNodeInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get timestamp => $_getI64(1);
   @$pb.TagNumber(2)
-  set timestamp($fixnum.Int64 v) { $_setInt64(1, v); }
+  set timestamp($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasTimestamp() => $_has(1);
   @$pb.TagNumber(2)
@@ -3094,7 +3862,10 @@ class GetNodeInfoResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.List<$core.int> get signature => $_getN(2);
   @$pb.TagNumber(3)
-  set signature($core.List<$core.int> v) { $_setBytes(2, v); }
+  set signature($core.List<$core.int> v) {
+    $_setBytes(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasSignature() => $_has(2);
   @$pb.TagNumber(3)
@@ -3102,13 +3873,24 @@ class GetNodeInfoResponse extends $pb.GeneratedMessage {
 }
 
 class JoinCTPSessionRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'JoinCTPSessionRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..e<JoinCTPSessionRequest_PartyType>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'partyType', $pb.PbFieldType.OE, protoName: 'partyType', defaultOrMaker: JoinCTPSessionRequest_PartyType.PAYER, valueOf: JoinCTPSessionRequest_PartyType.valueOf, enumValues: JoinCTPSessionRequest_PartyType.values)
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'partyName', protoName: 'partyName')
-    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'notificationToken', protoName: 'notificationToken')
-    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sessionID', protoName: 'sessionID')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'JoinCTPSessionRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..e<JoinCTPSessionRequest_PartyType>(1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'partyType', $pb.PbFieldType.OE,
+        protoName: 'partyType',
+        defaultOrMaker: JoinCTPSessionRequest_PartyType.PAYER,
+        valueOf: JoinCTPSessionRequest_PartyType.valueOf,
+        enumValues: JoinCTPSessionRequest_PartyType.values)
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'partyName',
+        protoName: 'partyName')
+    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'notificationToken',
+        protoName: 'notificationToken')
+    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sessionID',
+        protoName: 'sessionID')
+    ..hasRequiredFields = false;
 
   JoinCTPSessionRequest._() : super();
   factory JoinCTPSessionRequest({
@@ -3132,31 +3914,39 @@ class JoinCTPSessionRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory JoinCTPSessionRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory JoinCTPSessionRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory JoinCTPSessionRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory JoinCTPSessionRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   JoinCTPSessionRequest clone() => JoinCTPSessionRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  JoinCTPSessionRequest copyWith(void Function(JoinCTPSessionRequest) updates) => super.copyWith((message) => updates(message as JoinCTPSessionRequest)) as JoinCTPSessionRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  JoinCTPSessionRequest copyWith(void Function(JoinCTPSessionRequest) updates) =>
+      super.copyWith((message) => updates(message as JoinCTPSessionRequest))
+          as JoinCTPSessionRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static JoinCTPSessionRequest create() => JoinCTPSessionRequest._();
   JoinCTPSessionRequest createEmptyInstance() => create();
   static $pb.PbList<JoinCTPSessionRequest> createRepeated() => $pb.PbList<JoinCTPSessionRequest>();
   @$core.pragma('dart2js:noInline')
-  static JoinCTPSessionRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<JoinCTPSessionRequest>(create);
+  static JoinCTPSessionRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<JoinCTPSessionRequest>(create);
   static JoinCTPSessionRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   JoinCTPSessionRequest_PartyType get partyType => $_getN(0);
   @$pb.TagNumber(1)
-  set partyType(JoinCTPSessionRequest_PartyType v) { setField(1, v); }
+  set partyType(JoinCTPSessionRequest_PartyType v) {
+    setField(1, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasPartyType() => $_has(0);
   @$pb.TagNumber(1)
@@ -3165,7 +3955,10 @@ class JoinCTPSessionRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get partyName => $_getSZ(1);
   @$pb.TagNumber(2)
-  set partyName($core.String v) { $_setString(1, v); }
+  set partyName($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasPartyName() => $_has(1);
   @$pb.TagNumber(2)
@@ -3174,7 +3967,10 @@ class JoinCTPSessionRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get notificationToken => $_getSZ(2);
   @$pb.TagNumber(3)
-  set notificationToken($core.String v) { $_setString(2, v); }
+  set notificationToken($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasNotificationToken() => $_has(2);
   @$pb.TagNumber(3)
@@ -3183,7 +3979,10 @@ class JoinCTPSessionRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get sessionID => $_getSZ(3);
   @$pb.TagNumber(4)
-  set sessionID($core.String v) { $_setString(3, v); }
+  set sessionID($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasSessionID() => $_has(3);
   @$pb.TagNumber(4)
@@ -3191,11 +3990,15 @@ class JoinCTPSessionRequest extends $pb.GeneratedMessage {
 }
 
 class JoinCTPSessionResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'JoinCTPSessionResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sessionID', protoName: 'sessionID')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'JoinCTPSessionResponse',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sessionID',
+        protoName: 'sessionID')
     ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'expiry')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   JoinCTPSessionResponse._() : super();
   factory JoinCTPSessionResponse({
@@ -3211,31 +4014,39 @@ class JoinCTPSessionResponse extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory JoinCTPSessionResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory JoinCTPSessionResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory JoinCTPSessionResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory JoinCTPSessionResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   JoinCTPSessionResponse clone() => JoinCTPSessionResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  JoinCTPSessionResponse copyWith(void Function(JoinCTPSessionResponse) updates) => super.copyWith((message) => updates(message as JoinCTPSessionResponse)) as JoinCTPSessionResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  JoinCTPSessionResponse copyWith(void Function(JoinCTPSessionResponse) updates) =>
+      super.copyWith((message) => updates(message as JoinCTPSessionResponse))
+          as JoinCTPSessionResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static JoinCTPSessionResponse create() => JoinCTPSessionResponse._();
   JoinCTPSessionResponse createEmptyInstance() => create();
   static $pb.PbList<JoinCTPSessionResponse> createRepeated() => $pb.PbList<JoinCTPSessionResponse>();
   @$core.pragma('dart2js:noInline')
-  static JoinCTPSessionResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<JoinCTPSessionResponse>(create);
+  static JoinCTPSessionResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<JoinCTPSessionResponse>(create);
   static JoinCTPSessionResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sessionID => $_getSZ(0);
   @$pb.TagNumber(1)
-  set sessionID($core.String v) { $_setString(0, v); }
+  set sessionID($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasSessionID() => $_has(0);
   @$pb.TagNumber(1)
@@ -3244,7 +4055,10 @@ class JoinCTPSessionResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get expiry => $_getI64(1);
   @$pb.TagNumber(2)
-  set expiry($fixnum.Int64 v) { $_setInt64(1, v); }
+  set expiry($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasExpiry() => $_has(1);
   @$pb.TagNumber(2)
@@ -3252,10 +4066,14 @@ class JoinCTPSessionResponse extends $pb.GeneratedMessage {
 }
 
 class TerminateCTPSessionRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'TerminateCTPSessionRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sessionID', protoName: 'sessionID')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'TerminateCTPSessionRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sessionID',
+        protoName: 'sessionID')
+    ..hasRequiredFields = false;
 
   TerminateCTPSessionRequest._() : super();
   factory TerminateCTPSessionRequest({
@@ -3267,31 +4085,39 @@ class TerminateCTPSessionRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory TerminateCTPSessionRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory TerminateCTPSessionRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory TerminateCTPSessionRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory TerminateCTPSessionRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   TerminateCTPSessionRequest clone() => TerminateCTPSessionRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  TerminateCTPSessionRequest copyWith(void Function(TerminateCTPSessionRequest) updates) => super.copyWith((message) => updates(message as TerminateCTPSessionRequest)) as TerminateCTPSessionRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  TerminateCTPSessionRequest copyWith(void Function(TerminateCTPSessionRequest) updates) =>
+      super.copyWith((message) => updates(message as TerminateCTPSessionRequest))
+          as TerminateCTPSessionRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static TerminateCTPSessionRequest create() => TerminateCTPSessionRequest._();
   TerminateCTPSessionRequest createEmptyInstance() => create();
   static $pb.PbList<TerminateCTPSessionRequest> createRepeated() => $pb.PbList<TerminateCTPSessionRequest>();
   @$core.pragma('dart2js:noInline')
-  static TerminateCTPSessionRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TerminateCTPSessionRequest>(create);
+  static TerminateCTPSessionRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TerminateCTPSessionRequest>(create);
   static TerminateCTPSessionRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sessionID => $_getSZ(0);
   @$pb.TagNumber(1)
-  set sessionID($core.String v) { $_setString(0, v); }
+  set sessionID($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasSessionID() => $_has(0);
   @$pb.TagNumber(1)
@@ -3299,41 +4125,63 @@ class TerminateCTPSessionRequest extends $pb.GeneratedMessage {
 }
 
 class TerminateCTPSessionResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'TerminateCTPSessionResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'TerminateCTPSessionResponse',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   TerminateCTPSessionResponse._() : super();
   factory TerminateCTPSessionResponse() => create();
-  factory TerminateCTPSessionResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory TerminateCTPSessionResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory TerminateCTPSessionResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory TerminateCTPSessionResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   TerminateCTPSessionResponse clone() => TerminateCTPSessionResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  TerminateCTPSessionResponse copyWith(void Function(TerminateCTPSessionResponse) updates) => super.copyWith((message) => updates(message as TerminateCTPSessionResponse)) as TerminateCTPSessionResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  TerminateCTPSessionResponse copyWith(void Function(TerminateCTPSessionResponse) updates) =>
+      super.copyWith((message) => updates(message as TerminateCTPSessionResponse))
+          as TerminateCTPSessionResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static TerminateCTPSessionResponse create() => TerminateCTPSessionResponse._();
   TerminateCTPSessionResponse createEmptyInstance() => create();
-  static $pb.PbList<TerminateCTPSessionResponse> createRepeated() => $pb.PbList<TerminateCTPSessionResponse>();
+  static $pb.PbList<TerminateCTPSessionResponse> createRepeated() =>
+      $pb.PbList<TerminateCTPSessionResponse>();
   @$core.pragma('dart2js:noInline')
-  static TerminateCTPSessionResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TerminateCTPSessionResponse>(create);
+  static TerminateCTPSessionResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TerminateCTPSessionResponse>(create);
   static TerminateCTPSessionResponse? _defaultInstance;
 }
 
 class RegisterTransactionConfirmationRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RegisterTransactionConfirmationRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'RegisterTransactionConfirmationRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'txID', protoName: 'txID')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'notificationToken', protoName: 'notificationToken')
-    ..e<RegisterTransactionConfirmationRequest_NotificationType>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'notificationType', $pb.PbFieldType.OE, protoName: 'notificationType', defaultOrMaker: RegisterTransactionConfirmationRequest_NotificationType.READY_RECEIVE_PAYMENT, valueOf: RegisterTransactionConfirmationRequest_NotificationType.valueOf, enumValues: RegisterTransactionConfirmationRequest_NotificationType.values)
-    ..hasRequiredFields = false
-  ;
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'notificationToken',
+        protoName: 'notificationToken')
+    ..e<RegisterTransactionConfirmationRequest_NotificationType>(
+        3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'notificationType',
+        $pb.PbFieldType.OE,
+        protoName: 'notificationType',
+        defaultOrMaker: RegisterTransactionConfirmationRequest_NotificationType.READY_RECEIVE_PAYMENT,
+        valueOf: RegisterTransactionConfirmationRequest_NotificationType.valueOf,
+        enumValues: RegisterTransactionConfirmationRequest_NotificationType.values)
+    ..hasRequiredFields = false;
 
   RegisterTransactionConfirmationRequest._() : super();
   factory RegisterTransactionConfirmationRequest({
@@ -3353,31 +4201,42 @@ class RegisterTransactionConfirmationRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RegisterTransactionConfirmationRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RegisterTransactionConfirmationRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  RegisterTransactionConfirmationRequest clone() => RegisterTransactionConfirmationRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RegisterTransactionConfirmationRequest copyWith(void Function(RegisterTransactionConfirmationRequest) updates) => super.copyWith((message) => updates(message as RegisterTransactionConfirmationRequest)) as RegisterTransactionConfirmationRequest; // ignore: deprecated_member_use
+  factory RegisterTransactionConfirmationRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RegisterTransactionConfirmationRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  RegisterTransactionConfirmationRequest clone() =>
+      RegisterTransactionConfirmationRequest()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RegisterTransactionConfirmationRequest copyWith(
+          void Function(RegisterTransactionConfirmationRequest) updates) =>
+      super.copyWith((message) => updates(message as RegisterTransactionConfirmationRequest))
+          as RegisterTransactionConfirmationRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RegisterTransactionConfirmationRequest create() => RegisterTransactionConfirmationRequest._();
   RegisterTransactionConfirmationRequest createEmptyInstance() => create();
-  static $pb.PbList<RegisterTransactionConfirmationRequest> createRepeated() => $pb.PbList<RegisterTransactionConfirmationRequest>();
+  static $pb.PbList<RegisterTransactionConfirmationRequest> createRepeated() =>
+      $pb.PbList<RegisterTransactionConfirmationRequest>();
   @$core.pragma('dart2js:noInline')
-  static RegisterTransactionConfirmationRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterTransactionConfirmationRequest>(create);
+  static RegisterTransactionConfirmationRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterTransactionConfirmationRequest>(create);
   static RegisterTransactionConfirmationRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txID => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txID($core.String v) { $_setString(0, v); }
+  set txID($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasTxID() => $_has(0);
   @$pb.TagNumber(1)
@@ -3386,7 +4245,10 @@ class RegisterTransactionConfirmationRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get notificationToken => $_getSZ(1);
   @$pb.TagNumber(2)
-  set notificationToken($core.String v) { $_setString(1, v); }
+  set notificationToken($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasNotificationToken() => $_has(1);
   @$pb.TagNumber(2)
@@ -3395,7 +4257,10 @@ class RegisterTransactionConfirmationRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   RegisterTransactionConfirmationRequest_NotificationType get notificationType => $_getN(2);
   @$pb.TagNumber(3)
-  set notificationType(RegisterTransactionConfirmationRequest_NotificationType v) { setField(3, v); }
+  set notificationType(RegisterTransactionConfirmationRequest_NotificationType v) {
+    setField(3, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasNotificationType() => $_has(2);
   @$pb.TagNumber(3)
@@ -3403,39 +4268,56 @@ class RegisterTransactionConfirmationRequest extends $pb.GeneratedMessage {
 }
 
 class RegisterTransactionConfirmationResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RegisterTransactionConfirmationResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'RegisterTransactionConfirmationResponse',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   RegisterTransactionConfirmationResponse._() : super();
   factory RegisterTransactionConfirmationResponse() => create();
-  factory RegisterTransactionConfirmationResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RegisterTransactionConfirmationResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  RegisterTransactionConfirmationResponse clone() => RegisterTransactionConfirmationResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RegisterTransactionConfirmationResponse copyWith(void Function(RegisterTransactionConfirmationResponse) updates) => super.copyWith((message) => updates(message as RegisterTransactionConfirmationResponse)) as RegisterTransactionConfirmationResponse; // ignore: deprecated_member_use
+  factory RegisterTransactionConfirmationResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RegisterTransactionConfirmationResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  RegisterTransactionConfirmationResponse clone() =>
+      RegisterTransactionConfirmationResponse()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RegisterTransactionConfirmationResponse copyWith(
+          void Function(RegisterTransactionConfirmationResponse) updates) =>
+      super.copyWith((message) => updates(message as RegisterTransactionConfirmationResponse))
+          as RegisterTransactionConfirmationResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RegisterTransactionConfirmationResponse create() => RegisterTransactionConfirmationResponse._();
   RegisterTransactionConfirmationResponse createEmptyInstance() => create();
-  static $pb.PbList<RegisterTransactionConfirmationResponse> createRepeated() => $pb.PbList<RegisterTransactionConfirmationResponse>();
+  static $pb.PbList<RegisterTransactionConfirmationResponse> createRepeated() =>
+      $pb.PbList<RegisterTransactionConfirmationResponse>();
   @$core.pragma('dart2js:noInline')
-  static RegisterTransactionConfirmationResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterTransactionConfirmationResponse>(create);
+  static RegisterTransactionConfirmationResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterTransactionConfirmationResponse>(create);
   static RegisterTransactionConfirmationResponse? _defaultInstance;
 }
 
 class RegisterPeriodicSyncRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RegisterPeriodicSyncRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'notificationToken', protoName: 'notificationToken')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RegisterPeriodicSyncRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'notificationToken',
+        protoName: 'notificationToken')
+    ..hasRequiredFields = false;
 
   RegisterPeriodicSyncRequest._() : super();
   factory RegisterPeriodicSyncRequest({
@@ -3447,31 +4329,40 @@ class RegisterPeriodicSyncRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RegisterPeriodicSyncRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RegisterPeriodicSyncRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RegisterPeriodicSyncRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RegisterPeriodicSyncRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RegisterPeriodicSyncRequest clone() => RegisterPeriodicSyncRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RegisterPeriodicSyncRequest copyWith(void Function(RegisterPeriodicSyncRequest) updates) => super.copyWith((message) => updates(message as RegisterPeriodicSyncRequest)) as RegisterPeriodicSyncRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RegisterPeriodicSyncRequest copyWith(void Function(RegisterPeriodicSyncRequest) updates) =>
+      super.copyWith((message) => updates(message as RegisterPeriodicSyncRequest))
+          as RegisterPeriodicSyncRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RegisterPeriodicSyncRequest create() => RegisterPeriodicSyncRequest._();
   RegisterPeriodicSyncRequest createEmptyInstance() => create();
-  static $pb.PbList<RegisterPeriodicSyncRequest> createRepeated() => $pb.PbList<RegisterPeriodicSyncRequest>();
+  static $pb.PbList<RegisterPeriodicSyncRequest> createRepeated() =>
+      $pb.PbList<RegisterPeriodicSyncRequest>();
   @$core.pragma('dart2js:noInline')
-  static RegisterPeriodicSyncRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterPeriodicSyncRequest>(create);
+  static RegisterPeriodicSyncRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterPeriodicSyncRequest>(create);
   static RegisterPeriodicSyncRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get notificationToken => $_getSZ(0);
   @$pb.TagNumber(1)
-  set notificationToken($core.String v) { $_setString(0, v); }
+  set notificationToken($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasNotificationToken() => $_has(0);
   @$pb.TagNumber(1)
@@ -3479,40 +4370,55 @@ class RegisterPeriodicSyncRequest extends $pb.GeneratedMessage {
 }
 
 class RegisterPeriodicSyncResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RegisterPeriodicSyncResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RegisterPeriodicSyncResponse',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   RegisterPeriodicSyncResponse._() : super();
   factory RegisterPeriodicSyncResponse() => create();
-  factory RegisterPeriodicSyncResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RegisterPeriodicSyncResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RegisterPeriodicSyncResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RegisterPeriodicSyncResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RegisterPeriodicSyncResponse clone() => RegisterPeriodicSyncResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RegisterPeriodicSyncResponse copyWith(void Function(RegisterPeriodicSyncResponse) updates) => super.copyWith((message) => updates(message as RegisterPeriodicSyncResponse)) as RegisterPeriodicSyncResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RegisterPeriodicSyncResponse copyWith(void Function(RegisterPeriodicSyncResponse) updates) =>
+      super.copyWith((message) => updates(message as RegisterPeriodicSyncResponse))
+          as RegisterPeriodicSyncResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RegisterPeriodicSyncResponse create() => RegisterPeriodicSyncResponse._();
   RegisterPeriodicSyncResponse createEmptyInstance() => create();
-  static $pb.PbList<RegisterPeriodicSyncResponse> createRepeated() => $pb.PbList<RegisterPeriodicSyncResponse>();
+  static $pb.PbList<RegisterPeriodicSyncResponse> createRepeated() =>
+      $pb.PbList<RegisterPeriodicSyncResponse>();
   @$core.pragma('dart2js:noInline')
-  static RegisterPeriodicSyncResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterPeriodicSyncResponse>(create);
+  static RegisterPeriodicSyncResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RegisterPeriodicSyncResponse>(create);
   static RegisterPeriodicSyncResponse? _defaultInstance;
 }
 
 class BoltzReverseSwapLockupTx extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'BoltzReverseSwapLockupTx', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'BoltzReverseSwapLockupTx',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'boltzId')
-    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'timeoutBlockHeight', $pb.PbFieldType.OU3)
-    ..hasRequiredFields = false
-  ;
+    ..a<$core.int>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'timeoutBlockHeight',
+        $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false;
 
   BoltzReverseSwapLockupTx._() : super();
   factory BoltzReverseSwapLockupTx({
@@ -3528,31 +4434,39 @@ class BoltzReverseSwapLockupTx extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory BoltzReverseSwapLockupTx.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory BoltzReverseSwapLockupTx.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory BoltzReverseSwapLockupTx.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory BoltzReverseSwapLockupTx.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   BoltzReverseSwapLockupTx clone() => BoltzReverseSwapLockupTx()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  BoltzReverseSwapLockupTx copyWith(void Function(BoltzReverseSwapLockupTx) updates) => super.copyWith((message) => updates(message as BoltzReverseSwapLockupTx)) as BoltzReverseSwapLockupTx; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  BoltzReverseSwapLockupTx copyWith(void Function(BoltzReverseSwapLockupTx) updates) =>
+      super.copyWith((message) => updates(message as BoltzReverseSwapLockupTx))
+          as BoltzReverseSwapLockupTx; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static BoltzReverseSwapLockupTx create() => BoltzReverseSwapLockupTx._();
   BoltzReverseSwapLockupTx createEmptyInstance() => create();
   static $pb.PbList<BoltzReverseSwapLockupTx> createRepeated() => $pb.PbList<BoltzReverseSwapLockupTx>();
   @$core.pragma('dart2js:noInline')
-  static BoltzReverseSwapLockupTx getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BoltzReverseSwapLockupTx>(create);
+  static BoltzReverseSwapLockupTx getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BoltzReverseSwapLockupTx>(create);
   static BoltzReverseSwapLockupTx? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get boltzId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set boltzId($core.String v) { $_setString(0, v); }
+  set boltzId($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasBoltzId() => $_has(0);
   @$pb.TagNumber(1)
@@ -3561,34 +4475,42 @@ class BoltzReverseSwapLockupTx extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get timeoutBlockHeight => $_getIZ(1);
   @$pb.TagNumber(2)
-  set timeoutBlockHeight($core.int v) { $_setUnsignedInt32(1, v); }
+  set timeoutBlockHeight($core.int v) {
+    $_setUnsignedInt32(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasTimeoutBlockHeight() => $_has(1);
   @$pb.TagNumber(2)
   void clearTimeoutBlockHeight() => clearField(2);
 }
 
-enum PushTxNotificationRequest_Info {
-  boltzReverseSwapLockupTxInfo, 
-  notSet
-}
+enum PushTxNotificationRequest_Info { boltzReverseSwapLockupTxInfo, notSet }
 
 class PushTxNotificationRequest extends $pb.GeneratedMessage {
   static const $core.Map<$core.int, PushTxNotificationRequest_Info> _PushTxNotificationRequest_InfoByTag = {
-    7 : PushTxNotificationRequest_Info.boltzReverseSwapLockupTxInfo,
-    0 : PushTxNotificationRequest_Info.notSet
+    7: PushTxNotificationRequest_Info.boltzReverseSwapLockupTxInfo,
+    0: PushTxNotificationRequest_Info.notSet
   };
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PushTxNotificationRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PushTxNotificationRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..oo(0, [7])
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deviceId')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'title')
     ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'body')
-    ..a<$core.List<$core.int>>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'txHash', $pb.PbFieldType.OY)
-    ..a<$core.List<$core.int>>(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'script', $pb.PbFieldType.OY)
-    ..a<$core.int>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'blockHeightHint', $pb.PbFieldType.OU3)
-    ..aOM<BoltzReverseSwapLockupTx>(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'boltzReverseSwapLockupTxInfo', subBuilder: BoltzReverseSwapLockupTx.create)
-    ..hasRequiredFields = false
-  ;
+    ..a<$core.List<$core.int>>(
+        4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'txHash', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(
+        5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'script', $pb.PbFieldType.OY)
+    ..a<$core.int>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'blockHeightHint',
+        $pb.PbFieldType.OU3)
+    ..aOM<BoltzReverseSwapLockupTx>(7,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'boltzReverseSwapLockupTxInfo',
+        subBuilder: BoltzReverseSwapLockupTx.create)
+    ..hasRequiredFields = false;
 
   PushTxNotificationRequest._() : super();
   factory PushTxNotificationRequest({
@@ -3624,25 +4546,30 @@ class PushTxNotificationRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory PushTxNotificationRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PushTxNotificationRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory PushTxNotificationRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory PushTxNotificationRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   PushTxNotificationRequest clone() => PushTxNotificationRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  PushTxNotificationRequest copyWith(void Function(PushTxNotificationRequest) updates) => super.copyWith((message) => updates(message as PushTxNotificationRequest)) as PushTxNotificationRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  PushTxNotificationRequest copyWith(void Function(PushTxNotificationRequest) updates) =>
+      super.copyWith((message) => updates(message as PushTxNotificationRequest))
+          as PushTxNotificationRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PushTxNotificationRequest create() => PushTxNotificationRequest._();
   PushTxNotificationRequest createEmptyInstance() => create();
   static $pb.PbList<PushTxNotificationRequest> createRepeated() => $pb.PbList<PushTxNotificationRequest>();
   @$core.pragma('dart2js:noInline')
-  static PushTxNotificationRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PushTxNotificationRequest>(create);
+  static PushTxNotificationRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PushTxNotificationRequest>(create);
   static PushTxNotificationRequest? _defaultInstance;
 
   PushTxNotificationRequest_Info whichInfo() => _PushTxNotificationRequest_InfoByTag[$_whichOneof(0)]!;
@@ -3651,7 +4578,10 @@ class PushTxNotificationRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get deviceId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set deviceId($core.String v) { $_setString(0, v); }
+  set deviceId($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasDeviceId() => $_has(0);
   @$pb.TagNumber(1)
@@ -3660,7 +4590,10 @@ class PushTxNotificationRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get title => $_getSZ(1);
   @$pb.TagNumber(2)
-  set title($core.String v) { $_setString(1, v); }
+  set title($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasTitle() => $_has(1);
   @$pb.TagNumber(2)
@@ -3669,7 +4602,10 @@ class PushTxNotificationRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get body => $_getSZ(2);
   @$pb.TagNumber(3)
-  set body($core.String v) { $_setString(2, v); }
+  set body($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasBody() => $_has(2);
   @$pb.TagNumber(3)
@@ -3678,7 +4614,10 @@ class PushTxNotificationRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.List<$core.int> get txHash => $_getN(3);
   @$pb.TagNumber(4)
-  set txHash($core.List<$core.int> v) { $_setBytes(3, v); }
+  set txHash($core.List<$core.int> v) {
+    $_setBytes(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasTxHash() => $_has(3);
   @$pb.TagNumber(4)
@@ -3687,7 +4626,10 @@ class PushTxNotificationRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.List<$core.int> get script => $_getN(4);
   @$pb.TagNumber(5)
-  set script($core.List<$core.int> v) { $_setBytes(4, v); }
+  set script($core.List<$core.int> v) {
+    $_setBytes(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasScript() => $_has(4);
   @$pb.TagNumber(5)
@@ -3696,7 +4638,10 @@ class PushTxNotificationRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.int get blockHeightHint => $_getIZ(5);
   @$pb.TagNumber(6)
-  set blockHeightHint($core.int v) { $_setUnsignedInt32(5, v); }
+  set blockHeightHint($core.int v) {
+    $_setUnsignedInt32(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasBlockHeightHint() => $_has(5);
   @$pb.TagNumber(6)
@@ -3705,7 +4650,10 @@ class PushTxNotificationRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   BoltzReverseSwapLockupTx get boltzReverseSwapLockupTxInfo => $_getN(6);
   @$pb.TagNumber(7)
-  set boltzReverseSwapLockupTxInfo(BoltzReverseSwapLockupTx v) { setField(7, v); }
+  set boltzReverseSwapLockupTxInfo(BoltzReverseSwapLockupTx v) {
+    setField(7, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasBoltzReverseSwapLockupTxInfo() => $_has(6);
   @$pb.TagNumber(7)
@@ -3715,68 +4663,87 @@ class PushTxNotificationRequest extends $pb.GeneratedMessage {
 }
 
 class PushTxNotificationResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PushTxNotificationResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PushTxNotificationResponse',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   PushTxNotificationResponse._() : super();
   factory PushTxNotificationResponse() => create();
-  factory PushTxNotificationResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PushTxNotificationResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory PushTxNotificationResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory PushTxNotificationResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   PushTxNotificationResponse clone() => PushTxNotificationResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  PushTxNotificationResponse copyWith(void Function(PushTxNotificationResponse) updates) => super.copyWith((message) => updates(message as PushTxNotificationResponse)) as PushTxNotificationResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  PushTxNotificationResponse copyWith(void Function(PushTxNotificationResponse) updates) =>
+      super.copyWith((message) => updates(message as PushTxNotificationResponse))
+          as PushTxNotificationResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PushTxNotificationResponse create() => PushTxNotificationResponse._();
   PushTxNotificationResponse createEmptyInstance() => create();
   static $pb.PbList<PushTxNotificationResponse> createRepeated() => $pb.PbList<PushTxNotificationResponse>();
   @$core.pragma('dart2js:noInline')
-  static PushTxNotificationResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PushTxNotificationResponse>(create);
+  static PushTxNotificationResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PushTxNotificationResponse>(create);
   static PushTxNotificationResponse? _defaultInstance;
 }
 
 class BreezAppVersionsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'BreezAppVersionsRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'BreezAppVersionsRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   BreezAppVersionsRequest._() : super();
   factory BreezAppVersionsRequest() => create();
-  factory BreezAppVersionsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory BreezAppVersionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory BreezAppVersionsRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory BreezAppVersionsRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   BreezAppVersionsRequest clone() => BreezAppVersionsRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  BreezAppVersionsRequest copyWith(void Function(BreezAppVersionsRequest) updates) => super.copyWith((message) => updates(message as BreezAppVersionsRequest)) as BreezAppVersionsRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  BreezAppVersionsRequest copyWith(void Function(BreezAppVersionsRequest) updates) =>
+      super.copyWith((message) => updates(message as BreezAppVersionsRequest))
+          as BreezAppVersionsRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static BreezAppVersionsRequest create() => BreezAppVersionsRequest._();
   BreezAppVersionsRequest createEmptyInstance() => create();
   static $pb.PbList<BreezAppVersionsRequest> createRepeated() => $pb.PbList<BreezAppVersionsRequest>();
   @$core.pragma('dart2js:noInline')
-  static BreezAppVersionsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BreezAppVersionsRequest>(create);
+  static BreezAppVersionsRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BreezAppVersionsRequest>(create);
   static BreezAppVersionsRequest? _defaultInstance;
 }
 
 class BreezAppVersionsReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'BreezAppVersionsReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'BreezAppVersionsReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..pPS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'version')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   BreezAppVersionsReply._() : super();
   factory BreezAppVersionsReply({
@@ -3788,25 +4755,30 @@ class BreezAppVersionsReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory BreezAppVersionsReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory BreezAppVersionsReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory BreezAppVersionsReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory BreezAppVersionsReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   BreezAppVersionsReply clone() => BreezAppVersionsReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  BreezAppVersionsReply copyWith(void Function(BreezAppVersionsReply) updates) => super.copyWith((message) => updates(message as BreezAppVersionsReply)) as BreezAppVersionsReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  BreezAppVersionsReply copyWith(void Function(BreezAppVersionsReply) updates) =>
+      super.copyWith((message) => updates(message as BreezAppVersionsReply))
+          as BreezAppVersionsReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static BreezAppVersionsReply create() => BreezAppVersionsReply._();
   BreezAppVersionsReply createEmptyInstance() => create();
   static $pb.PbList<BreezAppVersionsReply> createRepeated() => $pb.PbList<BreezAppVersionsReply>();
   @$core.pragma('dart2js:noInline')
-  static BreezAppVersionsReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BreezAppVersionsReply>(create);
+  static BreezAppVersionsReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BreezAppVersionsReply>(create);
   static BreezAppVersionsReply? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -3814,39 +4786,52 @@ class BreezAppVersionsReply extends $pb.GeneratedMessage {
 }
 
 class GetReverseRoutingNodeRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GetReverseRoutingNodeRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GetReverseRoutingNodeRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   GetReverseRoutingNodeRequest._() : super();
   factory GetReverseRoutingNodeRequest() => create();
-  factory GetReverseRoutingNodeRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GetReverseRoutingNodeRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory GetReverseRoutingNodeRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GetReverseRoutingNodeRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GetReverseRoutingNodeRequest clone() => GetReverseRoutingNodeRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GetReverseRoutingNodeRequest copyWith(void Function(GetReverseRoutingNodeRequest) updates) => super.copyWith((message) => updates(message as GetReverseRoutingNodeRequest)) as GetReverseRoutingNodeRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GetReverseRoutingNodeRequest copyWith(void Function(GetReverseRoutingNodeRequest) updates) =>
+      super.copyWith((message) => updates(message as GetReverseRoutingNodeRequest))
+          as GetReverseRoutingNodeRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GetReverseRoutingNodeRequest create() => GetReverseRoutingNodeRequest._();
   GetReverseRoutingNodeRequest createEmptyInstance() => create();
-  static $pb.PbList<GetReverseRoutingNodeRequest> createRepeated() => $pb.PbList<GetReverseRoutingNodeRequest>();
+  static $pb.PbList<GetReverseRoutingNodeRequest> createRepeated() =>
+      $pb.PbList<GetReverseRoutingNodeRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetReverseRoutingNodeRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetReverseRoutingNodeRequest>(create);
+  static GetReverseRoutingNodeRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetReverseRoutingNodeRequest>(create);
   static GetReverseRoutingNodeRequest? _defaultInstance;
 }
 
 class GetReverseRoutingNodeReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GetReverseRoutingNodeReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..a<$core.List<$core.int>>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'nodeId', $pb.PbFieldType.OY)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GetReverseRoutingNodeReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'nodeId', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
 
   GetReverseRoutingNodeReply._() : super();
   factory GetReverseRoutingNodeReply({
@@ -3858,31 +4843,39 @@ class GetReverseRoutingNodeReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory GetReverseRoutingNodeReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GetReverseRoutingNodeReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory GetReverseRoutingNodeReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GetReverseRoutingNodeReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GetReverseRoutingNodeReply clone() => GetReverseRoutingNodeReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GetReverseRoutingNodeReply copyWith(void Function(GetReverseRoutingNodeReply) updates) => super.copyWith((message) => updates(message as GetReverseRoutingNodeReply)) as GetReverseRoutingNodeReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GetReverseRoutingNodeReply copyWith(void Function(GetReverseRoutingNodeReply) updates) =>
+      super.copyWith((message) => updates(message as GetReverseRoutingNodeReply))
+          as GetReverseRoutingNodeReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GetReverseRoutingNodeReply create() => GetReverseRoutingNodeReply._();
   GetReverseRoutingNodeReply createEmptyInstance() => create();
   static $pb.PbList<GetReverseRoutingNodeReply> createRepeated() => $pb.PbList<GetReverseRoutingNodeReply>();
   @$core.pragma('dart2js:noInline')
-  static GetReverseRoutingNodeReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetReverseRoutingNodeReply>(create);
+  static GetReverseRoutingNodeReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetReverseRoutingNodeReply>(create);
   static GetReverseRoutingNodeReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get nodeId => $_getN(0);
   @$pb.TagNumber(1)
-  set nodeId($core.List<$core.int> v) { $_setBytes(0, v); }
+  set nodeId($core.List<$core.int> v) {
+    $_setBytes(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasNodeId() => $_has(0);
   @$pb.TagNumber(1)
@@ -3890,7 +4883,11 @@ class GetReverseRoutingNodeReply extends $pb.GeneratedMessage {
 }
 
 class ReportPaymentFailureRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReportPaymentFailureRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReportPaymentFailureRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sdkVersion')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sdkGitHash')
     ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'nodeId')
@@ -3898,8 +4895,7 @@ class ReportPaymentFailureRequest extends $pb.GeneratedMessage {
     ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'timestamp')
     ..aOS(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'comment')
     ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'report')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   ReportPaymentFailureRequest._() : super();
   factory ReportPaymentFailureRequest({
@@ -3935,31 +4931,40 @@ class ReportPaymentFailureRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ReportPaymentFailureRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ReportPaymentFailureRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ReportPaymentFailureRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ReportPaymentFailureRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ReportPaymentFailureRequest clone() => ReportPaymentFailureRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ReportPaymentFailureRequest copyWith(void Function(ReportPaymentFailureRequest) updates) => super.copyWith((message) => updates(message as ReportPaymentFailureRequest)) as ReportPaymentFailureRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ReportPaymentFailureRequest copyWith(void Function(ReportPaymentFailureRequest) updates) =>
+      super.copyWith((message) => updates(message as ReportPaymentFailureRequest))
+          as ReportPaymentFailureRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReportPaymentFailureRequest create() => ReportPaymentFailureRequest._();
   ReportPaymentFailureRequest createEmptyInstance() => create();
-  static $pb.PbList<ReportPaymentFailureRequest> createRepeated() => $pb.PbList<ReportPaymentFailureRequest>();
+  static $pb.PbList<ReportPaymentFailureRequest> createRepeated() =>
+      $pb.PbList<ReportPaymentFailureRequest>();
   @$core.pragma('dart2js:noInline')
-  static ReportPaymentFailureRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReportPaymentFailureRequest>(create);
+  static ReportPaymentFailureRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReportPaymentFailureRequest>(create);
   static ReportPaymentFailureRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sdkVersion => $_getSZ(0);
   @$pb.TagNumber(1)
-  set sdkVersion($core.String v) { $_setString(0, v); }
+  set sdkVersion($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasSdkVersion() => $_has(0);
   @$pb.TagNumber(1)
@@ -3968,7 +4973,10 @@ class ReportPaymentFailureRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get sdkGitHash => $_getSZ(1);
   @$pb.TagNumber(2)
-  set sdkGitHash($core.String v) { $_setString(1, v); }
+  set sdkGitHash($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasSdkGitHash() => $_has(1);
   @$pb.TagNumber(2)
@@ -3977,7 +4985,10 @@ class ReportPaymentFailureRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get nodeId => $_getSZ(2);
   @$pb.TagNumber(3)
-  set nodeId($core.String v) { $_setString(2, v); }
+  set nodeId($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasNodeId() => $_has(2);
   @$pb.TagNumber(3)
@@ -3986,7 +4997,10 @@ class ReportPaymentFailureRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get lspId => $_getSZ(3);
   @$pb.TagNumber(4)
-  set lspId($core.String v) { $_setString(3, v); }
+  set lspId($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasLspId() => $_has(3);
   @$pb.TagNumber(4)
@@ -3995,7 +5009,10 @@ class ReportPaymentFailureRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get timestamp => $_getSZ(4);
   @$pb.TagNumber(5)
-  set timestamp($core.String v) { $_setString(4, v); }
+  set timestamp($core.String v) {
+    $_setString(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasTimestamp() => $_has(4);
   @$pb.TagNumber(5)
@@ -4004,7 +5021,10 @@ class ReportPaymentFailureRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.String get comment => $_getSZ(5);
   @$pb.TagNumber(6)
-  set comment($core.String v) { $_setString(5, v); }
+  set comment($core.String v) {
+    $_setString(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasComment() => $_has(5);
   @$pb.TagNumber(6)
@@ -4013,7 +5033,10 @@ class ReportPaymentFailureRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.String get report => $_getSZ(6);
   @$pb.TagNumber(7)
-  set report($core.String v) { $_setString(6, v); }
+  set report($core.String v) {
+    $_setString(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasReport() => $_has(6);
   @$pb.TagNumber(7)
@@ -4021,68 +5044,91 @@ class ReportPaymentFailureRequest extends $pb.GeneratedMessage {
 }
 
 class ReportPaymentFailureReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReportPaymentFailureReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReportPaymentFailureReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   ReportPaymentFailureReply._() : super();
   factory ReportPaymentFailureReply() => create();
-  factory ReportPaymentFailureReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ReportPaymentFailureReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ReportPaymentFailureReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ReportPaymentFailureReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ReportPaymentFailureReply clone() => ReportPaymentFailureReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ReportPaymentFailureReply copyWith(void Function(ReportPaymentFailureReply) updates) => super.copyWith((message) => updates(message as ReportPaymentFailureReply)) as ReportPaymentFailureReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ReportPaymentFailureReply copyWith(void Function(ReportPaymentFailureReply) updates) =>
+      super.copyWith((message) => updates(message as ReportPaymentFailureReply))
+          as ReportPaymentFailureReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReportPaymentFailureReply create() => ReportPaymentFailureReply._();
   ReportPaymentFailureReply createEmptyInstance() => create();
   static $pb.PbList<ReportPaymentFailureReply> createRepeated() => $pb.PbList<ReportPaymentFailureReply>();
   @$core.pragma('dart2js:noInline')
-  static ReportPaymentFailureReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReportPaymentFailureReply>(create);
+  static ReportPaymentFailureReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReportPaymentFailureReply>(create);
   static ReportPaymentFailureReply? _defaultInstance;
 }
 
 class BreezStatusRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'BreezStatusRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'BreezStatusRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   BreezStatusRequest._() : super();
   factory BreezStatusRequest() => create();
-  factory BreezStatusRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory BreezStatusRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory BreezStatusRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory BreezStatusRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   BreezStatusRequest clone() => BreezStatusRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  BreezStatusRequest copyWith(void Function(BreezStatusRequest) updates) => super.copyWith((message) => updates(message as BreezStatusRequest)) as BreezStatusRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  BreezStatusRequest copyWith(void Function(BreezStatusRequest) updates) =>
+      super.copyWith((message) => updates(message as BreezStatusRequest))
+          as BreezStatusRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static BreezStatusRequest create() => BreezStatusRequest._();
   BreezStatusRequest createEmptyInstance() => create();
   static $pb.PbList<BreezStatusRequest> createRepeated() => $pb.PbList<BreezStatusRequest>();
   @$core.pragma('dart2js:noInline')
-  static BreezStatusRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BreezStatusRequest>(create);
+  static BreezStatusRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BreezStatusRequest>(create);
   static BreezStatusRequest? _defaultInstance;
 }
 
 class BreezStatusReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'BreezStatusReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..e<BreezStatusReply_BreezStatus>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'status', $pb.PbFieldType.OE, defaultOrMaker: BreezStatusReply_BreezStatus.OPERATIONAL, valueOf: BreezStatusReply_BreezStatus.valueOf, enumValues: BreezStatusReply_BreezStatus.values)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'BreezStatusReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..e<BreezStatusReply_BreezStatus>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'status', $pb.PbFieldType.OE,
+        defaultOrMaker: BreezStatusReply_BreezStatus.OPERATIONAL,
+        valueOf: BreezStatusReply_BreezStatus.valueOf,
+        enumValues: BreezStatusReply_BreezStatus.values)
+    ..hasRequiredFields = false;
 
   BreezStatusReply._() : super();
   factory BreezStatusReply({
@@ -4094,31 +5140,39 @@ class BreezStatusReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory BreezStatusReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory BreezStatusReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory BreezStatusReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory BreezStatusReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   BreezStatusReply clone() => BreezStatusReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  BreezStatusReply copyWith(void Function(BreezStatusReply) updates) => super.copyWith((message) => updates(message as BreezStatusReply)) as BreezStatusReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  BreezStatusReply copyWith(void Function(BreezStatusReply) updates) =>
+      super.copyWith((message) => updates(message as BreezStatusReply))
+          as BreezStatusReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static BreezStatusReply create() => BreezStatusReply._();
   BreezStatusReply createEmptyInstance() => create();
   static $pb.PbList<BreezStatusReply> createRepeated() => $pb.PbList<BreezStatusReply>();
   @$core.pragma('dart2js:noInline')
-  static BreezStatusReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BreezStatusReply>(create);
+  static BreezStatusReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BreezStatusReply>(create);
   static BreezStatusReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   BreezStatusReply_BreezStatus get status => $_getN(0);
   @$pb.TagNumber(1)
-  set status(BreezStatusReply_BreezStatus v) { setField(1, v); }
+  set status(BreezStatusReply_BreezStatus v) {
+    setField(1, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasStatus() => $_has(0);
   @$pb.TagNumber(1)
@@ -4126,40 +5180,53 @@ class BreezStatusReply extends $pb.GeneratedMessage {
 }
 
 class ChainApiServersRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ChainApiServersRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ChainApiServersRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   ChainApiServersRequest._() : super();
   factory ChainApiServersRequest() => create();
-  factory ChainApiServersRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ChainApiServersRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ChainApiServersRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ChainApiServersRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ChainApiServersRequest clone() => ChainApiServersRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ChainApiServersRequest copyWith(void Function(ChainApiServersRequest) updates) => super.copyWith((message) => updates(message as ChainApiServersRequest)) as ChainApiServersRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ChainApiServersRequest copyWith(void Function(ChainApiServersRequest) updates) =>
+      super.copyWith((message) => updates(message as ChainApiServersRequest))
+          as ChainApiServersRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ChainApiServersRequest create() => ChainApiServersRequest._();
   ChainApiServersRequest createEmptyInstance() => create();
   static $pb.PbList<ChainApiServersRequest> createRepeated() => $pb.PbList<ChainApiServersRequest>();
   @$core.pragma('dart2js:noInline')
-  static ChainApiServersRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChainApiServersRequest>(create);
+  static ChainApiServersRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChainApiServersRequest>(create);
   static ChainApiServersRequest? _defaultInstance;
 }
 
 class ChainApiServersReply_ChainAPIServer extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ChainApiServersReply.ChainAPIServer', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'ChainApiServersReply.ChainAPIServer',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'serverType')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'serverBaseUrl')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   ChainApiServersReply_ChainAPIServer._() : super();
   factory ChainApiServersReply_ChainAPIServer({
@@ -4175,31 +5242,41 @@ class ChainApiServersReply_ChainAPIServer extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ChainApiServersReply_ChainAPIServer.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ChainApiServersReply_ChainAPIServer.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  ChainApiServersReply_ChainAPIServer clone() => ChainApiServersReply_ChainAPIServer()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ChainApiServersReply_ChainAPIServer copyWith(void Function(ChainApiServersReply_ChainAPIServer) updates) => super.copyWith((message) => updates(message as ChainApiServersReply_ChainAPIServer)) as ChainApiServersReply_ChainAPIServer; // ignore: deprecated_member_use
+  factory ChainApiServersReply_ChainAPIServer.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ChainApiServersReply_ChainAPIServer.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  ChainApiServersReply_ChainAPIServer clone() =>
+      ChainApiServersReply_ChainAPIServer()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ChainApiServersReply_ChainAPIServer copyWith(void Function(ChainApiServersReply_ChainAPIServer) updates) =>
+      super.copyWith((message) => updates(message as ChainApiServersReply_ChainAPIServer))
+          as ChainApiServersReply_ChainAPIServer; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ChainApiServersReply_ChainAPIServer create() => ChainApiServersReply_ChainAPIServer._();
   ChainApiServersReply_ChainAPIServer createEmptyInstance() => create();
-  static $pb.PbList<ChainApiServersReply_ChainAPIServer> createRepeated() => $pb.PbList<ChainApiServersReply_ChainAPIServer>();
+  static $pb.PbList<ChainApiServersReply_ChainAPIServer> createRepeated() =>
+      $pb.PbList<ChainApiServersReply_ChainAPIServer>();
   @$core.pragma('dart2js:noInline')
-  static ChainApiServersReply_ChainAPIServer getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChainApiServersReply_ChainAPIServer>(create);
+  static ChainApiServersReply_ChainAPIServer getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChainApiServersReply_ChainAPIServer>(create);
   static ChainApiServersReply_ChainAPIServer? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get serverType => $_getSZ(0);
   @$pb.TagNumber(1)
-  set serverType($core.String v) { $_setString(0, v); }
+  set serverType($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasServerType() => $_has(0);
   @$pb.TagNumber(1)
@@ -4208,7 +5285,10 @@ class ChainApiServersReply_ChainAPIServer extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get serverBaseUrl => $_getSZ(1);
   @$pb.TagNumber(2)
-  set serverBaseUrl($core.String v) { $_setString(1, v); }
+  set serverBaseUrl($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasServerBaseUrl() => $_has(1);
   @$pb.TagNumber(2)
@@ -4216,10 +5296,15 @@ class ChainApiServersReply_ChainAPIServer extends $pb.GeneratedMessage {
 }
 
 class ChainApiServersReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ChainApiServersReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'), createEmptyInstance: create)
-    ..pc<ChainApiServersReply_ChainAPIServer>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'servers', $pb.PbFieldType.PM, subBuilder: ChainApiServersReply_ChainAPIServer.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ChainApiServersReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'breez'),
+      createEmptyInstance: create)
+    ..pc<ChainApiServersReply_ChainAPIServer>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'servers', $pb.PbFieldType.PM,
+        subBuilder: ChainApiServersReply_ChainAPIServer.create)
+    ..hasRequiredFields = false;
 
   ChainApiServersReply._() : super();
   factory ChainApiServersReply({
@@ -4231,28 +5316,32 @@ class ChainApiServersReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ChainApiServersReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ChainApiServersReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ChainApiServersReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ChainApiServersReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ChainApiServersReply clone() => ChainApiServersReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ChainApiServersReply copyWith(void Function(ChainApiServersReply) updates) => super.copyWith((message) => updates(message as ChainApiServersReply)) as ChainApiServersReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ChainApiServersReply copyWith(void Function(ChainApiServersReply) updates) =>
+      super.copyWith((message) => updates(message as ChainApiServersReply))
+          as ChainApiServersReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ChainApiServersReply create() => ChainApiServersReply._();
   ChainApiServersReply createEmptyInstance() => create();
   static $pb.PbList<ChainApiServersReply> createRepeated() => $pb.PbList<ChainApiServersReply>();
   @$core.pragma('dart2js:noInline')
-  static ChainApiServersReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChainApiServersReply>(create);
+  static ChainApiServersReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChainApiServersReply>(create);
   static ChainApiServersReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<ChainApiServersReply_ChainAPIServer> get servers => $_getList(0);
 }
-

--- a/lib/services/breez_server/generated/breez.pbenum.dart
+++ b/lib/services/breez_server/generated/breez.pbenum.dart
@@ -10,13 +10,18 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class GetSwapPaymentReply_SwapError extends $pb.ProtobufEnum {
-  static const GetSwapPaymentReply_SwapError NO_ERROR = GetSwapPaymentReply_SwapError._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'NO_ERROR');
-  static const GetSwapPaymentReply_SwapError FUNDS_EXCEED_LIMIT = GetSwapPaymentReply_SwapError._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'FUNDS_EXCEED_LIMIT');
-  static const GetSwapPaymentReply_SwapError TX_TOO_SMALL = GetSwapPaymentReply_SwapError._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'TX_TOO_SMALL');
-  static const GetSwapPaymentReply_SwapError INVOICE_AMOUNT_MISMATCH = GetSwapPaymentReply_SwapError._(3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'INVOICE_AMOUNT_MISMATCH');
-  static const GetSwapPaymentReply_SwapError SWAP_EXPIRED = GetSwapPaymentReply_SwapError._(4, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'SWAP_EXPIRED');
+  static const GetSwapPaymentReply_SwapError NO_ERROR = GetSwapPaymentReply_SwapError._(
+      0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'NO_ERROR');
+  static const GetSwapPaymentReply_SwapError FUNDS_EXCEED_LIMIT = GetSwapPaymentReply_SwapError._(
+      1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'FUNDS_EXCEED_LIMIT');
+  static const GetSwapPaymentReply_SwapError TX_TOO_SMALL = GetSwapPaymentReply_SwapError._(
+      2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'TX_TOO_SMALL');
+  static const GetSwapPaymentReply_SwapError INVOICE_AMOUNT_MISMATCH = GetSwapPaymentReply_SwapError._(
+      3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'INVOICE_AMOUNT_MISMATCH');
+  static const GetSwapPaymentReply_SwapError SWAP_EXPIRED = GetSwapPaymentReply_SwapError._(
+      4, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'SWAP_EXPIRED');
 
-  static const $core.List<GetSwapPaymentReply_SwapError> values = <GetSwapPaymentReply_SwapError> [
+  static const $core.List<GetSwapPaymentReply_SwapError> values = <GetSwapPaymentReply_SwapError>[
     NO_ERROR,
     FUNDS_EXCEED_LIMIT,
     TX_TOO_SMALL,
@@ -24,56 +29,69 @@ class GetSwapPaymentReply_SwapError extends $pb.ProtobufEnum {
     SWAP_EXPIRED,
   ];
 
-  static final $core.Map<$core.int, GetSwapPaymentReply_SwapError> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static final $core.Map<$core.int, GetSwapPaymentReply_SwapError> _byValue =
+      $pb.ProtobufEnum.initByValue(values);
   static GetSwapPaymentReply_SwapError? valueOf($core.int value) => _byValue[value];
 
   const GetSwapPaymentReply_SwapError._($core.int v, $core.String n) : super(v, n);
 }
 
 class JoinCTPSessionRequest_PartyType extends $pb.ProtobufEnum {
-  static const JoinCTPSessionRequest_PartyType PAYER = JoinCTPSessionRequest_PartyType._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PAYER');
-  static const JoinCTPSessionRequest_PartyType PAYEE = JoinCTPSessionRequest_PartyType._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PAYEE');
+  static const JoinCTPSessionRequest_PartyType PAYER = JoinCTPSessionRequest_PartyType._(
+      0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PAYER');
+  static const JoinCTPSessionRequest_PartyType PAYEE = JoinCTPSessionRequest_PartyType._(
+      1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PAYEE');
 
-  static const $core.List<JoinCTPSessionRequest_PartyType> values = <JoinCTPSessionRequest_PartyType> [
+  static const $core.List<JoinCTPSessionRequest_PartyType> values = <JoinCTPSessionRequest_PartyType>[
     PAYER,
     PAYEE,
   ];
 
-  static final $core.Map<$core.int, JoinCTPSessionRequest_PartyType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static final $core.Map<$core.int, JoinCTPSessionRequest_PartyType> _byValue =
+      $pb.ProtobufEnum.initByValue(values);
   static JoinCTPSessionRequest_PartyType? valueOf($core.int value) => _byValue[value];
 
   const JoinCTPSessionRequest_PartyType._($core.int v, $core.String n) : super(v, n);
 }
 
 class RegisterTransactionConfirmationRequest_NotificationType extends $pb.ProtobufEnum {
-  static const RegisterTransactionConfirmationRequest_NotificationType READY_RECEIVE_PAYMENT = RegisterTransactionConfirmationRequest_NotificationType._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'READY_RECEIVE_PAYMENT');
-  static const RegisterTransactionConfirmationRequest_NotificationType CHANNEL_OPENED = RegisterTransactionConfirmationRequest_NotificationType._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'CHANNEL_OPENED');
+  static const RegisterTransactionConfirmationRequest_NotificationType READY_RECEIVE_PAYMENT =
+      RegisterTransactionConfirmationRequest_NotificationType._(
+          0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'READY_RECEIVE_PAYMENT');
+  static const RegisterTransactionConfirmationRequest_NotificationType CHANNEL_OPENED =
+      RegisterTransactionConfirmationRequest_NotificationType._(
+          1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'CHANNEL_OPENED');
 
-  static const $core.List<RegisterTransactionConfirmationRequest_NotificationType> values = <RegisterTransactionConfirmationRequest_NotificationType> [
+  static const $core.List<RegisterTransactionConfirmationRequest_NotificationType> values =
+      <RegisterTransactionConfirmationRequest_NotificationType>[
     READY_RECEIVE_PAYMENT,
     CHANNEL_OPENED,
   ];
 
-  static final $core.Map<$core.int, RegisterTransactionConfirmationRequest_NotificationType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static final $core.Map<$core.int, RegisterTransactionConfirmationRequest_NotificationType> _byValue =
+      $pb.ProtobufEnum.initByValue(values);
   static RegisterTransactionConfirmationRequest_NotificationType? valueOf($core.int value) => _byValue[value];
 
   const RegisterTransactionConfirmationRequest_NotificationType._($core.int v, $core.String n) : super(v, n);
 }
 
 class BreezStatusReply_BreezStatus extends $pb.ProtobufEnum {
-  static const BreezStatusReply_BreezStatus OPERATIONAL = BreezStatusReply_BreezStatus._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'OPERATIONAL');
-  static const BreezStatusReply_BreezStatus MAINTENANCE = BreezStatusReply_BreezStatus._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'MAINTENANCE');
-  static const BreezStatusReply_BreezStatus SERVICE_DISRUPTION = BreezStatusReply_BreezStatus._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'SERVICE_DISRUPTION');
+  static const BreezStatusReply_BreezStatus OPERATIONAL = BreezStatusReply_BreezStatus._(
+      0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'OPERATIONAL');
+  static const BreezStatusReply_BreezStatus MAINTENANCE = BreezStatusReply_BreezStatus._(
+      1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'MAINTENANCE');
+  static const BreezStatusReply_BreezStatus SERVICE_DISRUPTION = BreezStatusReply_BreezStatus._(
+      2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'SERVICE_DISRUPTION');
 
-  static const $core.List<BreezStatusReply_BreezStatus> values = <BreezStatusReply_BreezStatus> [
+  static const $core.List<BreezStatusReply_BreezStatus> values = <BreezStatusReply_BreezStatus>[
     OPERATIONAL,
     MAINTENANCE,
     SERVICE_DISRUPTION,
   ];
 
-  static final $core.Map<$core.int, BreezStatusReply_BreezStatus> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static final $core.Map<$core.int, BreezStatusReply_BreezStatus> _byValue =
+      $pb.ProtobufEnum.initByValue(values);
   static BreezStatusReply_BreezStatus? valueOf($core.int value) => _byValue[value];
 
   const BreezStatusReply_BreezStatus._($core.int v, $core.String n) : super(v, n);
 }
-

--- a/lib/services/breez_server/generated/breez.pbgrpc.dart
+++ b/lib/services/breez_server/generated/breez.pbgrpc.dart
@@ -14,30 +14,25 @@ import 'breez.pb.dart' as $0;
 export 'breez.pb.dart';
 
 class InvoicerClient extends $grpc.Client {
-  static final _$registerDevice =
-      $grpc.ClientMethod<$0.RegisterRequest, $0.RegisterReply>(
-          '/breez.Invoicer/RegisterDevice',
-          ($0.RegisterRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.RegisterReply.fromBuffer(value));
-  static final _$sendInvoice =
-      $grpc.ClientMethod<$0.PaymentRequest, $0.InvoiceReply>(
-          '/breez.Invoicer/SendInvoice',
-          ($0.PaymentRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.InvoiceReply.fromBuffer(value));
+  static final _$registerDevice = $grpc.ClientMethod<$0.RegisterRequest, $0.RegisterReply>(
+      '/breez.Invoicer/RegisterDevice',
+      ($0.RegisterRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.RegisterReply.fromBuffer(value));
+  static final _$sendInvoice = $grpc.ClientMethod<$0.PaymentRequest, $0.InvoiceReply>(
+      '/breez.Invoicer/SendInvoice',
+      ($0.PaymentRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.InvoiceReply.fromBuffer(value));
 
   InvoicerClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions? options,
-      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
+      {$grpc.CallOptions? options, $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
-  $grpc.ResponseFuture<$0.RegisterReply> registerDevice(
-      $0.RegisterRequest request,
+  $grpc.ResponseFuture<$0.RegisterReply> registerDevice($0.RegisterRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$registerDevice, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.InvoiceReply> sendInvoice($0.PaymentRequest request,
-      {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.InvoiceReply> sendInvoice($0.PaymentRequest request, {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$sendInvoice, request, options: options);
   }
 }
@@ -72,10 +67,8 @@ abstract class InvoicerServiceBase extends $grpc.Service {
     return sendInvoice(call, await request);
   }
 
-  $async.Future<$0.RegisterReply> registerDevice(
-      $grpc.ServiceCall call, $0.RegisterRequest request);
-  $async.Future<$0.InvoiceReply> sendInvoice(
-      $grpc.ServiceCall call, $0.PaymentRequest request);
+  $async.Future<$0.RegisterReply> registerDevice($grpc.ServiceCall call, $0.RegisterRequest request);
+  $async.Future<$0.InvoiceReply> sendInvoice($grpc.ServiceCall call, $0.PaymentRequest request);
 }
 
 class CardOrdererClient extends $grpc.Client {
@@ -85,12 +78,10 @@ class CardOrdererClient extends $grpc.Client {
       ($core.List<$core.int> value) => $0.OrderReply.fromBuffer(value));
 
   CardOrdererClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions? options,
-      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
+      {$grpc.CallOptions? options, $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
-  $grpc.ResponseFuture<$0.OrderReply> order($0.OrderRequest request,
-      {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.OrderReply> order($0.OrderRequest request, {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$order, request, options: options);
   }
 }
@@ -113,36 +104,29 @@ abstract class CardOrdererServiceBase extends $grpc.Service {
     return order(call, await request);
   }
 
-  $async.Future<$0.OrderReply> order(
-      $grpc.ServiceCall call, $0.OrderRequest request);
+  $async.Future<$0.OrderReply> order($grpc.ServiceCall call, $0.OrderRequest request);
 }
 
 class PosClient extends $grpc.Client {
-  static final _$registerDevice =
-      $grpc.ClientMethod<$0.RegisterRequest, $0.RegisterReply>(
-          '/breez.Pos/RegisterDevice',
-          ($0.RegisterRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.RegisterReply.fromBuffer(value));
-  static final _$uploadLogo =
-      $grpc.ClientMethod<$0.UploadFileRequest, $0.UploadFileReply>(
-          '/breez.Pos/UploadLogo',
-          ($0.UploadFileRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.UploadFileReply.fromBuffer(value));
+  static final _$registerDevice = $grpc.ClientMethod<$0.RegisterRequest, $0.RegisterReply>(
+      '/breez.Pos/RegisterDevice',
+      ($0.RegisterRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.RegisterReply.fromBuffer(value));
+  static final _$uploadLogo = $grpc.ClientMethod<$0.UploadFileRequest, $0.UploadFileReply>(
+      '/breez.Pos/UploadLogo',
+      ($0.UploadFileRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.UploadFileReply.fromBuffer(value));
 
   PosClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions? options,
-      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
+      {$grpc.CallOptions? options, $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
-  $grpc.ResponseFuture<$0.RegisterReply> registerDevice(
-      $0.RegisterRequest request,
+  $grpc.ResponseFuture<$0.RegisterReply> registerDevice($0.RegisterRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$registerDevice, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.UploadFileReply> uploadLogo(
-      $0.UploadFileRequest request,
+  $grpc.ResponseFuture<$0.UploadFileReply> uploadLogo($0.UploadFileRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$uploadLogo, request, options: options);
   }
@@ -173,15 +157,13 @@ abstract class PosServiceBase extends $grpc.Service {
     return registerDevice(call, await request);
   }
 
-  $async.Future<$0.UploadFileReply> uploadLogo_Pre($grpc.ServiceCall call,
-      $async.Future<$0.UploadFileRequest> request) async {
+  $async.Future<$0.UploadFileReply> uploadLogo_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.UploadFileRequest> request) async {
     return uploadLogo(call, await request);
   }
 
-  $async.Future<$0.RegisterReply> registerDevice(
-      $grpc.ServiceCall call, $0.RegisterRequest request);
-  $async.Future<$0.UploadFileReply> uploadLogo(
-      $grpc.ServiceCall call, $0.UploadFileRequest request);
+  $async.Future<$0.RegisterReply> registerDevice($grpc.ServiceCall call, $0.RegisterRequest request);
+  $async.Future<$0.UploadFileReply> uploadLogo($grpc.ServiceCall call, $0.UploadFileRequest request);
 }
 
 class InformationClient extends $grpc.Client {
@@ -193,54 +175,42 @@ class InformationClient extends $grpc.Client {
       '/breez.Information/Rates',
       ($0.RatesRequest value) => value.writeToBuffer(),
       ($core.List<$core.int> value) => $0.RatesReply.fromBuffer(value));
-  static final _$breezAppVersions =
-      $grpc.ClientMethod<$0.BreezAppVersionsRequest, $0.BreezAppVersionsReply>(
-          '/breez.Information/BreezAppVersions',
-          ($0.BreezAppVersionsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.BreezAppVersionsReply.fromBuffer(value));
-  static final _$receiverInfo =
-      $grpc.ClientMethod<$0.ReceiverInfoRequest, $0.ReceiverInfoReply>(
-          '/breez.Information/ReceiverInfo',
-          ($0.ReceiverInfoRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.ReceiverInfoReply.fromBuffer(value));
-  static final _$chainApiServers =
-      $grpc.ClientMethod<$0.ChainApiServersRequest, $0.ChainApiServersReply>(
-          '/breez.Information/ChainApiServers',
-          ($0.ChainApiServersRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.ChainApiServersReply.fromBuffer(value));
+  static final _$breezAppVersions = $grpc.ClientMethod<$0.BreezAppVersionsRequest, $0.BreezAppVersionsReply>(
+      '/breez.Information/BreezAppVersions',
+      ($0.BreezAppVersionsRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.BreezAppVersionsReply.fromBuffer(value));
+  static final _$receiverInfo = $grpc.ClientMethod<$0.ReceiverInfoRequest, $0.ReceiverInfoReply>(
+      '/breez.Information/ReceiverInfo',
+      ($0.ReceiverInfoRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.ReceiverInfoReply.fromBuffer(value));
+  static final _$chainApiServers = $grpc.ClientMethod<$0.ChainApiServersRequest, $0.ChainApiServersReply>(
+      '/breez.Information/ChainApiServers',
+      ($0.ChainApiServersRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.ChainApiServersReply.fromBuffer(value));
 
   InformationClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions? options,
-      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
+      {$grpc.CallOptions? options, $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
-  $grpc.ResponseFuture<$0.PingReply> ping($0.PingRequest request,
-      {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.PingReply> ping($0.PingRequest request, {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$ping, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.RatesReply> rates($0.RatesRequest request,
-      {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.RatesReply> rates($0.RatesRequest request, {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$rates, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.BreezAppVersionsReply> breezAppVersions(
-      $0.BreezAppVersionsRequest request,
+  $grpc.ResponseFuture<$0.BreezAppVersionsReply> breezAppVersions($0.BreezAppVersionsRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$breezAppVersions, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.ReceiverInfoReply> receiverInfo(
-      $0.ReceiverInfoRequest request,
+  $grpc.ResponseFuture<$0.ReceiverInfoReply> receiverInfo($0.ReceiverInfoRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$receiverInfo, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.ChainApiServersReply> chainApiServers(
-      $0.ChainApiServersRequest request,
+  $grpc.ResponseFuture<$0.ChainApiServersReply> chainApiServers($0.ChainApiServersRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$chainApiServers, request, options: options);
   }
@@ -264,37 +234,30 @@ abstract class InformationServiceBase extends $grpc.Service {
         false,
         ($core.List<$core.int> value) => $0.RatesRequest.fromBuffer(value),
         ($0.RatesReply value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<$0.BreezAppVersionsRequest,
-            $0.BreezAppVersionsReply>(
+    $addMethod($grpc.ServiceMethod<$0.BreezAppVersionsRequest, $0.BreezAppVersionsReply>(
         'BreezAppVersions',
         breezAppVersions_Pre,
         false,
         false,
-        ($core.List<$core.int> value) =>
-            $0.BreezAppVersionsRequest.fromBuffer(value),
+        ($core.List<$core.int> value) => $0.BreezAppVersionsRequest.fromBuffer(value),
         ($0.BreezAppVersionsReply value) => value.writeToBuffer()));
-    $addMethod(
-        $grpc.ServiceMethod<$0.ReceiverInfoRequest, $0.ReceiverInfoReply>(
-            'ReceiverInfo',
-            receiverInfo_Pre,
-            false,
-            false,
-            ($core.List<$core.int> value) =>
-                $0.ReceiverInfoRequest.fromBuffer(value),
-            ($0.ReceiverInfoReply value) => value.writeToBuffer()));
-    $addMethod(
-        $grpc.ServiceMethod<$0.ChainApiServersRequest, $0.ChainApiServersReply>(
-            'ChainApiServers',
-            chainApiServers_Pre,
-            false,
-            false,
-            ($core.List<$core.int> value) =>
-                $0.ChainApiServersRequest.fromBuffer(value),
-            ($0.ChainApiServersReply value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.ReceiverInfoRequest, $0.ReceiverInfoReply>(
+        'ReceiverInfo',
+        receiverInfo_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.ReceiverInfoRequest.fromBuffer(value),
+        ($0.ReceiverInfoReply value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.ChainApiServersRequest, $0.ChainApiServersReply>(
+        'ChainApiServers',
+        chainApiServers_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.ChainApiServersRequest.fromBuffer(value),
+        ($0.ChainApiServersReply value) => value.writeToBuffer()));
   }
 
-  $async.Future<$0.PingReply> ping_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.PingRequest> request) async {
+  $async.Future<$0.PingReply> ping_Pre($grpc.ServiceCall call, $async.Future<$0.PingRequest> request) async {
     return ping(call, await request);
   }
 
@@ -304,71 +267,57 @@ abstract class InformationServiceBase extends $grpc.Service {
   }
 
   $async.Future<$0.BreezAppVersionsReply> breezAppVersions_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.BreezAppVersionsRequest> request) async {
+      $grpc.ServiceCall call, $async.Future<$0.BreezAppVersionsRequest> request) async {
     return breezAppVersions(call, await request);
   }
 
-  $async.Future<$0.ReceiverInfoReply> receiverInfo_Pre($grpc.ServiceCall call,
-      $async.Future<$0.ReceiverInfoRequest> request) async {
+  $async.Future<$0.ReceiverInfoReply> receiverInfo_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.ReceiverInfoRequest> request) async {
     return receiverInfo(call, await request);
   }
 
   $async.Future<$0.ChainApiServersReply> chainApiServers_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.ChainApiServersRequest> request) async {
+      $grpc.ServiceCall call, $async.Future<$0.ChainApiServersRequest> request) async {
     return chainApiServers(call, await request);
   }
 
-  $async.Future<$0.PingReply> ping(
-      $grpc.ServiceCall call, $0.PingRequest request);
-  $async.Future<$0.RatesReply> rates(
-      $grpc.ServiceCall call, $0.RatesRequest request);
+  $async.Future<$0.PingReply> ping($grpc.ServiceCall call, $0.PingRequest request);
+  $async.Future<$0.RatesReply> rates($grpc.ServiceCall call, $0.RatesRequest request);
   $async.Future<$0.BreezAppVersionsReply> breezAppVersions(
       $grpc.ServiceCall call, $0.BreezAppVersionsRequest request);
-  $async.Future<$0.ReceiverInfoReply> receiverInfo(
-      $grpc.ServiceCall call, $0.ReceiverInfoRequest request);
+  $async.Future<$0.ReceiverInfoReply> receiverInfo($grpc.ServiceCall call, $0.ReceiverInfoRequest request);
   $async.Future<$0.ChainApiServersReply> chainApiServers(
       $grpc.ServiceCall call, $0.ChainApiServersRequest request);
 }
 
 class ChannelOpenerClient extends $grpc.Client {
-  static final _$lSPList =
-      $grpc.ClientMethod<$0.LSPListRequest, $0.LSPListReply>(
-          '/breez.ChannelOpener/LSPList',
-          ($0.LSPListRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.LSPListReply.fromBuffer(value));
-  static final _$registerPayment =
-      $grpc.ClientMethod<$0.RegisterPaymentRequest, $0.RegisterPaymentReply>(
-          '/breez.ChannelOpener/RegisterPayment',
-          ($0.RegisterPaymentRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.RegisterPaymentReply.fromBuffer(value));
-  static final _$checkChannels =
-      $grpc.ClientMethod<$0.CheckChannelsRequest, $0.CheckChannelsReply>(
-          '/breez.ChannelOpener/CheckChannels',
-          ($0.CheckChannelsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.CheckChannelsReply.fromBuffer(value));
+  static final _$lSPList = $grpc.ClientMethod<$0.LSPListRequest, $0.LSPListReply>(
+      '/breez.ChannelOpener/LSPList',
+      ($0.LSPListRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.LSPListReply.fromBuffer(value));
+  static final _$registerPayment = $grpc.ClientMethod<$0.RegisterPaymentRequest, $0.RegisterPaymentReply>(
+      '/breez.ChannelOpener/RegisterPayment',
+      ($0.RegisterPaymentRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.RegisterPaymentReply.fromBuffer(value));
+  static final _$checkChannels = $grpc.ClientMethod<$0.CheckChannelsRequest, $0.CheckChannelsReply>(
+      '/breez.ChannelOpener/CheckChannels',
+      ($0.CheckChannelsRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.CheckChannelsReply.fromBuffer(value));
 
   ChannelOpenerClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions? options,
-      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
+      {$grpc.CallOptions? options, $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
-  $grpc.ResponseFuture<$0.LSPListReply> lSPList($0.LSPListRequest request,
-      {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.LSPListReply> lSPList($0.LSPListRequest request, {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$lSPList, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.RegisterPaymentReply> registerPayment(
-      $0.RegisterPaymentRequest request,
+  $grpc.ResponseFuture<$0.RegisterPaymentReply> registerPayment($0.RegisterPaymentRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$registerPayment, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.CheckChannelsReply> checkChannels(
-      $0.CheckChannelsRequest request,
+  $grpc.ResponseFuture<$0.CheckChannelsReply> checkChannels($0.CheckChannelsRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$checkChannels, request, options: options);
   }
@@ -385,24 +334,20 @@ abstract class ChannelOpenerServiceBase extends $grpc.Service {
         false,
         ($core.List<$core.int> value) => $0.LSPListRequest.fromBuffer(value),
         ($0.LSPListReply value) => value.writeToBuffer()));
-    $addMethod(
-        $grpc.ServiceMethod<$0.RegisterPaymentRequest, $0.RegisterPaymentReply>(
-            'RegisterPayment',
-            registerPayment_Pre,
-            false,
-            false,
-            ($core.List<$core.int> value) =>
-                $0.RegisterPaymentRequest.fromBuffer(value),
-            ($0.RegisterPaymentReply value) => value.writeToBuffer()));
-    $addMethod(
-        $grpc.ServiceMethod<$0.CheckChannelsRequest, $0.CheckChannelsReply>(
-            'CheckChannels',
-            checkChannels_Pre,
-            false,
-            false,
-            ($core.List<$core.int> value) =>
-                $0.CheckChannelsRequest.fromBuffer(value),
-            ($0.CheckChannelsReply value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.RegisterPaymentRequest, $0.RegisterPaymentReply>(
+        'RegisterPayment',
+        registerPayment_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.RegisterPaymentRequest.fromBuffer(value),
+        ($0.RegisterPaymentReply value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.CheckChannelsRequest, $0.CheckChannelsReply>(
+        'CheckChannels',
+        checkChannels_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.CheckChannelsRequest.fromBuffer(value),
+        ($0.CheckChannelsReply value) => value.writeToBuffer()));
   }
 
   $async.Future<$0.LSPListReply> lSPList_Pre(
@@ -411,117 +356,92 @@ abstract class ChannelOpenerServiceBase extends $grpc.Service {
   }
 
   $async.Future<$0.RegisterPaymentReply> registerPayment_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.RegisterPaymentRequest> request) async {
+      $grpc.ServiceCall call, $async.Future<$0.RegisterPaymentRequest> request) async {
     return registerPayment(call, await request);
   }
 
-  $async.Future<$0.CheckChannelsReply> checkChannels_Pre($grpc.ServiceCall call,
-      $async.Future<$0.CheckChannelsRequest> request) async {
+  $async.Future<$0.CheckChannelsReply> checkChannels_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.CheckChannelsRequest> request) async {
     return checkChannels(call, await request);
   }
 
-  $async.Future<$0.LSPListReply> lSPList(
-      $grpc.ServiceCall call, $0.LSPListRequest request);
+  $async.Future<$0.LSPListReply> lSPList($grpc.ServiceCall call, $0.LSPListRequest request);
   $async.Future<$0.RegisterPaymentReply> registerPayment(
       $grpc.ServiceCall call, $0.RegisterPaymentRequest request);
-  $async.Future<$0.CheckChannelsReply> checkChannels(
-      $grpc.ServiceCall call, $0.CheckChannelsRequest request);
+  $async.Future<$0.CheckChannelsReply> checkChannels($grpc.ServiceCall call, $0.CheckChannelsRequest request);
 }
 
 class FundManagerClient extends $grpc.Client {
-  static final _$updateChannelPolicy = $grpc.ClientMethod<
-          $0.UpdateChannelPolicyRequest, $0.UpdateChannelPolicyReply>(
-      '/breez.FundManager/UpdateChannelPolicy',
-      ($0.UpdateChannelPolicyRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.UpdateChannelPolicyReply.fromBuffer(value));
-  static final _$addFundInit =
-      $grpc.ClientMethod<$0.AddFundInitRequest, $0.AddFundInitReply>(
-          '/breez.FundManager/AddFundInit',
-          ($0.AddFundInitRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.AddFundInitReply.fromBuffer(value));
-  static final _$addFundStatus =
-      $grpc.ClientMethod<$0.AddFundStatusRequest, $0.AddFundStatusReply>(
-          '/breez.FundManager/AddFundStatus',
-          ($0.AddFundStatusRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.AddFundStatusReply.fromBuffer(value));
-  static final _$removeFund =
-      $grpc.ClientMethod<$0.RemoveFundRequest, $0.RemoveFundReply>(
-          '/breez.FundManager/RemoveFund',
-          ($0.RemoveFundRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.RemoveFundReply.fromBuffer(value));
-  static final _$redeemRemovedFunds = $grpc.ClientMethod<
-          $0.RedeemRemovedFundsRequest, $0.RedeemRemovedFundsReply>(
-      '/breez.FundManager/RedeemRemovedFunds',
-      ($0.RedeemRemovedFundsRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.RedeemRemovedFundsReply.fromBuffer(value));
-  static final _$getSwapPayment =
-      $grpc.ClientMethod<$0.GetSwapPaymentRequest, $0.GetSwapPaymentReply>(
-          '/breez.FundManager/GetSwapPayment',
-          ($0.GetSwapPaymentRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.GetSwapPaymentReply.fromBuffer(value));
+  static final _$updateChannelPolicy =
+      $grpc.ClientMethod<$0.UpdateChannelPolicyRequest, $0.UpdateChannelPolicyReply>(
+          '/breez.FundManager/UpdateChannelPolicy',
+          ($0.UpdateChannelPolicyRequest value) => value.writeToBuffer(),
+          ($core.List<$core.int> value) => $0.UpdateChannelPolicyReply.fromBuffer(value));
+  static final _$addFundInit = $grpc.ClientMethod<$0.AddFundInitRequest, $0.AddFundInitReply>(
+      '/breez.FundManager/AddFundInit',
+      ($0.AddFundInitRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.AddFundInitReply.fromBuffer(value));
+  static final _$addFundStatus = $grpc.ClientMethod<$0.AddFundStatusRequest, $0.AddFundStatusReply>(
+      '/breez.FundManager/AddFundStatus',
+      ($0.AddFundStatusRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.AddFundStatusReply.fromBuffer(value));
+  static final _$removeFund = $grpc.ClientMethod<$0.RemoveFundRequest, $0.RemoveFundReply>(
+      '/breez.FundManager/RemoveFund',
+      ($0.RemoveFundRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.RemoveFundReply.fromBuffer(value));
+  static final _$redeemRemovedFunds =
+      $grpc.ClientMethod<$0.RedeemRemovedFundsRequest, $0.RedeemRemovedFundsReply>(
+          '/breez.FundManager/RedeemRemovedFunds',
+          ($0.RedeemRemovedFundsRequest value) => value.writeToBuffer(),
+          ($core.List<$core.int> value) => $0.RedeemRemovedFundsReply.fromBuffer(value));
+  static final _$getSwapPayment = $grpc.ClientMethod<$0.GetSwapPaymentRequest, $0.GetSwapPaymentReply>(
+      '/breez.FundManager/GetSwapPayment',
+      ($0.GetSwapPaymentRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.GetSwapPaymentReply.fromBuffer(value));
   static final _$registerTransactionConfirmation = $grpc.ClientMethod<
-          $0.RegisterTransactionConfirmationRequest,
-          $0.RegisterTransactionConfirmationResponse>(
+          $0.RegisterTransactionConfirmationRequest, $0.RegisterTransactionConfirmationResponse>(
       '/breez.FundManager/RegisterTransactionConfirmation',
-      ($0.RegisterTransactionConfirmationRequest value) =>
-          value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.RegisterTransactionConfirmationResponse.fromBuffer(value));
+      ($0.RegisterTransactionConfirmationRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.RegisterTransactionConfirmationResponse.fromBuffer(value));
 
   FundManagerClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions? options,
-      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
+      {$grpc.CallOptions? options, $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
-  $grpc.ResponseFuture<$0.UpdateChannelPolicyReply> updateChannelPolicy(
-      $0.UpdateChannelPolicyRequest request,
+  $grpc.ResponseFuture<$0.UpdateChannelPolicyReply> updateChannelPolicy($0.UpdateChannelPolicyRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$updateChannelPolicy, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.AddFundInitReply> addFundInit(
-      $0.AddFundInitRequest request,
+  $grpc.ResponseFuture<$0.AddFundInitReply> addFundInit($0.AddFundInitRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$addFundInit, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.AddFundStatusReply> addFundStatus(
-      $0.AddFundStatusRequest request,
+  $grpc.ResponseFuture<$0.AddFundStatusReply> addFundStatus($0.AddFundStatusRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$addFundStatus, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.RemoveFundReply> removeFund(
-      $0.RemoveFundRequest request,
+  $grpc.ResponseFuture<$0.RemoveFundReply> removeFund($0.RemoveFundRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$removeFund, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.RedeemRemovedFundsReply> redeemRemovedFunds(
-      $0.RedeemRemovedFundsRequest request,
+  $grpc.ResponseFuture<$0.RedeemRemovedFundsReply> redeemRemovedFunds($0.RedeemRemovedFundsRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$redeemRemovedFunds, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.GetSwapPaymentReply> getSwapPayment(
-      $0.GetSwapPaymentRequest request,
+  $grpc.ResponseFuture<$0.GetSwapPaymentReply> getSwapPayment($0.GetSwapPaymentRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$getSwapPayment, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.RegisterTransactionConfirmationResponse>
-      registerTransactionConfirmation(
-          $0.RegisterTransactionConfirmationRequest request,
-          {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$registerTransactionConfirmation, request,
-        options: options);
+  $grpc.ResponseFuture<$0.RegisterTransactionConfirmationResponse> registerTransactionConfirmation(
+      $0.RegisterTransactionConfirmationRequest request,
+      {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$registerTransactionConfirmation, request, options: options);
   }
 }
 
@@ -529,32 +449,27 @@ abstract class FundManagerServiceBase extends $grpc.Service {
   $core.String get $name => 'breez.FundManager';
 
   FundManagerServiceBase() {
-    $addMethod($grpc.ServiceMethod<$0.UpdateChannelPolicyRequest,
-            $0.UpdateChannelPolicyReply>(
+    $addMethod($grpc.ServiceMethod<$0.UpdateChannelPolicyRequest, $0.UpdateChannelPolicyReply>(
         'UpdateChannelPolicy',
         updateChannelPolicy_Pre,
         false,
         false,
-        ($core.List<$core.int> value) =>
-            $0.UpdateChannelPolicyRequest.fromBuffer(value),
+        ($core.List<$core.int> value) => $0.UpdateChannelPolicyRequest.fromBuffer(value),
         ($0.UpdateChannelPolicyReply value) => value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$0.AddFundInitRequest, $0.AddFundInitReply>(
         'AddFundInit',
         addFundInit_Pre,
         false,
         false,
-        ($core.List<$core.int> value) =>
-            $0.AddFundInitRequest.fromBuffer(value),
+        ($core.List<$core.int> value) => $0.AddFundInitRequest.fromBuffer(value),
         ($0.AddFundInitReply value) => value.writeToBuffer()));
-    $addMethod(
-        $grpc.ServiceMethod<$0.AddFundStatusRequest, $0.AddFundStatusReply>(
-            'AddFundStatus',
-            addFundStatus_Pre,
-            false,
-            false,
-            ($core.List<$core.int> value) =>
-                $0.AddFundStatusRequest.fromBuffer(value),
-            ($0.AddFundStatusReply value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.AddFundStatusRequest, $0.AddFundStatusReply>(
+        'AddFundStatus',
+        addFundStatus_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.AddFundStatusRequest.fromBuffer(value),
+        ($0.AddFundStatusReply value) => value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$0.RemoveFundRequest, $0.RemoveFundReply>(
         'RemoveFund',
         removeFund_Pre,
@@ -562,151 +477,122 @@ abstract class FundManagerServiceBase extends $grpc.Service {
         false,
         ($core.List<$core.int> value) => $0.RemoveFundRequest.fromBuffer(value),
         ($0.RemoveFundReply value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<$0.RedeemRemovedFundsRequest,
-            $0.RedeemRemovedFundsReply>(
+    $addMethod($grpc.ServiceMethod<$0.RedeemRemovedFundsRequest, $0.RedeemRemovedFundsReply>(
         'RedeemRemovedFunds',
         redeemRemovedFunds_Pre,
         false,
         false,
-        ($core.List<$core.int> value) =>
-            $0.RedeemRemovedFundsRequest.fromBuffer(value),
+        ($core.List<$core.int> value) => $0.RedeemRemovedFundsRequest.fromBuffer(value),
         ($0.RedeemRemovedFundsReply value) => value.writeToBuffer()));
-    $addMethod(
-        $grpc.ServiceMethod<$0.GetSwapPaymentRequest, $0.GetSwapPaymentReply>(
-            'GetSwapPayment',
-            getSwapPayment_Pre,
-            false,
-            false,
-            ($core.List<$core.int> value) =>
-                $0.GetSwapPaymentRequest.fromBuffer(value),
-            ($0.GetSwapPaymentReply value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.GetSwapPaymentRequest, $0.GetSwapPaymentReply>(
+        'GetSwapPayment',
+        getSwapPayment_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.GetSwapPaymentRequest.fromBuffer(value),
+        ($0.GetSwapPaymentReply value) => value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$0.RegisterTransactionConfirmationRequest,
             $0.RegisterTransactionConfirmationResponse>(
         'RegisterTransactionConfirmation',
         registerTransactionConfirmation_Pre,
         false,
         false,
-        ($core.List<$core.int> value) =>
-            $0.RegisterTransactionConfirmationRequest.fromBuffer(value),
-        ($0.RegisterTransactionConfirmationResponse value) =>
-            value.writeToBuffer()));
+        ($core.List<$core.int> value) => $0.RegisterTransactionConfirmationRequest.fromBuffer(value),
+        ($0.RegisterTransactionConfirmationResponse value) => value.writeToBuffer()));
   }
 
   $async.Future<$0.UpdateChannelPolicyReply> updateChannelPolicy_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.UpdateChannelPolicyRequest> request) async {
+      $grpc.ServiceCall call, $async.Future<$0.UpdateChannelPolicyRequest> request) async {
     return updateChannelPolicy(call, await request);
   }
 
-  $async.Future<$0.AddFundInitReply> addFundInit_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AddFundInitRequest> request) async {
+  $async.Future<$0.AddFundInitReply> addFundInit_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.AddFundInitRequest> request) async {
     return addFundInit(call, await request);
   }
 
-  $async.Future<$0.AddFundStatusReply> addFundStatus_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AddFundStatusRequest> request) async {
+  $async.Future<$0.AddFundStatusReply> addFundStatus_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.AddFundStatusRequest> request) async {
     return addFundStatus(call, await request);
   }
 
-  $async.Future<$0.RemoveFundReply> removeFund_Pre($grpc.ServiceCall call,
-      $async.Future<$0.RemoveFundRequest> request) async {
+  $async.Future<$0.RemoveFundReply> removeFund_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.RemoveFundRequest> request) async {
     return removeFund(call, await request);
   }
 
   $async.Future<$0.RedeemRemovedFundsReply> redeemRemovedFunds_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.RedeemRemovedFundsRequest> request) async {
+      $grpc.ServiceCall call, $async.Future<$0.RedeemRemovedFundsRequest> request) async {
     return redeemRemovedFunds(call, await request);
   }
 
   $async.Future<$0.GetSwapPaymentReply> getSwapPayment_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.GetSwapPaymentRequest> request) async {
+      $grpc.ServiceCall call, $async.Future<$0.GetSwapPaymentRequest> request) async {
     return getSwapPayment(call, await request);
   }
 
-  $async.Future<$0.RegisterTransactionConfirmationResponse>
-      registerTransactionConfirmation_Pre(
-          $grpc.ServiceCall call,
-          $async.Future<$0.RegisterTransactionConfirmationRequest>
-              request) async {
+  $async.Future<$0.RegisterTransactionConfirmationResponse> registerTransactionConfirmation_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.RegisterTransactionConfirmationRequest> request) async {
     return registerTransactionConfirmation(call, await request);
   }
 
   $async.Future<$0.UpdateChannelPolicyReply> updateChannelPolicy(
       $grpc.ServiceCall call, $0.UpdateChannelPolicyRequest request);
-  $async.Future<$0.AddFundInitReply> addFundInit(
-      $grpc.ServiceCall call, $0.AddFundInitRequest request);
-  $async.Future<$0.AddFundStatusReply> addFundStatus(
-      $grpc.ServiceCall call, $0.AddFundStatusRequest request);
-  $async.Future<$0.RemoveFundReply> removeFund(
-      $grpc.ServiceCall call, $0.RemoveFundRequest request);
+  $async.Future<$0.AddFundInitReply> addFundInit($grpc.ServiceCall call, $0.AddFundInitRequest request);
+  $async.Future<$0.AddFundStatusReply> addFundStatus($grpc.ServiceCall call, $0.AddFundStatusRequest request);
+  $async.Future<$0.RemoveFundReply> removeFund($grpc.ServiceCall call, $0.RemoveFundRequest request);
   $async.Future<$0.RedeemRemovedFundsReply> redeemRemovedFunds(
       $grpc.ServiceCall call, $0.RedeemRemovedFundsRequest request);
   $async.Future<$0.GetSwapPaymentReply> getSwapPayment(
       $grpc.ServiceCall call, $0.GetSwapPaymentRequest request);
-  $async.Future<$0.RegisterTransactionConfirmationResponse>
-      registerTransactionConfirmation($grpc.ServiceCall call,
-          $0.RegisterTransactionConfirmationRequest request);
+  $async.Future<$0.RegisterTransactionConfirmationResponse> registerTransactionConfirmation(
+      $grpc.ServiceCall call, $0.RegisterTransactionConfirmationRequest request);
 }
 
 class SwapperClient extends $grpc.Client {
-  static final _$addFundInit =
-      $grpc.ClientMethod<$0.AddFundInitRequest, $0.AddFundInitReply>(
-          '/breez.Swapper/AddFundInit',
-          ($0.AddFundInitRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.AddFundInitReply.fromBuffer(value));
-  static final _$addFundStatus =
-      $grpc.ClientMethod<$0.AddFundStatusRequest, $0.AddFundStatusReply>(
-          '/breez.Swapper/AddFundStatus',
-          ($0.AddFundStatusRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.AddFundStatusReply.fromBuffer(value));
-  static final _$getSwapPayment =
-      $grpc.ClientMethod<$0.GetSwapPaymentRequest, $0.GetSwapPaymentReply>(
-          '/breez.Swapper/GetSwapPayment',
-          ($0.GetSwapPaymentRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.GetSwapPaymentReply.fromBuffer(value));
-  static final _$redeemSwapPayment = $grpc.ClientMethod<
-          $0.RedeemSwapPaymentRequest, $0.RedeemSwapPaymentReply>(
-      '/breez.Swapper/RedeemSwapPayment',
-      ($0.RedeemSwapPaymentRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.RedeemSwapPaymentReply.fromBuffer(value));
-  static final _$getReverseRoutingNode = $grpc.ClientMethod<
-          $0.GetReverseRoutingNodeRequest, $0.GetReverseRoutingNodeReply>(
-      '/breez.Swapper/GetReverseRoutingNode',
-      ($0.GetReverseRoutingNodeRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.GetReverseRoutingNodeReply.fromBuffer(value));
+  static final _$addFundInit = $grpc.ClientMethod<$0.AddFundInitRequest, $0.AddFundInitReply>(
+      '/breez.Swapper/AddFundInit',
+      ($0.AddFundInitRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.AddFundInitReply.fromBuffer(value));
+  static final _$addFundStatus = $grpc.ClientMethod<$0.AddFundStatusRequest, $0.AddFundStatusReply>(
+      '/breez.Swapper/AddFundStatus',
+      ($0.AddFundStatusRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.AddFundStatusReply.fromBuffer(value));
+  static final _$getSwapPayment = $grpc.ClientMethod<$0.GetSwapPaymentRequest, $0.GetSwapPaymentReply>(
+      '/breez.Swapper/GetSwapPayment',
+      ($0.GetSwapPaymentRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.GetSwapPaymentReply.fromBuffer(value));
+  static final _$redeemSwapPayment =
+      $grpc.ClientMethod<$0.RedeemSwapPaymentRequest, $0.RedeemSwapPaymentReply>(
+          '/breez.Swapper/RedeemSwapPayment',
+          ($0.RedeemSwapPaymentRequest value) => value.writeToBuffer(),
+          ($core.List<$core.int> value) => $0.RedeemSwapPaymentReply.fromBuffer(value));
+  static final _$getReverseRoutingNode =
+      $grpc.ClientMethod<$0.GetReverseRoutingNodeRequest, $0.GetReverseRoutingNodeReply>(
+          '/breez.Swapper/GetReverseRoutingNode',
+          ($0.GetReverseRoutingNodeRequest value) => value.writeToBuffer(),
+          ($core.List<$core.int> value) => $0.GetReverseRoutingNodeReply.fromBuffer(value));
 
   SwapperClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions? options,
-      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
+      {$grpc.CallOptions? options, $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
-  $grpc.ResponseFuture<$0.AddFundInitReply> addFundInit(
-      $0.AddFundInitRequest request,
+  $grpc.ResponseFuture<$0.AddFundInitReply> addFundInit($0.AddFundInitRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$addFundInit, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.AddFundStatusReply> addFundStatus(
-      $0.AddFundStatusRequest request,
+  $grpc.ResponseFuture<$0.AddFundStatusReply> addFundStatus($0.AddFundStatusRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$addFundStatus, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.GetSwapPaymentReply> getSwapPayment(
-      $0.GetSwapPaymentRequest request,
+  $grpc.ResponseFuture<$0.GetSwapPaymentReply> getSwapPayment($0.GetSwapPaymentRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$getSwapPayment, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.RedeemSwapPaymentReply> redeemSwapPayment(
-      $0.RedeemSwapPaymentRequest request,
+  $grpc.ResponseFuture<$0.RedeemSwapPaymentReply> redeemSwapPayment($0.RedeemSwapPaymentRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$redeemSwapPayment, request, options: options);
   }
@@ -727,79 +613,65 @@ abstract class SwapperServiceBase extends $grpc.Service {
         addFundInit_Pre,
         false,
         false,
-        ($core.List<$core.int> value) =>
-            $0.AddFundInitRequest.fromBuffer(value),
+        ($core.List<$core.int> value) => $0.AddFundInitRequest.fromBuffer(value),
         ($0.AddFundInitReply value) => value.writeToBuffer()));
-    $addMethod(
-        $grpc.ServiceMethod<$0.AddFundStatusRequest, $0.AddFundStatusReply>(
-            'AddFundStatus',
-            addFundStatus_Pre,
-            false,
-            false,
-            ($core.List<$core.int> value) =>
-                $0.AddFundStatusRequest.fromBuffer(value),
-            ($0.AddFundStatusReply value) => value.writeToBuffer()));
-    $addMethod(
-        $grpc.ServiceMethod<$0.GetSwapPaymentRequest, $0.GetSwapPaymentReply>(
-            'GetSwapPayment',
-            getSwapPayment_Pre,
-            false,
-            false,
-            ($core.List<$core.int> value) =>
-                $0.GetSwapPaymentRequest.fromBuffer(value),
-            ($0.GetSwapPaymentReply value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<$0.RedeemSwapPaymentRequest,
-            $0.RedeemSwapPaymentReply>(
+    $addMethod($grpc.ServiceMethod<$0.AddFundStatusRequest, $0.AddFundStatusReply>(
+        'AddFundStatus',
+        addFundStatus_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.AddFundStatusRequest.fromBuffer(value),
+        ($0.AddFundStatusReply value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.GetSwapPaymentRequest, $0.GetSwapPaymentReply>(
+        'GetSwapPayment',
+        getSwapPayment_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.GetSwapPaymentRequest.fromBuffer(value),
+        ($0.GetSwapPaymentReply value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.RedeemSwapPaymentRequest, $0.RedeemSwapPaymentReply>(
         'RedeemSwapPayment',
         redeemSwapPayment_Pre,
         false,
         false,
-        ($core.List<$core.int> value) =>
-            $0.RedeemSwapPaymentRequest.fromBuffer(value),
+        ($core.List<$core.int> value) => $0.RedeemSwapPaymentRequest.fromBuffer(value),
         ($0.RedeemSwapPaymentReply value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<$0.GetReverseRoutingNodeRequest,
-            $0.GetReverseRoutingNodeReply>(
+    $addMethod($grpc.ServiceMethod<$0.GetReverseRoutingNodeRequest, $0.GetReverseRoutingNodeReply>(
         'GetReverseRoutingNode',
         getReverseRoutingNode_Pre,
         false,
         false,
-        ($core.List<$core.int> value) =>
-            $0.GetReverseRoutingNodeRequest.fromBuffer(value),
+        ($core.List<$core.int> value) => $0.GetReverseRoutingNodeRequest.fromBuffer(value),
         ($0.GetReverseRoutingNodeReply value) => value.writeToBuffer()));
   }
 
-  $async.Future<$0.AddFundInitReply> addFundInit_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AddFundInitRequest> request) async {
+  $async.Future<$0.AddFundInitReply> addFundInit_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.AddFundInitRequest> request) async {
     return addFundInit(call, await request);
   }
 
-  $async.Future<$0.AddFundStatusReply> addFundStatus_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AddFundStatusRequest> request) async {
+  $async.Future<$0.AddFundStatusReply> addFundStatus_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.AddFundStatusRequest> request) async {
     return addFundStatus(call, await request);
   }
 
   $async.Future<$0.GetSwapPaymentReply> getSwapPayment_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.GetSwapPaymentRequest> request) async {
+      $grpc.ServiceCall call, $async.Future<$0.GetSwapPaymentRequest> request) async {
     return getSwapPayment(call, await request);
   }
 
   $async.Future<$0.RedeemSwapPaymentReply> redeemSwapPayment_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.RedeemSwapPaymentRequest> request) async {
+      $grpc.ServiceCall call, $async.Future<$0.RedeemSwapPaymentRequest> request) async {
     return redeemSwapPayment(call, await request);
   }
 
   $async.Future<$0.GetReverseRoutingNodeReply> getReverseRoutingNode_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.GetReverseRoutingNodeRequest> request) async {
+      $grpc.ServiceCall call, $async.Future<$0.GetReverseRoutingNodeRequest> request) async {
     return getReverseRoutingNode(call, await request);
   }
 
-  $async.Future<$0.AddFundInitReply> addFundInit(
-      $grpc.ServiceCall call, $0.AddFundInitRequest request);
-  $async.Future<$0.AddFundStatusReply> addFundStatus(
-      $grpc.ServiceCall call, $0.AddFundStatusRequest request);
+  $async.Future<$0.AddFundInitReply> addFundInit($grpc.ServiceCall call, $0.AddFundInitRequest request);
+  $async.Future<$0.AddFundStatusReply> addFundStatus($grpc.ServiceCall call, $0.AddFundStatusRequest request);
   $async.Future<$0.GetSwapPaymentReply> getSwapPayment(
       $grpc.ServiceCall call, $0.GetSwapPaymentRequest request);
   $async.Future<$0.RedeemSwapPaymentReply> redeemSwapPayment(
@@ -809,26 +681,21 @@ abstract class SwapperServiceBase extends $grpc.Service {
 }
 
 class CTPClient extends $grpc.Client {
-  static final _$joinCTPSession =
-      $grpc.ClientMethod<$0.JoinCTPSessionRequest, $0.JoinCTPSessionResponse>(
-          '/breez.CTP/JoinCTPSession',
-          ($0.JoinCTPSessionRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.JoinCTPSessionResponse.fromBuffer(value));
-  static final _$terminateCTPSession = $grpc.ClientMethod<
-          $0.TerminateCTPSessionRequest, $0.TerminateCTPSessionResponse>(
-      '/breez.CTP/TerminateCTPSession',
-      ($0.TerminateCTPSessionRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.TerminateCTPSessionResponse.fromBuffer(value));
+  static final _$joinCTPSession = $grpc.ClientMethod<$0.JoinCTPSessionRequest, $0.JoinCTPSessionResponse>(
+      '/breez.CTP/JoinCTPSession',
+      ($0.JoinCTPSessionRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.JoinCTPSessionResponse.fromBuffer(value));
+  static final _$terminateCTPSession =
+      $grpc.ClientMethod<$0.TerminateCTPSessionRequest, $0.TerminateCTPSessionResponse>(
+          '/breez.CTP/TerminateCTPSession',
+          ($0.TerminateCTPSessionRequest value) => value.writeToBuffer(),
+          ($core.List<$core.int> value) => $0.TerminateCTPSessionResponse.fromBuffer(value));
 
   CTPClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions? options,
-      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
+      {$grpc.CallOptions? options, $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
-  $grpc.ResponseFuture<$0.JoinCTPSessionResponse> joinCTPSession(
-      $0.JoinCTPSessionRequest request,
+  $grpc.ResponseFuture<$0.JoinCTPSessionResponse> joinCTPSession($0.JoinCTPSessionRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$joinCTPSession, request, options: options);
   }
@@ -844,35 +711,29 @@ abstract class CTPServiceBase extends $grpc.Service {
   $core.String get $name => 'breez.CTP';
 
   CTPServiceBase() {
-    $addMethod($grpc.ServiceMethod<$0.JoinCTPSessionRequest,
-            $0.JoinCTPSessionResponse>(
+    $addMethod($grpc.ServiceMethod<$0.JoinCTPSessionRequest, $0.JoinCTPSessionResponse>(
         'JoinCTPSession',
         joinCTPSession_Pre,
         false,
         false,
-        ($core.List<$core.int> value) =>
-            $0.JoinCTPSessionRequest.fromBuffer(value),
+        ($core.List<$core.int> value) => $0.JoinCTPSessionRequest.fromBuffer(value),
         ($0.JoinCTPSessionResponse value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<$0.TerminateCTPSessionRequest,
-            $0.TerminateCTPSessionResponse>(
+    $addMethod($grpc.ServiceMethod<$0.TerminateCTPSessionRequest, $0.TerminateCTPSessionResponse>(
         'TerminateCTPSession',
         terminateCTPSession_Pre,
         false,
         false,
-        ($core.List<$core.int> value) =>
-            $0.TerminateCTPSessionRequest.fromBuffer(value),
+        ($core.List<$core.int> value) => $0.TerminateCTPSessionRequest.fromBuffer(value),
         ($0.TerminateCTPSessionResponse value) => value.writeToBuffer()));
   }
 
   $async.Future<$0.JoinCTPSessionResponse> joinCTPSession_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.JoinCTPSessionRequest> request) async {
+      $grpc.ServiceCall call, $async.Future<$0.JoinCTPSessionRequest> request) async {
     return joinCTPSession(call, await request);
   }
 
   $async.Future<$0.TerminateCTPSessionResponse> terminateCTPSession_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.TerminateCTPSessionRequest> request) async {
+      $grpc.ServiceCall call, $async.Future<$0.TerminateCTPSessionRequest> request) async {
     return terminateCTPSession(call, await request);
   }
 
@@ -883,32 +744,25 @@ abstract class CTPServiceBase extends $grpc.Service {
 }
 
 class NodeInfoClient extends $grpc.Client {
-  static final _$setNodeInfo =
-      $grpc.ClientMethod<$0.SetNodeInfoRequest, $0.SetNodeInfoResponse>(
-          '/breez.NodeInfo/SetNodeInfo',
-          ($0.SetNodeInfoRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.SetNodeInfoResponse.fromBuffer(value));
-  static final _$getNodeInfo =
-      $grpc.ClientMethod<$0.GetNodeInfoRequest, $0.GetNodeInfoResponse>(
-          '/breez.NodeInfo/GetNodeInfo',
-          ($0.GetNodeInfoRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.GetNodeInfoResponse.fromBuffer(value));
+  static final _$setNodeInfo = $grpc.ClientMethod<$0.SetNodeInfoRequest, $0.SetNodeInfoResponse>(
+      '/breez.NodeInfo/SetNodeInfo',
+      ($0.SetNodeInfoRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.SetNodeInfoResponse.fromBuffer(value));
+  static final _$getNodeInfo = $grpc.ClientMethod<$0.GetNodeInfoRequest, $0.GetNodeInfoResponse>(
+      '/breez.NodeInfo/GetNodeInfo',
+      ($0.GetNodeInfoRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.GetNodeInfoResponse.fromBuffer(value));
 
   NodeInfoClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions? options,
-      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
+      {$grpc.CallOptions? options, $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
-  $grpc.ResponseFuture<$0.SetNodeInfoResponse> setNodeInfo(
-      $0.SetNodeInfoRequest request,
+  $grpc.ResponseFuture<$0.SetNodeInfoResponse> setNodeInfo($0.SetNodeInfoRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$setNodeInfo, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.GetNodeInfoResponse> getNodeInfo(
-      $0.GetNodeInfoRequest request,
+  $grpc.ResponseFuture<$0.GetNodeInfoResponse> getNodeInfo($0.GetNodeInfoRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$getNodeInfo, request, options: options);
   }
@@ -918,53 +772,45 @@ abstract class NodeInfoServiceBase extends $grpc.Service {
   $core.String get $name => 'breez.NodeInfo';
 
   NodeInfoServiceBase() {
-    $addMethod(
-        $grpc.ServiceMethod<$0.SetNodeInfoRequest, $0.SetNodeInfoResponse>(
-            'SetNodeInfo',
-            setNodeInfo_Pre,
-            false,
-            false,
-            ($core.List<$core.int> value) =>
-                $0.SetNodeInfoRequest.fromBuffer(value),
-            ($0.SetNodeInfoResponse value) => value.writeToBuffer()));
-    $addMethod(
-        $grpc.ServiceMethod<$0.GetNodeInfoRequest, $0.GetNodeInfoResponse>(
-            'GetNodeInfo',
-            getNodeInfo_Pre,
-            false,
-            false,
-            ($core.List<$core.int> value) =>
-                $0.GetNodeInfoRequest.fromBuffer(value),
-            ($0.GetNodeInfoResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.SetNodeInfoRequest, $0.SetNodeInfoResponse>(
+        'SetNodeInfo',
+        setNodeInfo_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.SetNodeInfoRequest.fromBuffer(value),
+        ($0.SetNodeInfoResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.GetNodeInfoRequest, $0.GetNodeInfoResponse>(
+        'GetNodeInfo',
+        getNodeInfo_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.GetNodeInfoRequest.fromBuffer(value),
+        ($0.GetNodeInfoResponse value) => value.writeToBuffer()));
   }
 
-  $async.Future<$0.SetNodeInfoResponse> setNodeInfo_Pre($grpc.ServiceCall call,
-      $async.Future<$0.SetNodeInfoRequest> request) async {
+  $async.Future<$0.SetNodeInfoResponse> setNodeInfo_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.SetNodeInfoRequest> request) async {
     return setNodeInfo(call, await request);
   }
 
-  $async.Future<$0.GetNodeInfoResponse> getNodeInfo_Pre($grpc.ServiceCall call,
-      $async.Future<$0.GetNodeInfoRequest> request) async {
+  $async.Future<$0.GetNodeInfoResponse> getNodeInfo_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.GetNodeInfoRequest> request) async {
     return getNodeInfo(call, await request);
   }
 
-  $async.Future<$0.SetNodeInfoResponse> setNodeInfo(
-      $grpc.ServiceCall call, $0.SetNodeInfoRequest request);
-  $async.Future<$0.GetNodeInfoResponse> getNodeInfo(
-      $grpc.ServiceCall call, $0.GetNodeInfoRequest request);
+  $async.Future<$0.SetNodeInfoResponse> setNodeInfo($grpc.ServiceCall call, $0.SetNodeInfoRequest request);
+  $async.Future<$0.GetNodeInfoResponse> getNodeInfo($grpc.ServiceCall call, $0.GetNodeInfoRequest request);
 }
 
 class SyncNotifierClient extends $grpc.Client {
-  static final _$registerPeriodicSync = $grpc.ClientMethod<
-          $0.RegisterPeriodicSyncRequest, $0.RegisterPeriodicSyncResponse>(
-      '/breez.SyncNotifier/RegisterPeriodicSync',
-      ($0.RegisterPeriodicSyncRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.RegisterPeriodicSyncResponse.fromBuffer(value));
+  static final _$registerPeriodicSync =
+      $grpc.ClientMethod<$0.RegisterPeriodicSyncRequest, $0.RegisterPeriodicSyncResponse>(
+          '/breez.SyncNotifier/RegisterPeriodicSync',
+          ($0.RegisterPeriodicSyncRequest value) => value.writeToBuffer(),
+          ($core.List<$core.int> value) => $0.RegisterPeriodicSyncResponse.fromBuffer(value));
 
   SyncNotifierClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions? options,
-      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
+      {$grpc.CallOptions? options, $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
   $grpc.ResponseFuture<$0.RegisterPeriodicSyncResponse> registerPeriodicSync(
@@ -978,20 +824,17 @@ abstract class SyncNotifierServiceBase extends $grpc.Service {
   $core.String get $name => 'breez.SyncNotifier';
 
   SyncNotifierServiceBase() {
-    $addMethod($grpc.ServiceMethod<$0.RegisterPeriodicSyncRequest,
-            $0.RegisterPeriodicSyncResponse>(
+    $addMethod($grpc.ServiceMethod<$0.RegisterPeriodicSyncRequest, $0.RegisterPeriodicSyncResponse>(
         'RegisterPeriodicSync',
         registerPeriodicSync_Pre,
         false,
         false,
-        ($core.List<$core.int> value) =>
-            $0.RegisterPeriodicSyncRequest.fromBuffer(value),
+        ($core.List<$core.int> value) => $0.RegisterPeriodicSyncRequest.fromBuffer(value),
         ($0.RegisterPeriodicSyncResponse value) => value.writeToBuffer()));
   }
 
   $async.Future<$0.RegisterPeriodicSyncResponse> registerPeriodicSync_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.RegisterPeriodicSyncRequest> request) async {
+      $grpc.ServiceCall call, $async.Future<$0.RegisterPeriodicSyncRequest> request) async {
     return registerPeriodicSync(call, await request);
   }
 
@@ -1000,23 +843,20 @@ abstract class SyncNotifierServiceBase extends $grpc.Service {
 }
 
 class PushTxNotifierClient extends $grpc.Client {
-  static final _$registerTxNotification = $grpc.ClientMethod<
-          $0.PushTxNotificationRequest, $0.PushTxNotificationResponse>(
-      '/breez.PushTxNotifier/RegisterTxNotification',
-      ($0.PushTxNotificationRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.PushTxNotificationResponse.fromBuffer(value));
+  static final _$registerTxNotification =
+      $grpc.ClientMethod<$0.PushTxNotificationRequest, $0.PushTxNotificationResponse>(
+          '/breez.PushTxNotifier/RegisterTxNotification',
+          ($0.PushTxNotificationRequest value) => value.writeToBuffer(),
+          ($core.List<$core.int> value) => $0.PushTxNotificationResponse.fromBuffer(value));
 
   PushTxNotifierClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions? options,
-      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
+      {$grpc.CallOptions? options, $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
   $grpc.ResponseFuture<$0.PushTxNotificationResponse> registerTxNotification(
       $0.PushTxNotificationRequest request,
       {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$registerTxNotification, request,
-        options: options);
+    return $createUnaryCall(_$registerTxNotification, request, options: options);
   }
 }
 
@@ -1024,20 +864,17 @@ abstract class PushTxNotifierServiceBase extends $grpc.Service {
   $core.String get $name => 'breez.PushTxNotifier';
 
   PushTxNotifierServiceBase() {
-    $addMethod($grpc.ServiceMethod<$0.PushTxNotificationRequest,
-            $0.PushTxNotificationResponse>(
+    $addMethod($grpc.ServiceMethod<$0.PushTxNotificationRequest, $0.PushTxNotificationResponse>(
         'RegisterTxNotification',
         registerTxNotification_Pre,
         false,
         false,
-        ($core.List<$core.int> value) =>
-            $0.PushTxNotificationRequest.fromBuffer(value),
+        ($core.List<$core.int> value) => $0.PushTxNotificationRequest.fromBuffer(value),
         ($0.PushTxNotificationResponse value) => value.writeToBuffer()));
   }
 
   $async.Future<$0.PushTxNotificationResponse> registerTxNotification_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.PushTxNotificationRequest> request) async {
+      $grpc.ServiceCall call, $async.Future<$0.PushTxNotificationRequest> request) async {
     return registerTxNotification(call, await request);
   }
 
@@ -1046,20 +883,16 @@ abstract class PushTxNotifierServiceBase extends $grpc.Service {
 }
 
 class InactiveNotifierClient extends $grpc.Client {
-  static final _$inactiveNotify =
-      $grpc.ClientMethod<$0.InactiveNotifyRequest, $0.InactiveNotifyResponse>(
-          '/breez.InactiveNotifier/InactiveNotify',
-          ($0.InactiveNotifyRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.InactiveNotifyResponse.fromBuffer(value));
+  static final _$inactiveNotify = $grpc.ClientMethod<$0.InactiveNotifyRequest, $0.InactiveNotifyResponse>(
+      '/breez.InactiveNotifier/InactiveNotify',
+      ($0.InactiveNotifyRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.InactiveNotifyResponse.fromBuffer(value));
 
   InactiveNotifierClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions? options,
-      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
+      {$grpc.CallOptions? options, $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
-  $grpc.ResponseFuture<$0.InactiveNotifyResponse> inactiveNotify(
-      $0.InactiveNotifyRequest request,
+  $grpc.ResponseFuture<$0.InactiveNotifyResponse> inactiveNotify($0.InactiveNotifyRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$inactiveNotify, request, options: options);
   }
@@ -1069,20 +902,17 @@ abstract class InactiveNotifierServiceBase extends $grpc.Service {
   $core.String get $name => 'breez.InactiveNotifier';
 
   InactiveNotifierServiceBase() {
-    $addMethod($grpc.ServiceMethod<$0.InactiveNotifyRequest,
-            $0.InactiveNotifyResponse>(
+    $addMethod($grpc.ServiceMethod<$0.InactiveNotifyRequest, $0.InactiveNotifyResponse>(
         'InactiveNotify',
         inactiveNotify_Pre,
         false,
         false,
-        ($core.List<$core.int> value) =>
-            $0.InactiveNotifyRequest.fromBuffer(value),
+        ($core.List<$core.int> value) => $0.InactiveNotifyRequest.fromBuffer(value),
         ($0.InactiveNotifyResponse value) => value.writeToBuffer()));
   }
 
   $async.Future<$0.InactiveNotifyResponse> inactiveNotify_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.InactiveNotifyRequest> request) async {
+      $grpc.ServiceCall call, $async.Future<$0.InactiveNotifyRequest> request) async {
     return inactiveNotify(call, await request);
   }
 
@@ -1091,38 +921,31 @@ abstract class InactiveNotifierServiceBase extends $grpc.Service {
 }
 
 class PaymentNotifierClient extends $grpc.Client {
-  static final _$registerPaymentNotification = $grpc.ClientMethod<
-          $0.RegisterPaymentNotificationRequest,
-          $0.RegisterPaymentNotificationResponse>(
-      '/breez.PaymentNotifier/RegisterPaymentNotification',
-      ($0.RegisterPaymentNotificationRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.RegisterPaymentNotificationResponse.fromBuffer(value));
-  static final _$removePaymentNotification = $grpc.ClientMethod<
-          $0.RemovePaymentNotificationRequest,
-          $0.RemovePaymentNotificationResponse>(
-      '/breez.PaymentNotifier/RemovePaymentNotification',
-      ($0.RemovePaymentNotificationRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.RemovePaymentNotificationResponse.fromBuffer(value));
+  static final _$registerPaymentNotification =
+      $grpc.ClientMethod<$0.RegisterPaymentNotificationRequest, $0.RegisterPaymentNotificationResponse>(
+          '/breez.PaymentNotifier/RegisterPaymentNotification',
+          ($0.RegisterPaymentNotificationRequest value) => value.writeToBuffer(),
+          ($core.List<$core.int> value) => $0.RegisterPaymentNotificationResponse.fromBuffer(value));
+  static final _$removePaymentNotification =
+      $grpc.ClientMethod<$0.RemovePaymentNotificationRequest, $0.RemovePaymentNotificationResponse>(
+          '/breez.PaymentNotifier/RemovePaymentNotification',
+          ($0.RemovePaymentNotificationRequest value) => value.writeToBuffer(),
+          ($core.List<$core.int> value) => $0.RemovePaymentNotificationResponse.fromBuffer(value));
 
   PaymentNotifierClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions? options,
-      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
+      {$grpc.CallOptions? options, $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
-  $grpc.ResponseFuture<$0.RegisterPaymentNotificationResponse>
-      registerPaymentNotification($0.RegisterPaymentNotificationRequest request,
-          {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$registerPaymentNotification, request,
-        options: options);
+  $grpc.ResponseFuture<$0.RegisterPaymentNotificationResponse> registerPaymentNotification(
+      $0.RegisterPaymentNotificationRequest request,
+      {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$registerPaymentNotification, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.RemovePaymentNotificationResponse>
-      removePaymentNotification($0.RemovePaymentNotificationRequest request,
-          {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$removePaymentNotification, request,
-        options: options);
+  $grpc.ResponseFuture<$0.RemovePaymentNotificationResponse> removePaymentNotification(
+      $0.RemovePaymentNotificationRequest request,
+      {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$removePaymentNotification, request, options: options);
   }
 }
 
@@ -1130,61 +953,50 @@ abstract class PaymentNotifierServiceBase extends $grpc.Service {
   $core.String get $name => 'breez.PaymentNotifier';
 
   PaymentNotifierServiceBase() {
-    $addMethod($grpc.ServiceMethod<$0.RegisterPaymentNotificationRequest,
-            $0.RegisterPaymentNotificationResponse>(
-        'RegisterPaymentNotification',
-        registerPaymentNotification_Pre,
-        false,
-        false,
-        ($core.List<$core.int> value) =>
-            $0.RegisterPaymentNotificationRequest.fromBuffer(value),
-        ($0.RegisterPaymentNotificationResponse value) =>
-            value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<$0.RemovePaymentNotificationRequest,
-            $0.RemovePaymentNotificationResponse>(
+    $addMethod(
+        $grpc.ServiceMethod<$0.RegisterPaymentNotificationRequest, $0.RegisterPaymentNotificationResponse>(
+            'RegisterPaymentNotification',
+            registerPaymentNotification_Pre,
+            false,
+            false,
+            ($core.List<$core.int> value) => $0.RegisterPaymentNotificationRequest.fromBuffer(value),
+            ($0.RegisterPaymentNotificationResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.RemovePaymentNotificationRequest, $0.RemovePaymentNotificationResponse>(
         'RemovePaymentNotification',
         removePaymentNotification_Pre,
         false,
         false,
-        ($core.List<$core.int> value) =>
-            $0.RemovePaymentNotificationRequest.fromBuffer(value),
+        ($core.List<$core.int> value) => $0.RemovePaymentNotificationRequest.fromBuffer(value),
         ($0.RemovePaymentNotificationResponse value) => value.writeToBuffer()));
   }
 
-  $async.Future<$0.RegisterPaymentNotificationResponse>
-      registerPaymentNotification_Pre($grpc.ServiceCall call,
-          $async.Future<$0.RegisterPaymentNotificationRequest> request) async {
+  $async.Future<$0.RegisterPaymentNotificationResponse> registerPaymentNotification_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.RegisterPaymentNotificationRequest> request) async {
     return registerPaymentNotification(call, await request);
   }
 
-  $async.Future<$0.RemovePaymentNotificationResponse>
-      removePaymentNotification_Pre($grpc.ServiceCall call,
-          $async.Future<$0.RemovePaymentNotificationRequest> request) async {
+  $async.Future<$0.RemovePaymentNotificationResponse> removePaymentNotification_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.RemovePaymentNotificationRequest> request) async {
     return removePaymentNotification(call, await request);
   }
 
-  $async.Future<$0.RegisterPaymentNotificationResponse>
-      registerPaymentNotification($grpc.ServiceCall call,
-          $0.RegisterPaymentNotificationRequest request);
+  $async.Future<$0.RegisterPaymentNotificationResponse> registerPaymentNotification(
+      $grpc.ServiceCall call, $0.RegisterPaymentNotificationRequest request);
   $async.Future<$0.RemovePaymentNotificationResponse> removePaymentNotification(
       $grpc.ServiceCall call, $0.RemovePaymentNotificationRequest request);
 }
 
 class SignerClient extends $grpc.Client {
-  static final _$signUrl =
-      $grpc.ClientMethod<$0.SignUrlRequest, $0.SignUrlResponse>(
-          '/breez.Signer/SignUrl',
-          ($0.SignUrlRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.SignUrlResponse.fromBuffer(value));
+  static final _$signUrl = $grpc.ClientMethod<$0.SignUrlRequest, $0.SignUrlResponse>(
+      '/breez.Signer/SignUrl',
+      ($0.SignUrlRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.SignUrlResponse.fromBuffer(value));
 
   SignerClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions? options,
-      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
+      {$grpc.CallOptions? options, $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
-  $grpc.ResponseFuture<$0.SignUrlResponse> signUrl($0.SignUrlRequest request,
-      {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.SignUrlResponse> signUrl($0.SignUrlRequest request, {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$signUrl, request, options: options);
   }
 }
@@ -1207,27 +1019,22 @@ abstract class SignerServiceBase extends $grpc.Service {
     return signUrl(call, await request);
   }
 
-  $async.Future<$0.SignUrlResponse> signUrl(
-      $grpc.ServiceCall call, $0.SignUrlRequest request);
+  $async.Future<$0.SignUrlResponse> signUrl($grpc.ServiceCall call, $0.SignUrlRequest request);
 }
 
 class SupportClient extends $grpc.Client {
-  static final _$reportPaymentFailure = $grpc.ClientMethod<
-          $0.ReportPaymentFailureRequest, $0.ReportPaymentFailureReply>(
-      '/breez.Support/ReportPaymentFailure',
-      ($0.ReportPaymentFailureRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.ReportPaymentFailureReply.fromBuffer(value));
-  static final _$breezStatus =
-      $grpc.ClientMethod<$0.BreezStatusRequest, $0.BreezStatusReply>(
-          '/breez.Support/BreezStatus',
-          ($0.BreezStatusRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.BreezStatusReply.fromBuffer(value));
+  static final _$reportPaymentFailure =
+      $grpc.ClientMethod<$0.ReportPaymentFailureRequest, $0.ReportPaymentFailureReply>(
+          '/breez.Support/ReportPaymentFailure',
+          ($0.ReportPaymentFailureRequest value) => value.writeToBuffer(),
+          ($core.List<$core.int> value) => $0.ReportPaymentFailureReply.fromBuffer(value));
+  static final _$breezStatus = $grpc.ClientMethod<$0.BreezStatusRequest, $0.BreezStatusReply>(
+      '/breez.Support/BreezStatus',
+      ($0.BreezStatusRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.BreezStatusReply.fromBuffer(value));
 
   SupportClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions? options,
-      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
+      {$grpc.CallOptions? options, $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
   $grpc.ResponseFuture<$0.ReportPaymentFailureReply> reportPaymentFailure(
@@ -1236,8 +1043,7 @@ class SupportClient extends $grpc.Client {
     return $createUnaryCall(_$reportPaymentFailure, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.BreezStatusReply> breezStatus(
-      $0.BreezStatusRequest request,
+  $grpc.ResponseFuture<$0.BreezStatusReply> breezStatus($0.BreezStatusRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$breezStatus, request, options: options);
   }
@@ -1247,38 +1053,33 @@ abstract class SupportServiceBase extends $grpc.Service {
   $core.String get $name => 'breez.Support';
 
   SupportServiceBase() {
-    $addMethod($grpc.ServiceMethod<$0.ReportPaymentFailureRequest,
-            $0.ReportPaymentFailureReply>(
+    $addMethod($grpc.ServiceMethod<$0.ReportPaymentFailureRequest, $0.ReportPaymentFailureReply>(
         'ReportPaymentFailure',
         reportPaymentFailure_Pre,
         false,
         false,
-        ($core.List<$core.int> value) =>
-            $0.ReportPaymentFailureRequest.fromBuffer(value),
+        ($core.List<$core.int> value) => $0.ReportPaymentFailureRequest.fromBuffer(value),
         ($0.ReportPaymentFailureReply value) => value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$0.BreezStatusRequest, $0.BreezStatusReply>(
         'BreezStatus',
         breezStatus_Pre,
         false,
         false,
-        ($core.List<$core.int> value) =>
-            $0.BreezStatusRequest.fromBuffer(value),
+        ($core.List<$core.int> value) => $0.BreezStatusRequest.fromBuffer(value),
         ($0.BreezStatusReply value) => value.writeToBuffer()));
   }
 
   $async.Future<$0.ReportPaymentFailureReply> reportPaymentFailure_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.ReportPaymentFailureRequest> request) async {
+      $grpc.ServiceCall call, $async.Future<$0.ReportPaymentFailureRequest> request) async {
     return reportPaymentFailure(call, await request);
   }
 
-  $async.Future<$0.BreezStatusReply> breezStatus_Pre($grpc.ServiceCall call,
-      $async.Future<$0.BreezStatusRequest> request) async {
+  $async.Future<$0.BreezStatusReply> breezStatus_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.BreezStatusRequest> request) async {
     return breezStatus(call, await request);
   }
 
   $async.Future<$0.ReportPaymentFailureReply> reportPaymentFailure(
       $grpc.ServiceCall call, $0.ReportPaymentFailureRequest request);
-  $async.Future<$0.BreezStatusReply> breezStatus(
-      $grpc.ServiceCall call, $0.BreezStatusRequest request);
+  $async.Future<$0.BreezStatusReply> breezStatus($grpc.ServiceCall call, $0.BreezStatusRequest request);
 }

--- a/lib/services/breez_server/generated/breez.pbjson.dart
+++ b/lib/services/breez_server/generated/breez.pbjson.dart
@@ -8,6 +8,7 @@
 import 'dart:core' as $core;
 import 'dart:convert' as $convert;
 import 'dart:typed_data' as $typed_data;
+
 @$core.Deprecated('Use signUrlRequestDescriptor instead')
 const SignUrlRequest$json = const {
   '1': 'SignUrlRequest',
@@ -18,7 +19,8 @@ const SignUrlRequest$json = const {
 };
 
 /// Descriptor for `SignUrlRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List signUrlRequestDescriptor = $convert.base64Decode('Cg5TaWduVXJsUmVxdWVzdBIZCgdiYXNlVXJsGAEgASgJUghiYXNlX3VybBIhCgtxdWVyeVN0cmluZxgCIAEoCVIMcXVlcnlfc3RyaW5n');
+final $typed_data.Uint8List signUrlRequestDescriptor = $convert.base64Decode(
+    'Cg5TaWduVXJsUmVxdWVzdBIZCgdiYXNlVXJsGAEgASgJUghiYXNlX3VybBIhCgtxdWVyeVN0cmluZxgCIAEoCVIMcXVlcnlfc3RyaW5n');
 @$core.Deprecated('Use signUrlResponseDescriptor instead')
 const SignUrlResponse$json = const {
   '1': 'SignUrlResponse',
@@ -28,7 +30,8 @@ const SignUrlResponse$json = const {
 };
 
 /// Descriptor for `SignUrlResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List signUrlResponseDescriptor = $convert.base64Decode('Cg9TaWduVXJsUmVzcG9uc2USGQoHZnVsbFVybBgBIAEoCVIIZnVsbF91cmw=');
+final $typed_data.Uint8List signUrlResponseDescriptor =
+    $convert.base64Decode('Cg9TaWduVXJsUmVzcG9uc2USGQoHZnVsbFVybBgBIAEoCVIIZnVsbF91cmw=');
 @$core.Deprecated('Use inactiveNotifyRequestDescriptor instead')
 const InactiveNotifyRequest$json = const {
   '1': 'InactiveNotifyRequest',
@@ -39,14 +42,16 @@ const InactiveNotifyRequest$json = const {
 };
 
 /// Descriptor for `InactiveNotifyRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List inactiveNotifyRequestDescriptor = $convert.base64Decode('ChVJbmFjdGl2ZU5vdGlmeVJlcXVlc3QSFgoGcHVia2V5GAEgASgMUgZwdWJrZXkSEgoEZGF5cxgCIAEoBVIEZGF5cw==');
+final $typed_data.Uint8List inactiveNotifyRequestDescriptor = $convert.base64Decode(
+    'ChVJbmFjdGl2ZU5vdGlmeVJlcXVlc3QSFgoGcHVia2V5GAEgASgMUgZwdWJrZXkSEgoEZGF5cxgCIAEoBVIEZGF5cw==');
 @$core.Deprecated('Use inactiveNotifyResponseDescriptor instead')
 const InactiveNotifyResponse$json = const {
   '1': 'InactiveNotifyResponse',
 };
 
 /// Descriptor for `InactiveNotifyResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List inactiveNotifyResponseDescriptor = $convert.base64Decode('ChZJbmFjdGl2ZU5vdGlmeVJlc3BvbnNl');
+final $typed_data.Uint8List inactiveNotifyResponseDescriptor =
+    $convert.base64Decode('ChZJbmFjdGl2ZU5vdGlmeVJlc3BvbnNl');
 @$core.Deprecated('Use registerPaymentNotificationRequestDescriptor instead')
 const RegisterPaymentNotificationRequest$json = const {
   '1': 'RegisterPaymentNotificationRequest',
@@ -57,14 +62,16 @@ const RegisterPaymentNotificationRequest$json = const {
 };
 
 /// Descriptor for `RegisterPaymentNotificationRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List registerPaymentNotificationRequestDescriptor = $convert.base64Decode('CiJSZWdpc3RlclBheW1lbnROb3RpZmljYXRpb25SZXF1ZXN0EhUKBmxzcF9pZBgBIAEoCVIFbHNwSWQSEgoEYmxvYhgCIAEoDFIEYmxvYg==');
+final $typed_data.Uint8List registerPaymentNotificationRequestDescriptor = $convert.base64Decode(
+    'CiJSZWdpc3RlclBheW1lbnROb3RpZmljYXRpb25SZXF1ZXN0EhUKBmxzcF9pZBgBIAEoCVIFbHNwSWQSEgoEYmxvYhgCIAEoDFIEYmxvYg==');
 @$core.Deprecated('Use registerPaymentNotificationResponseDescriptor instead')
 const RegisterPaymentNotificationResponse$json = const {
   '1': 'RegisterPaymentNotificationResponse',
 };
 
 /// Descriptor for `RegisterPaymentNotificationResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List registerPaymentNotificationResponseDescriptor = $convert.base64Decode('CiNSZWdpc3RlclBheW1lbnROb3RpZmljYXRpb25SZXNwb25zZQ==');
+final $typed_data.Uint8List registerPaymentNotificationResponseDescriptor =
+    $convert.base64Decode('CiNSZWdpc3RlclBheW1lbnROb3RpZmljYXRpb25SZXNwb25zZQ==');
 @$core.Deprecated('Use removePaymentNotificationRequestDescriptor instead')
 const RemovePaymentNotificationRequest$json = const {
   '1': 'RemovePaymentNotificationRequest',
@@ -75,21 +82,24 @@ const RemovePaymentNotificationRequest$json = const {
 };
 
 /// Descriptor for `RemovePaymentNotificationRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removePaymentNotificationRequestDescriptor = $convert.base64Decode('CiBSZW1vdmVQYXltZW50Tm90aWZpY2F0aW9uUmVxdWVzdBIVCgZsc3BfaWQYASABKAlSBWxzcElkEhIKBGJsb2IYAiABKAxSBGJsb2I=');
+final $typed_data.Uint8List removePaymentNotificationRequestDescriptor = $convert.base64Decode(
+    'CiBSZW1vdmVQYXltZW50Tm90aWZpY2F0aW9uUmVxdWVzdBIVCgZsc3BfaWQYASABKAlSBWxzcElkEhIKBGJsb2IYAiABKAxSBGJsb2I=');
 @$core.Deprecated('Use removePaymentNotificationResponseDescriptor instead')
 const RemovePaymentNotificationResponse$json = const {
   '1': 'RemovePaymentNotificationResponse',
 };
 
 /// Descriptor for `RemovePaymentNotificationResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removePaymentNotificationResponseDescriptor = $convert.base64Decode('CiFSZW1vdmVQYXltZW50Tm90aWZpY2F0aW9uUmVzcG9uc2U=');
+final $typed_data.Uint8List removePaymentNotificationResponseDescriptor =
+    $convert.base64Decode('CiFSZW1vdmVQYXltZW50Tm90aWZpY2F0aW9uUmVzcG9uc2U=');
 @$core.Deprecated('Use receiverInfoRequestDescriptor instead')
 const ReceiverInfoRequest$json = const {
   '1': 'ReceiverInfoRequest',
 };
 
 /// Descriptor for `ReceiverInfoRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List receiverInfoRequestDescriptor = $convert.base64Decode('ChNSZWNlaXZlckluZm9SZXF1ZXN0');
+final $typed_data.Uint8List receiverInfoRequestDescriptor =
+    $convert.base64Decode('ChNSZWNlaXZlckluZm9SZXF1ZXN0');
 @$core.Deprecated('Use receiverInfoReplyDescriptor instead')
 const ReceiverInfoReply$json = const {
   '1': 'ReceiverInfoReply',
@@ -99,7 +109,8 @@ const ReceiverInfoReply$json = const {
 };
 
 /// Descriptor for `ReceiverInfoReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List receiverInfoReplyDescriptor = $convert.base64Decode('ChFSZWNlaXZlckluZm9SZXBseRIWCgZwdWJrZXkYASABKAlSBnB1YmtleQ==');
+final $typed_data.Uint8List receiverInfoReplyDescriptor =
+    $convert.base64Decode('ChFSZWNlaXZlckluZm9SZXBseRIWCgZwdWJrZXkYASABKAlSBnB1YmtleQ==');
 @$core.Deprecated('Use ratesRequestDescriptor instead')
 const RatesRequest$json = const {
   '1': 'RatesRequest',
@@ -117,7 +128,8 @@ const Rate$json = const {
 };
 
 /// Descriptor for `Rate`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List rateDescriptor = $convert.base64Decode('CgRSYXRlEhIKBGNvaW4YASABKAlSBGNvaW4SFAoFdmFsdWUYAiABKAFSBXZhbHVl');
+final $typed_data.Uint8List rateDescriptor =
+    $convert.base64Decode('CgRSYXRlEhIKBGNvaW4YASABKAlSBGNvaW4SFAoFdmFsdWUYAiABKAFSBXZhbHVl');
 @$core.Deprecated('Use ratesReplyDescriptor instead')
 const RatesReply$json = const {
   '1': 'RatesReply',
@@ -127,7 +139,8 @@ const RatesReply$json = const {
 };
 
 /// Descriptor for `RatesReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List ratesReplyDescriptor = $convert.base64Decode('CgpSYXRlc1JlcGx5EiEKBXJhdGVzGAEgAygLMgsuYnJlZXouUmF0ZVIFcmF0ZXM=');
+final $typed_data.Uint8List ratesReplyDescriptor =
+    $convert.base64Decode('CgpSYXRlc1JlcGx5EiEKBXJhdGVzGAEgAygLMgsuYnJlZXouUmF0ZVIFcmF0ZXM=');
 @$core.Deprecated('Use lSPListRequestDescriptor instead')
 const LSPListRequest$json = const {
   '1': 'LSPListRequest',
@@ -137,7 +150,8 @@ const LSPListRequest$json = const {
 };
 
 /// Descriptor for `LSPListRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List lSPListRequestDescriptor = $convert.base64Decode('Cg5MU1BMaXN0UmVxdWVzdBIWCgZwdWJrZXkYAiABKAlSBnB1YmtleQ==');
+final $typed_data.Uint8List lSPListRequestDescriptor =
+    $convert.base64Decode('Cg5MU1BMaXN0UmVxdWVzdBIWCgZwdWJrZXkYAiABKAlSBnB1YmtleQ==');
 @$core.Deprecated('Use lSPInformationDescriptor instead')
 const LSPInformation$json = const {
   '1': 'LSPInformation',
@@ -177,12 +191,20 @@ const LSPInformation$json = const {
       '8': const {'3': true},
       '10': 'channelMinimumFeeMsat',
     },
-    const {'1': 'opening_fee_params_menu', '3': 15, '4': 3, '5': 11, '6': '.breez.OpeningFeeParams', '10': 'openingFeeParamsMenu'},
+    const {
+      '1': 'opening_fee_params_menu',
+      '3': 15,
+      '4': 3,
+      '5': 11,
+      '6': '.breez.OpeningFeeParams',
+      '10': 'openingFeeParamsMenu'
+    },
   ],
 };
 
 /// Descriptor for `LSPInformation`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List lSPInformationDescriptor = $convert.base64Decode('Cg5MU1BJbmZvcm1hdGlvbhISCgRuYW1lGAEgASgJUgRuYW1lEh4KCndpZGdldF91cmwYAiABKAlSCndpZGdldF91cmwSFgoGcHVia2V5GAMgASgJUgZwdWJrZXkSEgoEaG9zdBgEIAEoCVIEaG9zdBIqChBjaGFubmVsX2NhcGFjaXR5GAUgASgDUhBjaGFubmVsX2NhcGFjaXR5EiAKC3RhcmdldF9jb25mGAYgASgFUgt0YXJnZXRfY29uZhIkCg1iYXNlX2ZlZV9tc2F0GAcgASgDUg1iYXNlX2ZlZV9tc2F0EhoKCGZlZV9yYXRlGAggASgBUghmZWVfcmF0ZRIoCg90aW1lX2xvY2tfZGVsdGEYCSABKA1SD3RpbWVfbG9ja19kZWx0YRIkCg1taW5faHRsY19tc2F0GAogASgDUg1taW5faHRsY19tc2F0EjYKFWNoYW5uZWxfZmVlX3Blcm15cmlhZBgLIAEoA0ICGAFSE2NoYW5uZWxGZWVQZXJteXJpYWQSHQoKbHNwX3B1YmtleRgMIAEoDFIJbHNwUHVia2V5EjYKFW1heF9pbmFjdGl2ZV9kdXJhdGlvbhgNIAEoA0ICGAFSE21heEluYWN0aXZlRHVyYXRpb24SOwoYY2hhbm5lbF9taW5pbXVtX2ZlZV9tc2F0GA4gASgDQgIYAVIVY2hhbm5lbE1pbmltdW1GZWVNc2F0Ek4KF29wZW5pbmdfZmVlX3BhcmFtc19tZW51GA8gAygLMhcuYnJlZXouT3BlbmluZ0ZlZVBhcmFtc1IUb3BlbmluZ0ZlZVBhcmFtc01lbnU=');
+final $typed_data.Uint8List lSPInformationDescriptor = $convert.base64Decode(
+    'Cg5MU1BJbmZvcm1hdGlvbhISCgRuYW1lGAEgASgJUgRuYW1lEh4KCndpZGdldF91cmwYAiABKAlSCndpZGdldF91cmwSFgoGcHVia2V5GAMgASgJUgZwdWJrZXkSEgoEaG9zdBgEIAEoCVIEaG9zdBIqChBjaGFubmVsX2NhcGFjaXR5GAUgASgDUhBjaGFubmVsX2NhcGFjaXR5EiAKC3RhcmdldF9jb25mGAYgASgFUgt0YXJnZXRfY29uZhIkCg1iYXNlX2ZlZV9tc2F0GAcgASgDUg1iYXNlX2ZlZV9tc2F0EhoKCGZlZV9yYXRlGAggASgBUghmZWVfcmF0ZRIoCg90aW1lX2xvY2tfZGVsdGEYCSABKA1SD3RpbWVfbG9ja19kZWx0YRIkCg1taW5faHRsY19tc2F0GAogASgDUg1taW5faHRsY19tc2F0EjYKFWNoYW5uZWxfZmVlX3Blcm15cmlhZBgLIAEoA0ICGAFSE2NoYW5uZWxGZWVQZXJteXJpYWQSHQoKbHNwX3B1YmtleRgMIAEoDFIJbHNwUHVia2V5EjYKFW1heF9pbmFjdGl2ZV9kdXJhdGlvbhgNIAEoA0ICGAFSE21heEluYWN0aXZlRHVyYXRpb24SOwoYY2hhbm5lbF9taW5pbXVtX2ZlZV9tc2F0GA4gASgDQgIYAVIVY2hhbm5lbE1pbmltdW1GZWVNc2F0Ek4KF29wZW5pbmdfZmVlX3BhcmFtc19tZW51GA8gAygLMhcuYnJlZXouT3BlbmluZ0ZlZVBhcmFtc1IUb3BlbmluZ0ZlZVBhcmFtc01lbnU=');
 @$core.Deprecated('Use openingFeeParamsDescriptor instead')
 const OpeningFeeParams$json = const {
   '1': 'OpeningFeeParams',
@@ -197,7 +219,8 @@ const OpeningFeeParams$json = const {
 };
 
 /// Descriptor for `OpeningFeeParams`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List openingFeeParamsDescriptor = $convert.base64Decode('ChBPcGVuaW5nRmVlUGFyYW1zEhkKCG1pbl9tc2F0GAEgASgEUgdtaW5Nc2F0EiIKDHByb3BvcnRpb25hbBgCIAEoDVIMcHJvcG9ydGlvbmFsEh8KC3ZhbGlkX3VudGlsGAMgASgJUgp2YWxpZFVudGlsEiIKDW1heF9pZGxlX3RpbWUYBCABKA1SC21heElkbGVUaW1lEjYKGG1heF9jbGllbnRfdG9fc2VsZl9kZWxheRgFIAEoDVIUbWF4Q2xpZW50VG9TZWxmRGVsYXkSGAoHcHJvbWlzZRgGIAEoCVIHcHJvbWlzZQ==');
+final $typed_data.Uint8List openingFeeParamsDescriptor = $convert.base64Decode(
+    'ChBPcGVuaW5nRmVlUGFyYW1zEhkKCG1pbl9tc2F0GAEgASgEUgdtaW5Nc2F0EiIKDHByb3BvcnRpb25hbBgCIAEoDVIMcHJvcG9ydGlvbmFsEh8KC3ZhbGlkX3VudGlsGAMgASgJUgp2YWxpZFVudGlsEiIKDW1heF9pZGxlX3RpbWUYBCABKA1SC21heElkbGVUaW1lEjYKGG1heF9jbGllbnRfdG9fc2VsZl9kZWxheRgFIAEoDVIUbWF4Q2xpZW50VG9TZWxmRGVsYXkSGAoHcHJvbWlzZRgGIAEoCVIHcHJvbWlzZQ==');
 @$core.Deprecated('Use lSPListReplyDescriptor instead')
 const LSPListReply$json = const {
   '1': 'LSPListReply',
@@ -218,7 +241,8 @@ const LSPListReply_LspsEntry$json = const {
 };
 
 /// Descriptor for `LSPListReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List lSPListReplyDescriptor = $convert.base64Decode('CgxMU1BMaXN0UmVwbHkSMQoEbHNwcxgBIAMoCzIdLmJyZWV6LkxTUExpc3RSZXBseS5Mc3BzRW50cnlSBGxzcHMaTgoJTHNwc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EisKBXZhbHVlGAIgASgLMhUuYnJlZXouTFNQSW5mb3JtYXRpb25SBXZhbHVlOgI4AQ==');
+final $typed_data.Uint8List lSPListReplyDescriptor = $convert.base64Decode(
+    'CgxMU1BMaXN0UmVwbHkSMQoEbHNwcxgBIAMoCzIdLmJyZWV6LkxTUExpc3RSZXBseS5Mc3BzRW50cnlSBGxzcHMaTgoJTHNwc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EisKBXZhbHVlGAIgASgLMhUuYnJlZXouTFNQSW5mb3JtYXRpb25SBXZhbHVlOgI4AQ==');
 @$core.Deprecated('Use registerPaymentRequestDescriptor instead')
 const RegisterPaymentRequest$json = const {
   '1': 'RegisterPaymentRequest',
@@ -229,14 +253,16 @@ const RegisterPaymentRequest$json = const {
 };
 
 /// Descriptor for `RegisterPaymentRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List registerPaymentRequestDescriptor = $convert.base64Decode('ChZSZWdpc3RlclBheW1lbnRSZXF1ZXN0EhUKBmxzcF9pZBgBIAEoCVIFbHNwSWQSEgoEYmxvYhgDIAEoDFIEYmxvYg==');
+final $typed_data.Uint8List registerPaymentRequestDescriptor = $convert.base64Decode(
+    'ChZSZWdpc3RlclBheW1lbnRSZXF1ZXN0EhUKBmxzcF9pZBgBIAEoCVIFbHNwSWQSEgoEYmxvYhgDIAEoDFIEYmxvYg==');
 @$core.Deprecated('Use registerPaymentReplyDescriptor instead')
 const RegisterPaymentReply$json = const {
   '1': 'RegisterPaymentReply',
 };
 
 /// Descriptor for `RegisterPaymentReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List registerPaymentReplyDescriptor = $convert.base64Decode('ChRSZWdpc3RlclBheW1lbnRSZXBseQ==');
+final $typed_data.Uint8List registerPaymentReplyDescriptor =
+    $convert.base64Decode('ChRSZWdpc3RlclBheW1lbnRSZXBseQ==');
 @$core.Deprecated('Use checkChannelsRequestDescriptor instead')
 const CheckChannelsRequest$json = const {
   '1': 'CheckChannelsRequest',
@@ -247,7 +273,8 @@ const CheckChannelsRequest$json = const {
 };
 
 /// Descriptor for `CheckChannelsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List checkChannelsRequestDescriptor = $convert.base64Decode('ChRDaGVja0NoYW5uZWxzUmVxdWVzdBIVCgZsc3BfaWQYASABKAlSBWxzcElkEhIKBGJsb2IYAiABKAxSBGJsb2I=');
+final $typed_data.Uint8List checkChannelsRequestDescriptor = $convert
+    .base64Decode('ChRDaGVja0NoYW5uZWxzUmVxdWVzdBIVCgZsc3BfaWQYASABKAlSBWxzcElkEhIKBGJsb2IYAiABKAxSBGJsb2I=');
 @$core.Deprecated('Use checkChannelsReplyDescriptor instead')
 const CheckChannelsReply$json = const {
   '1': 'CheckChannelsReply',
@@ -257,7 +284,8 @@ const CheckChannelsReply$json = const {
 };
 
 /// Descriptor for `CheckChannelsReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List checkChannelsReplyDescriptor = $convert.base64Decode('ChJDaGVja0NoYW5uZWxzUmVwbHkSEgoEYmxvYhgCIAEoDFIEYmxvYg==');
+final $typed_data.Uint8List checkChannelsReplyDescriptor =
+    $convert.base64Decode('ChJDaGVja0NoYW5uZWxzUmVwbHkSEgoEYmxvYhgCIAEoDFIEYmxvYg==');
 @$core.Deprecated('Use captchaDescriptor instead')
 const Captcha$json = const {
   '1': 'Captcha',
@@ -268,7 +296,8 @@ const Captcha$json = const {
 };
 
 /// Descriptor for `Captcha`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List captchaDescriptor = $convert.base64Decode('CgdDYXB0Y2hhEg4KAmlkGAEgASgJUgJpZBIUCgVpbWFnZRgCIAEoDFIFaW1hZ2U=');
+final $typed_data.Uint8List captchaDescriptor =
+    $convert.base64Decode('CgdDYXB0Y2hhEg4KAmlkGAEgASgJUgJpZBIUCgVpbWFnZRgCIAEoDFIFaW1hZ2U=');
 @$core.Deprecated('Use updateChannelPolicyRequestDescriptor instead')
 const UpdateChannelPolicyRequest$json = const {
   '1': 'UpdateChannelPolicyRequest',
@@ -278,14 +307,16 @@ const UpdateChannelPolicyRequest$json = const {
 };
 
 /// Descriptor for `UpdateChannelPolicyRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List updateChannelPolicyRequestDescriptor = $convert.base64Decode('ChpVcGRhdGVDaGFubmVsUG9saWN5UmVxdWVzdBIWCgZwdWJLZXkYASABKAlSBnB1YktleQ==');
+final $typed_data.Uint8List updateChannelPolicyRequestDescriptor =
+    $convert.base64Decode('ChpVcGRhdGVDaGFubmVsUG9saWN5UmVxdWVzdBIWCgZwdWJLZXkYASABKAlSBnB1YktleQ==');
 @$core.Deprecated('Use updateChannelPolicyReplyDescriptor instead')
 const UpdateChannelPolicyReply$json = const {
   '1': 'UpdateChannelPolicyReply',
 };
 
 /// Descriptor for `UpdateChannelPolicyReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List updateChannelPolicyReplyDescriptor = $convert.base64Decode('ChhVcGRhdGVDaGFubmVsUG9saWN5UmVwbHk=');
+final $typed_data.Uint8List updateChannelPolicyReplyDescriptor =
+    $convert.base64Decode('ChhVcGRhdGVDaGFubmVsUG9saWN5UmVwbHk=');
 @$core.Deprecated('Use addFundInitRequestDescriptor instead')
 const AddFundInitRequest$json = const {
   '1': 'AddFundInitRequest',
@@ -298,7 +329,8 @@ const AddFundInitRequest$json = const {
 };
 
 /// Descriptor for `AddFundInitRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List addFundInitRequestDescriptor = $convert.base64Decode('ChJBZGRGdW5kSW5pdFJlcXVlc3QSFgoGbm9kZUlEGAEgASgJUgZub2RlSUQSLAoRbm90aWZpY2F0aW9uVG9rZW4YAiABKAlSEW5vdGlmaWNhdGlvblRva2VuEhYKBnB1YmtleRgDIAEoDFIGcHVia2V5EhIKBGhhc2gYBCABKAxSBGhhc2g=');
+final $typed_data.Uint8List addFundInitRequestDescriptor = $convert.base64Decode(
+    'ChJBZGRGdW5kSW5pdFJlcXVlc3QSFgoGbm9kZUlEGAEgASgJUgZub2RlSUQSLAoRbm90aWZpY2F0aW9uVG9rZW4YAiABKAlSEW5vdGlmaWNhdGlvblRva2VuEhYKBnB1YmtleRgDIAEoDFIGcHVia2V5EhIKBGhhc2gYBCABKAxSBGhhc2g=');
 @$core.Deprecated('Use addFundInitReplyDescriptor instead')
 const AddFundInitReply$json = const {
   '1': 'AddFundInitReply',
@@ -314,7 +346,8 @@ const AddFundInitReply$json = const {
 };
 
 /// Descriptor for `AddFundInitReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List addFundInitReplyDescriptor = $convert.base64Decode('ChBBZGRGdW5kSW5pdFJlcGx5EhgKB2FkZHJlc3MYASABKAlSB2FkZHJlc3MSFgoGcHVia2V5GAIgASgMUgZwdWJrZXkSHgoKbG9ja0hlaWdodBgDIAEoA1IKbG9ja0hlaWdodBIsChFtYXhBbGxvd2VkRGVwb3NpdBgEIAEoA1IRbWF4QWxsb3dlZERlcG9zaXQSIgoMZXJyb3JNZXNzYWdlGAUgASgJUgxlcnJvck1lc3NhZ2USKAoPcmVxdWlyZWRSZXNlcnZlGAYgASgDUg9yZXF1aXJlZFJlc2VydmUSLAoRbWluQWxsb3dlZERlcG9zaXQYByABKANSEW1pbkFsbG93ZWREZXBvc2l0');
+final $typed_data.Uint8List addFundInitReplyDescriptor = $convert.base64Decode(
+    'ChBBZGRGdW5kSW5pdFJlcGx5EhgKB2FkZHJlc3MYASABKAlSB2FkZHJlc3MSFgoGcHVia2V5GAIgASgMUgZwdWJrZXkSHgoKbG9ja0hlaWdodBgDIAEoA1IKbG9ja0hlaWdodBIsChFtYXhBbGxvd2VkRGVwb3NpdBgEIAEoA1IRbWF4QWxsb3dlZERlcG9zaXQSIgoMZXJyb3JNZXNzYWdlGAUgASgJUgxlcnJvck1lc3NhZ2USKAoPcmVxdWlyZWRSZXNlcnZlGAYgASgDUg9yZXF1aXJlZFJlc2VydmUSLAoRbWluQWxsb3dlZERlcG9zaXQYByABKANSEW1pbkFsbG93ZWREZXBvc2l0');
 @$core.Deprecated('Use addFundStatusRequestDescriptor instead')
 const AddFundStatusRequest$json = const {
   '1': 'AddFundStatusRequest',
@@ -325,12 +358,20 @@ const AddFundStatusRequest$json = const {
 };
 
 /// Descriptor for `AddFundStatusRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List addFundStatusRequestDescriptor = $convert.base64Decode('ChRBZGRGdW5kU3RhdHVzUmVxdWVzdBIcCglhZGRyZXNzZXMYASADKAlSCWFkZHJlc3NlcxIsChFub3RpZmljYXRpb25Ub2tlbhgCIAEoCVIRbm90aWZpY2F0aW9uVG9rZW4=');
+final $typed_data.Uint8List addFundStatusRequestDescriptor = $convert.base64Decode(
+    'ChRBZGRGdW5kU3RhdHVzUmVxdWVzdBIcCglhZGRyZXNzZXMYASADKAlSCWFkZHJlc3NlcxIsChFub3RpZmljYXRpb25Ub2tlbhgCIAEoCVIRbm90aWZpY2F0aW9uVG9rZW4=');
 @$core.Deprecated('Use addFundStatusReplyDescriptor instead')
 const AddFundStatusReply$json = const {
   '1': 'AddFundStatusReply',
   '2': const [
-    const {'1': 'statuses', '3': 1, '4': 3, '5': 11, '6': '.breez.AddFundStatusReply.StatusesEntry', '10': 'statuses'},
+    const {
+      '1': 'statuses',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.breez.AddFundStatusReply.StatusesEntry',
+      '10': 'statuses'
+    },
   ],
   '3': const [AddFundStatusReply_AddressStatus$json, AddFundStatusReply_StatusesEntry$json],
 };
@@ -351,13 +392,21 @@ const AddFundStatusReply_StatusesEntry$json = const {
   '1': 'StatusesEntry',
   '2': const [
     const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 11, '6': '.breez.AddFundStatusReply.AddressStatus', '10': 'value'},
+    const {
+      '1': 'value',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.breez.AddFundStatusReply.AddressStatus',
+      '10': 'value'
+    },
   ],
   '7': const {'7': true},
 };
 
 /// Descriptor for `AddFundStatusReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List addFundStatusReplyDescriptor = $convert.base64Decode('ChJBZGRGdW5kU3RhdHVzUmVwbHkSQwoIc3RhdHVzZXMYASADKAsyJy5icmVlei5BZGRGdW5kU3RhdHVzUmVwbHkuU3RhdHVzZXNFbnRyeVIIc3RhdHVzZXMacwoNQWRkcmVzc1N0YXR1cxIOCgJ0eBgBIAEoCVICdHgSFgoGYW1vdW50GAIgASgDUgZhbW91bnQSHAoJY29uZmlybWVkGAMgASgIUgljb25maXJtZWQSHAoJYmxvY2tIYXNoGAQgASgJUglibG9ja0hhc2gaZAoNU3RhdHVzZXNFbnRyeRIQCgNrZXkYASABKAlSA2tleRI9CgV2YWx1ZRgCIAEoCzInLmJyZWV6LkFkZEZ1bmRTdGF0dXNSZXBseS5BZGRyZXNzU3RhdHVzUgV2YWx1ZToCOAE=');
+final $typed_data.Uint8List addFundStatusReplyDescriptor = $convert.base64Decode(
+    'ChJBZGRGdW5kU3RhdHVzUmVwbHkSQwoIc3RhdHVzZXMYASADKAsyJy5icmVlei5BZGRGdW5kU3RhdHVzUmVwbHkuU3RhdHVzZXNFbnRyeVIIc3RhdHVzZXMacwoNQWRkcmVzc1N0YXR1cxIOCgJ0eBgBIAEoCVICdHgSFgoGYW1vdW50GAIgASgDUgZhbW91bnQSHAoJY29uZmlybWVkGAMgASgIUgljb25maXJtZWQSHAoJYmxvY2tIYXNoGAQgASgJUglibG9ja0hhc2gaZAoNU3RhdHVzZXNFbnRyeRIQCgNrZXkYASABKAlSA2tleRI9CgV2YWx1ZRgCIAEoCzInLmJyZWV6LkFkZEZ1bmRTdGF0dXNSZXBseS5BZGRyZXNzU3RhdHVzUgV2YWx1ZToCOAE=');
 @$core.Deprecated('Use removeFundRequestDescriptor instead')
 const RemoveFundRequest$json = const {
   '1': 'RemoveFundRequest',
@@ -368,7 +417,8 @@ const RemoveFundRequest$json = const {
 };
 
 /// Descriptor for `RemoveFundRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removeFundRequestDescriptor = $convert.base64Decode('ChFSZW1vdmVGdW5kUmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEhYKBmFtb3VudBgCIAEoA1IGYW1vdW50');
+final $typed_data.Uint8List removeFundRequestDescriptor = $convert.base64Decode(
+    'ChFSZW1vdmVGdW5kUmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEhYKBmFtb3VudBgCIAEoA1IGYW1vdW50');
 @$core.Deprecated('Use removeFundReplyDescriptor instead')
 const RemoveFundReply$json = const {
   '1': 'RemoveFundReply',
@@ -379,7 +429,8 @@ const RemoveFundReply$json = const {
 };
 
 /// Descriptor for `RemoveFundReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removeFundReplyDescriptor = $convert.base64Decode('Cg9SZW1vdmVGdW5kUmVwbHkSJgoOcGF5bWVudFJlcXVlc3QYASABKAlSDnBheW1lbnRSZXF1ZXN0EiIKDGVycm9yTWVzc2FnZRgCIAEoCVIMZXJyb3JNZXNzYWdl');
+final $typed_data.Uint8List removeFundReplyDescriptor = $convert.base64Decode(
+    'Cg9SZW1vdmVGdW5kUmVwbHkSJgoOcGF5bWVudFJlcXVlc3QYASABKAlSDnBheW1lbnRSZXF1ZXN0EiIKDGVycm9yTWVzc2FnZRgCIAEoCVIMZXJyb3JNZXNzYWdl');
 @$core.Deprecated('Use redeemRemovedFundsRequestDescriptor instead')
 const RedeemRemovedFundsRequest$json = const {
   '1': 'RedeemRemovedFundsRequest',
@@ -389,7 +440,8 @@ const RedeemRemovedFundsRequest$json = const {
 };
 
 /// Descriptor for `RedeemRemovedFundsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List redeemRemovedFundsRequestDescriptor = $convert.base64Decode('ChlSZWRlZW1SZW1vdmVkRnVuZHNSZXF1ZXN0EiAKC3BheW1lbnRoYXNoGAEgASgJUgtwYXltZW50aGFzaA==');
+final $typed_data.Uint8List redeemRemovedFundsRequestDescriptor = $convert
+    .base64Decode('ChlSZWRlZW1SZW1vdmVkRnVuZHNSZXF1ZXN0EiAKC3BheW1lbnRoYXNoGAEgASgJUgtwYXltZW50aGFzaA==');
 @$core.Deprecated('Use redeemRemovedFundsReplyDescriptor instead')
 const RedeemRemovedFundsReply$json = const {
   '1': 'RedeemRemovedFundsReply',
@@ -399,7 +451,8 @@ const RedeemRemovedFundsReply$json = const {
 };
 
 /// Descriptor for `RedeemRemovedFundsReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List redeemRemovedFundsReplyDescriptor = $convert.base64Decode('ChdSZWRlZW1SZW1vdmVkRnVuZHNSZXBseRISCgR0eGlkGAEgASgJUgR0eGlk');
+final $typed_data.Uint8List redeemRemovedFundsReplyDescriptor =
+    $convert.base64Decode('ChdSZWRlZW1SZW1vdmVkRnVuZHNSZXBseRISCgR0eGlkGAEgASgJUgR0eGlk');
 @$core.Deprecated('Use getSwapPaymentRequestDescriptor instead')
 const GetSwapPaymentRequest$json = const {
   '1': 'GetSwapPaymentRequest',
@@ -409,14 +462,22 @@ const GetSwapPaymentRequest$json = const {
 };
 
 /// Descriptor for `GetSwapPaymentRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSwapPaymentRequestDescriptor = $convert.base64Decode('ChVHZXRTd2FwUGF5bWVudFJlcXVlc3QSJgoOcGF5bWVudFJlcXVlc3QYASABKAlSDnBheW1lbnRSZXF1ZXN0');
+final $typed_data.Uint8List getSwapPaymentRequestDescriptor = $convert
+    .base64Decode('ChVHZXRTd2FwUGF5bWVudFJlcXVlc3QSJgoOcGF5bWVudFJlcXVlc3QYASABKAlSDnBheW1lbnRSZXF1ZXN0');
 @$core.Deprecated('Use getSwapPaymentReplyDescriptor instead')
 const GetSwapPaymentReply$json = const {
   '1': 'GetSwapPaymentReply',
   '2': const [
     const {'1': 'paymentError', '3': 1, '4': 1, '5': 9, '10': 'paymentError'},
     const {'1': 'funds_exceeded_limit', '3': 2, '4': 1, '5': 8, '10': 'fundsExceededLimit'},
-    const {'1': 'swap_error', '3': 3, '4': 1, '5': 14, '6': '.breez.GetSwapPaymentReply.SwapError', '10': 'swapError'},
+    const {
+      '1': 'swap_error',
+      '3': 3,
+      '4': 1,
+      '5': 14,
+      '6': '.breez.GetSwapPaymentReply.SwapError',
+      '10': 'swapError'
+    },
   ],
   '4': const [GetSwapPaymentReply_SwapError$json],
 };
@@ -434,7 +495,8 @@ const GetSwapPaymentReply_SwapError$json = const {
 };
 
 /// Descriptor for `GetSwapPaymentReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getSwapPaymentReplyDescriptor = $convert.base64Decode('ChNHZXRTd2FwUGF5bWVudFJlcGx5EiIKDHBheW1lbnRFcnJvchgBIAEoCVIMcGF5bWVudEVycm9yEjAKFGZ1bmRzX2V4Y2VlZGVkX2xpbWl0GAIgASgIUhJmdW5kc0V4Y2VlZGVkTGltaXQSQwoKc3dhcF9lcnJvchgDIAEoDjIkLmJyZWV6LkdldFN3YXBQYXltZW50UmVwbHkuU3dhcEVycm9yUglzd2FwRXJyb3IicgoJU3dhcEVycm9yEgwKCE5PX0VSUk9SEAASFgoSRlVORFNfRVhDRUVEX0xJTUlUEAESEAoMVFhfVE9PX1NNQUxMEAISGwoXSU5WT0lDRV9BTU9VTlRfTUlTTUFUQ0gQAxIQCgxTV0FQX0VYUElSRUQQBA==');
+final $typed_data.Uint8List getSwapPaymentReplyDescriptor = $convert.base64Decode(
+    'ChNHZXRTd2FwUGF5bWVudFJlcGx5EiIKDHBheW1lbnRFcnJvchgBIAEoCVIMcGF5bWVudEVycm9yEjAKFGZ1bmRzX2V4Y2VlZGVkX2xpbWl0GAIgASgIUhJmdW5kc0V4Y2VlZGVkTGltaXQSQwoKc3dhcF9lcnJvchgDIAEoDjIkLmJyZWV6LkdldFN3YXBQYXltZW50UmVwbHkuU3dhcEVycm9yUglzd2FwRXJyb3IicgoJU3dhcEVycm9yEgwKCE5PX0VSUk9SEAASFgoSRlVORFNfRVhDRUVEX0xJTUlUEAESEAoMVFhfVE9PX1NNQUxMEAISGwoXSU5WT0lDRV9BTU9VTlRfTUlTTUFUQ0gQAxIQCgxTV0FQX0VYUElSRUQQBA==');
 @$core.Deprecated('Use redeemSwapPaymentRequestDescriptor instead')
 const RedeemSwapPaymentRequest$json = const {
   '1': 'RedeemSwapPaymentRequest',
@@ -446,7 +508,8 @@ const RedeemSwapPaymentRequest$json = const {
 };
 
 /// Descriptor for `RedeemSwapPaymentRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List redeemSwapPaymentRequestDescriptor = $convert.base64Decode('ChhSZWRlZW1Td2FwUGF5bWVudFJlcXVlc3QSGgoIcHJlaW1hZ2UYASABKAxSCHByZWltYWdlEh8KC3RhcmdldF9jb25mGAIgASgFUgp0YXJnZXRDb25mEiAKDHNhdF9wZXJfYnl0ZRgDIAEoA1IKc2F0UGVyQnl0ZQ==');
+final $typed_data.Uint8List redeemSwapPaymentRequestDescriptor = $convert.base64Decode(
+    'ChhSZWRlZW1Td2FwUGF5bWVudFJlcXVlc3QSGgoIcHJlaW1hZ2UYASABKAxSCHByZWltYWdlEh8KC3RhcmdldF9jb25mGAIgASgFUgp0YXJnZXRDb25mEiAKDHNhdF9wZXJfYnl0ZRgDIAEoA1IKc2F0UGVyQnl0ZQ==');
 @$core.Deprecated('Use redeemSwapPaymentReplyDescriptor instead')
 const RedeemSwapPaymentReply$json = const {
   '1': 'RedeemSwapPaymentReply',
@@ -456,7 +519,8 @@ const RedeemSwapPaymentReply$json = const {
 };
 
 /// Descriptor for `RedeemSwapPaymentReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List redeemSwapPaymentReplyDescriptor = $convert.base64Decode('ChZSZWRlZW1Td2FwUGF5bWVudFJlcGx5EhIKBHR4aWQYASABKAlSBHR4aWQ=');
+final $typed_data.Uint8List redeemSwapPaymentReplyDescriptor =
+    $convert.base64Decode('ChZSZWRlZW1Td2FwUGF5bWVudFJlcGx5EhIKBHR4aWQYASABKAlSBHR4aWQ=');
 @$core.Deprecated('Use registerRequestDescriptor instead')
 const RegisterRequest$json = const {
   '1': 'RegisterRequest',
@@ -467,7 +531,8 @@ const RegisterRequest$json = const {
 };
 
 /// Descriptor for `RegisterRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List registerRequestDescriptor = $convert.base64Decode('Cg9SZWdpc3RlclJlcXVlc3QSGgoIZGV2aWNlSUQYASABKAlSCGRldmljZUlEEiAKC2xpZ2h0bmluZ0lEGAIgASgJUgtsaWdodG5pbmdJRA==');
+final $typed_data.Uint8List registerRequestDescriptor = $convert.base64Decode(
+    'Cg9SZWdpc3RlclJlcXVlc3QSGgoIZGV2aWNlSUQYASABKAlSCGRldmljZUlEEiAKC2xpZ2h0bmluZ0lEGAIgASgJUgtsaWdodG5pbmdJRA==');
 @$core.Deprecated('Use registerReplyDescriptor instead')
 const RegisterReply$json = const {
   '1': 'RegisterReply',
@@ -477,7 +542,8 @@ const RegisterReply$json = const {
 };
 
 /// Descriptor for `RegisterReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List registerReplyDescriptor = $convert.base64Decode('Cg1SZWdpc3RlclJlcGx5EhgKB2JyZWV6SUQYASABKAlSB2JyZWV6SUQ=');
+final $typed_data.Uint8List registerReplyDescriptor =
+    $convert.base64Decode('Cg1SZWdpc3RlclJlcGx5EhgKB2JyZWV6SUQYASABKAlSB2JyZWV6SUQ=');
 @$core.Deprecated('Use paymentRequestDescriptor instead')
 const PaymentRequest$json = const {
   '1': 'PaymentRequest',
@@ -490,7 +556,8 @@ const PaymentRequest$json = const {
 };
 
 /// Descriptor for `PaymentRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List paymentRequestDescriptor = $convert.base64Decode('Cg5QYXltZW50UmVxdWVzdBIYCgdicmVleklEGAEgASgJUgdicmVleklEEhgKB2ludm9pY2UYAiABKAlSB2ludm9pY2USFAoFcGF5ZWUYAyABKAlSBXBheWVlEhYKBmFtb3VudBgEIAEoA1IGYW1vdW50');
+final $typed_data.Uint8List paymentRequestDescriptor = $convert.base64Decode(
+    'Cg5QYXltZW50UmVxdWVzdBIYCgdicmVleklEGAEgASgJUgdicmVleklEEhgKB2ludm9pY2UYAiABKAlSB2ludm9pY2USFAoFcGF5ZWUYAyABKAlSBXBheWVlEhYKBmFtb3VudBgEIAEoA1IGYW1vdW50');
 @$core.Deprecated('Use invoiceReplyDescriptor instead')
 const InvoiceReply$json = const {
   '1': 'InvoiceReply',
@@ -500,7 +567,8 @@ const InvoiceReply$json = const {
 };
 
 /// Descriptor for `InvoiceReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List invoiceReplyDescriptor = $convert.base64Decode('CgxJbnZvaWNlUmVwbHkSFAoFRXJyb3IYASABKAlSBUVycm9y');
+final $typed_data.Uint8List invoiceReplyDescriptor =
+    $convert.base64Decode('CgxJbnZvaWNlUmVwbHkSFAoFRXJyb3IYASABKAlSBUVycm9y');
 @$core.Deprecated('Use uploadFileRequestDescriptor instead')
 const UploadFileRequest$json = const {
   '1': 'UploadFileRequest',
@@ -510,7 +578,8 @@ const UploadFileRequest$json = const {
 };
 
 /// Descriptor for `UploadFileRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List uploadFileRequestDescriptor = $convert.base64Decode('ChFVcGxvYWRGaWxlUmVxdWVzdBIYCgdjb250ZW50GAEgASgMUgdjb250ZW50');
+final $typed_data.Uint8List uploadFileRequestDescriptor =
+    $convert.base64Decode('ChFVcGxvYWRGaWxlUmVxdWVzdBIYCgdjb250ZW50GAEgASgMUgdjb250ZW50');
 @$core.Deprecated('Use uploadFileReplyDescriptor instead')
 const UploadFileReply$json = const {
   '1': 'UploadFileReply',
@@ -520,7 +589,8 @@ const UploadFileReply$json = const {
 };
 
 /// Descriptor for `UploadFileReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List uploadFileReplyDescriptor = $convert.base64Decode('Cg9VcGxvYWRGaWxlUmVwbHkSEAoDdXJsGAEgASgJUgN1cmw=');
+final $typed_data.Uint8List uploadFileReplyDescriptor =
+    $convert.base64Decode('Cg9VcGxvYWRGaWxlUmVwbHkSEAoDdXJsGAEgASgJUgN1cmw=');
 @$core.Deprecated('Use pingRequestDescriptor instead')
 const PingRequest$json = const {
   '1': 'PingRequest',
@@ -537,7 +607,8 @@ const PingReply$json = const {
 };
 
 /// Descriptor for `PingReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List pingReplyDescriptor = $convert.base64Decode('CglQaW5nUmVwbHkSGAoHdmVyc2lvbhgBIAEoCVIHdmVyc2lvbg==');
+final $typed_data.Uint8List pingReplyDescriptor =
+    $convert.base64Decode('CglQaW5nUmVwbHkSGAoHdmVyc2lvbhgBIAEoCVIHdmVyc2lvbg==');
 @$core.Deprecated('Use orderRequestDescriptor instead')
 const OrderRequest$json = const {
   '1': 'OrderRequest',
@@ -553,7 +624,8 @@ const OrderRequest$json = const {
 };
 
 /// Descriptor for `OrderRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List orderRequestDescriptor = $convert.base64Decode('CgxPcmRlclJlcXVlc3QSGgoIRnVsbE5hbWUYASABKAlSCEZ1bGxOYW1lEhgKB0FkZHJlc3MYAiABKAlSB0FkZHJlc3MSEgoEQ2l0eRgDIAEoCVIEQ2l0eRIUCgVTdGF0ZRgEIAEoCVIFU3RhdGUSEAoDWmlwGAUgASgJUgNaaXASGAoHQ291bnRyeRgGIAEoCVIHQ291bnRyeRIUCgVFbWFpbBgHIAEoCVIFRW1haWw=');
+final $typed_data.Uint8List orderRequestDescriptor = $convert.base64Decode(
+    'CgxPcmRlclJlcXVlc3QSGgoIRnVsbE5hbWUYASABKAlSCEZ1bGxOYW1lEhgKB0FkZHJlc3MYAiABKAlSB0FkZHJlc3MSEgoEQ2l0eRgDIAEoCVIEQ2l0eRIUCgVTdGF0ZRgEIAEoCVIFU3RhdGUSEAoDWmlwGAUgASgJUgNaaXASGAoHQ291bnRyeRgGIAEoCVIHQ291bnRyeRIUCgVFbWFpbBgHIAEoCVIFRW1haWw=');
 @$core.Deprecated('Use orderReplyDescriptor instead')
 const OrderReply$json = const {
   '1': 'OrderReply',
@@ -574,14 +646,16 @@ const SetNodeInfoRequest$json = const {
 };
 
 /// Descriptor for `SetNodeInfoRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setNodeInfoRequestDescriptor = $convert.base64Decode('ChJTZXROb2RlSW5mb1JlcXVlc3QSFgoGcHVia2V5GAEgASgMUgZwdWJrZXkSEAoDa2V5GAIgASgJUgNrZXkSFAoFdmFsdWUYAyABKAxSBXZhbHVlEhwKCXRpbWVzdGFtcBgEIAEoA1IJdGltZXN0YW1wEhwKCXNpZ25hdHVyZRgFIAEoDFIJc2lnbmF0dXJl');
+final $typed_data.Uint8List setNodeInfoRequestDescriptor = $convert.base64Decode(
+    'ChJTZXROb2RlSW5mb1JlcXVlc3QSFgoGcHVia2V5GAEgASgMUgZwdWJrZXkSEAoDa2V5GAIgASgJUgNrZXkSFAoFdmFsdWUYAyABKAxSBXZhbHVlEhwKCXRpbWVzdGFtcBgEIAEoA1IJdGltZXN0YW1wEhwKCXNpZ25hdHVyZRgFIAEoDFIJc2lnbmF0dXJl');
 @$core.Deprecated('Use setNodeInfoResponseDescriptor instead')
 const SetNodeInfoResponse$json = const {
   '1': 'SetNodeInfoResponse',
 };
 
 /// Descriptor for `SetNodeInfoResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List setNodeInfoResponseDescriptor = $convert.base64Decode('ChNTZXROb2RlSW5mb1Jlc3BvbnNl');
+final $typed_data.Uint8List setNodeInfoResponseDescriptor =
+    $convert.base64Decode('ChNTZXROb2RlSW5mb1Jlc3BvbnNl');
 @$core.Deprecated('Use getNodeInfoRequestDescriptor instead')
 const GetNodeInfoRequest$json = const {
   '1': 'GetNodeInfoRequest',
@@ -592,7 +666,8 @@ const GetNodeInfoRequest$json = const {
 };
 
 /// Descriptor for `GetNodeInfoRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNodeInfoRequestDescriptor = $convert.base64Decode('ChJHZXROb2RlSW5mb1JlcXVlc3QSFgoGcHVia2V5GAEgASgMUgZwdWJrZXkSEAoDa2V5GAIgASgJUgNrZXk=');
+final $typed_data.Uint8List getNodeInfoRequestDescriptor = $convert
+    .base64Decode('ChJHZXROb2RlSW5mb1JlcXVlc3QSFgoGcHVia2V5GAEgASgMUgZwdWJrZXkSEAoDa2V5GAIgASgJUgNrZXk=');
 @$core.Deprecated('Use getNodeInfoResponseDescriptor instead')
 const GetNodeInfoResponse$json = const {
   '1': 'GetNodeInfoResponse',
@@ -604,12 +679,20 @@ const GetNodeInfoResponse$json = const {
 };
 
 /// Descriptor for `GetNodeInfoResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getNodeInfoResponseDescriptor = $convert.base64Decode('ChNHZXROb2RlSW5mb1Jlc3BvbnNlEhQKBXZhbHVlGAEgASgMUgV2YWx1ZRIcCgl0aW1lc3RhbXAYAiABKANSCXRpbWVzdGFtcBIcCglzaWduYXR1cmUYAyABKAxSCXNpZ25hdHVyZQ==');
+final $typed_data.Uint8List getNodeInfoResponseDescriptor = $convert.base64Decode(
+    'ChNHZXROb2RlSW5mb1Jlc3BvbnNlEhQKBXZhbHVlGAEgASgMUgV2YWx1ZRIcCgl0aW1lc3RhbXAYAiABKANSCXRpbWVzdGFtcBIcCglzaWduYXR1cmUYAyABKAxSCXNpZ25hdHVyZQ==');
 @$core.Deprecated('Use joinCTPSessionRequestDescriptor instead')
 const JoinCTPSessionRequest$json = const {
   '1': 'JoinCTPSessionRequest',
   '2': const [
-    const {'1': 'partyType', '3': 1, '4': 1, '5': 14, '6': '.breez.JoinCTPSessionRequest.PartyType', '10': 'partyType'},
+    const {
+      '1': 'partyType',
+      '3': 1,
+      '4': 1,
+      '5': 14,
+      '6': '.breez.JoinCTPSessionRequest.PartyType',
+      '10': 'partyType'
+    },
     const {'1': 'partyName', '3': 2, '4': 1, '5': 9, '10': 'partyName'},
     const {'1': 'notificationToken', '3': 3, '4': 1, '5': 9, '10': 'notificationToken'},
     const {'1': 'sessionID', '3': 4, '4': 1, '5': 9, '10': 'sessionID'},
@@ -627,7 +710,8 @@ const JoinCTPSessionRequest_PartyType$json = const {
 };
 
 /// Descriptor for `JoinCTPSessionRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List joinCTPSessionRequestDescriptor = $convert.base64Decode('ChVKb2luQ1RQU2Vzc2lvblJlcXVlc3QSRAoJcGFydHlUeXBlGAEgASgOMiYuYnJlZXouSm9pbkNUUFNlc3Npb25SZXF1ZXN0LlBhcnR5VHlwZVIJcGFydHlUeXBlEhwKCXBhcnR5TmFtZRgCIAEoCVIJcGFydHlOYW1lEiwKEW5vdGlmaWNhdGlvblRva2VuGAMgASgJUhFub3RpZmljYXRpb25Ub2tlbhIcCglzZXNzaW9uSUQYBCABKAlSCXNlc3Npb25JRCIhCglQYXJ0eVR5cGUSCQoFUEFZRVIQABIJCgVQQVlFRRAB');
+final $typed_data.Uint8List joinCTPSessionRequestDescriptor = $convert.base64Decode(
+    'ChVKb2luQ1RQU2Vzc2lvblJlcXVlc3QSRAoJcGFydHlUeXBlGAEgASgOMiYuYnJlZXouSm9pbkNUUFNlc3Npb25SZXF1ZXN0LlBhcnR5VHlwZVIJcGFydHlUeXBlEhwKCXBhcnR5TmFtZRgCIAEoCVIJcGFydHlOYW1lEiwKEW5vdGlmaWNhdGlvblRva2VuGAMgASgJUhFub3RpZmljYXRpb25Ub2tlbhIcCglzZXNzaW9uSUQYBCABKAlSCXNlc3Npb25JRCIhCglQYXJ0eVR5cGUSCQoFUEFZRVIQABIJCgVQQVlFRRAB');
 @$core.Deprecated('Use joinCTPSessionResponseDescriptor instead')
 const JoinCTPSessionResponse$json = const {
   '1': 'JoinCTPSessionResponse',
@@ -638,7 +722,8 @@ const JoinCTPSessionResponse$json = const {
 };
 
 /// Descriptor for `JoinCTPSessionResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List joinCTPSessionResponseDescriptor = $convert.base64Decode('ChZKb2luQ1RQU2Vzc2lvblJlc3BvbnNlEhwKCXNlc3Npb25JRBgBIAEoCVIJc2Vzc2lvbklEEhYKBmV4cGlyeRgCIAEoA1IGZXhwaXJ5');
+final $typed_data.Uint8List joinCTPSessionResponseDescriptor = $convert.base64Decode(
+    'ChZKb2luQ1RQU2Vzc2lvblJlc3BvbnNlEhwKCXNlc3Npb25JRBgBIAEoCVIJc2Vzc2lvbklEEhYKBmV4cGlyeRgCIAEoA1IGZXhwaXJ5');
 @$core.Deprecated('Use terminateCTPSessionRequestDescriptor instead')
 const TerminateCTPSessionRequest$json = const {
   '1': 'TerminateCTPSessionRequest',
@@ -648,21 +733,30 @@ const TerminateCTPSessionRequest$json = const {
 };
 
 /// Descriptor for `TerminateCTPSessionRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List terminateCTPSessionRequestDescriptor = $convert.base64Decode('ChpUZXJtaW5hdGVDVFBTZXNzaW9uUmVxdWVzdBIcCglzZXNzaW9uSUQYASABKAlSCXNlc3Npb25JRA==');
+final $typed_data.Uint8List terminateCTPSessionRequestDescriptor =
+    $convert.base64Decode('ChpUZXJtaW5hdGVDVFBTZXNzaW9uUmVxdWVzdBIcCglzZXNzaW9uSUQYASABKAlSCXNlc3Npb25JRA==');
 @$core.Deprecated('Use terminateCTPSessionResponseDescriptor instead')
 const TerminateCTPSessionResponse$json = const {
   '1': 'TerminateCTPSessionResponse',
 };
 
 /// Descriptor for `TerminateCTPSessionResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List terminateCTPSessionResponseDescriptor = $convert.base64Decode('ChtUZXJtaW5hdGVDVFBTZXNzaW9uUmVzcG9uc2U=');
+final $typed_data.Uint8List terminateCTPSessionResponseDescriptor =
+    $convert.base64Decode('ChtUZXJtaW5hdGVDVFBTZXNzaW9uUmVzcG9uc2U=');
 @$core.Deprecated('Use registerTransactionConfirmationRequestDescriptor instead')
 const RegisterTransactionConfirmationRequest$json = const {
   '1': 'RegisterTransactionConfirmationRequest',
   '2': const [
     const {'1': 'txID', '3': 1, '4': 1, '5': 9, '10': 'txID'},
     const {'1': 'notificationToken', '3': 2, '4': 1, '5': 9, '10': 'notificationToken'},
-    const {'1': 'notificationType', '3': 3, '4': 1, '5': 14, '6': '.breez.RegisterTransactionConfirmationRequest.NotificationType', '10': 'notificationType'},
+    const {
+      '1': 'notificationType',
+      '3': 3,
+      '4': 1,
+      '5': 14,
+      '6': '.breez.RegisterTransactionConfirmationRequest.NotificationType',
+      '10': 'notificationType'
+    },
   ],
   '4': const [RegisterTransactionConfirmationRequest_NotificationType$json],
 };
@@ -677,14 +771,16 @@ const RegisterTransactionConfirmationRequest_NotificationType$json = const {
 };
 
 /// Descriptor for `RegisterTransactionConfirmationRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List registerTransactionConfirmationRequestDescriptor = $convert.base64Decode('CiZSZWdpc3RlclRyYW5zYWN0aW9uQ29uZmlybWF0aW9uUmVxdWVzdBISCgR0eElEGAEgASgJUgR0eElEEiwKEW5vdGlmaWNhdGlvblRva2VuGAIgASgJUhFub3RpZmljYXRpb25Ub2tlbhJqChBub3RpZmljYXRpb25UeXBlGAMgASgOMj4uYnJlZXouUmVnaXN0ZXJUcmFuc2FjdGlvbkNvbmZpcm1hdGlvblJlcXVlc3QuTm90aWZpY2F0aW9uVHlwZVIQbm90aWZpY2F0aW9uVHlwZSJBChBOb3RpZmljYXRpb25UeXBlEhkKFVJFQURZX1JFQ0VJVkVfUEFZTUVOVBAAEhIKDkNIQU5ORUxfT1BFTkVEEAE=');
+final $typed_data.Uint8List registerTransactionConfirmationRequestDescriptor = $convert.base64Decode(
+    'CiZSZWdpc3RlclRyYW5zYWN0aW9uQ29uZmlybWF0aW9uUmVxdWVzdBISCgR0eElEGAEgASgJUgR0eElEEiwKEW5vdGlmaWNhdGlvblRva2VuGAIgASgJUhFub3RpZmljYXRpb25Ub2tlbhJqChBub3RpZmljYXRpb25UeXBlGAMgASgOMj4uYnJlZXouUmVnaXN0ZXJUcmFuc2FjdGlvbkNvbmZpcm1hdGlvblJlcXVlc3QuTm90aWZpY2F0aW9uVHlwZVIQbm90aWZpY2F0aW9uVHlwZSJBChBOb3RpZmljYXRpb25UeXBlEhkKFVJFQURZX1JFQ0VJVkVfUEFZTUVOVBAAEhIKDkNIQU5ORUxfT1BFTkVEEAE=');
 @$core.Deprecated('Use registerTransactionConfirmationResponseDescriptor instead')
 const RegisterTransactionConfirmationResponse$json = const {
   '1': 'RegisterTransactionConfirmationResponse',
 };
 
 /// Descriptor for `RegisterTransactionConfirmationResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List registerTransactionConfirmationResponseDescriptor = $convert.base64Decode('CidSZWdpc3RlclRyYW5zYWN0aW9uQ29uZmlybWF0aW9uUmVzcG9uc2U=');
+final $typed_data.Uint8List registerTransactionConfirmationResponseDescriptor =
+    $convert.base64Decode('CidSZWdpc3RlclRyYW5zYWN0aW9uQ29uZmlybWF0aW9uUmVzcG9uc2U=');
 @$core.Deprecated('Use registerPeriodicSyncRequestDescriptor instead')
 const RegisterPeriodicSyncRequest$json = const {
   '1': 'RegisterPeriodicSyncRequest',
@@ -694,14 +790,16 @@ const RegisterPeriodicSyncRequest$json = const {
 };
 
 /// Descriptor for `RegisterPeriodicSyncRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List registerPeriodicSyncRequestDescriptor = $convert.base64Decode('ChtSZWdpc3RlclBlcmlvZGljU3luY1JlcXVlc3QSLAoRbm90aWZpY2F0aW9uVG9rZW4YASABKAlSEW5vdGlmaWNhdGlvblRva2Vu');
+final $typed_data.Uint8List registerPeriodicSyncRequestDescriptor = $convert.base64Decode(
+    'ChtSZWdpc3RlclBlcmlvZGljU3luY1JlcXVlc3QSLAoRbm90aWZpY2F0aW9uVG9rZW4YASABKAlSEW5vdGlmaWNhdGlvblRva2Vu');
 @$core.Deprecated('Use registerPeriodicSyncResponseDescriptor instead')
 const RegisterPeriodicSyncResponse$json = const {
   '1': 'RegisterPeriodicSyncResponse',
 };
 
 /// Descriptor for `RegisterPeriodicSyncResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List registerPeriodicSyncResponseDescriptor = $convert.base64Decode('ChxSZWdpc3RlclBlcmlvZGljU3luY1Jlc3BvbnNl');
+final $typed_data.Uint8List registerPeriodicSyncResponseDescriptor =
+    $convert.base64Decode('ChxSZWdpc3RlclBlcmlvZGljU3luY1Jlc3BvbnNl');
 @$core.Deprecated('Use boltzReverseSwapLockupTxDescriptor instead')
 const BoltzReverseSwapLockupTx$json = const {
   '1': 'BoltzReverseSwapLockupTx',
@@ -712,7 +810,8 @@ const BoltzReverseSwapLockupTx$json = const {
 };
 
 /// Descriptor for `BoltzReverseSwapLockupTx`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List boltzReverseSwapLockupTxDescriptor = $convert.base64Decode('ChhCb2x0elJldmVyc2VTd2FwTG9ja3VwVHgSGQoIYm9sdHpfaWQYASABKAlSB2JvbHR6SWQSMAoUdGltZW91dF9ibG9ja19oZWlnaHQYAiABKA1SEnRpbWVvdXRCbG9ja0hlaWdodA==');
+final $typed_data.Uint8List boltzReverseSwapLockupTxDescriptor = $convert.base64Decode(
+    'ChhCb2x0elJldmVyc2VTd2FwTG9ja3VwVHgSGQoIYm9sdHpfaWQYASABKAlSB2JvbHR6SWQSMAoUdGltZW91dF9ibG9ja19oZWlnaHQYAiABKA1SEnRpbWVvdXRCbG9ja0hlaWdodA==');
 @$core.Deprecated('Use pushTxNotificationRequestDescriptor instead')
 const PushTxNotificationRequest$json = const {
   '1': 'PushTxNotificationRequest',
@@ -723,7 +822,15 @@ const PushTxNotificationRequest$json = const {
     const {'1': 'tx_hash', '3': 4, '4': 1, '5': 12, '10': 'txHash'},
     const {'1': 'script', '3': 5, '4': 1, '5': 12, '10': 'script'},
     const {'1': 'block_height_hint', '3': 6, '4': 1, '5': 13, '10': 'blockHeightHint'},
-    const {'1': 'boltz_reverse_swap_lockup_tx_info', '3': 7, '4': 1, '5': 11, '6': '.breez.BoltzReverseSwapLockupTx', '9': 0, '10': 'boltzReverseSwapLockupTxInfo'},
+    const {
+      '1': 'boltz_reverse_swap_lockup_tx_info',
+      '3': 7,
+      '4': 1,
+      '5': 11,
+      '6': '.breez.BoltzReverseSwapLockupTx',
+      '9': 0,
+      '10': 'boltzReverseSwapLockupTxInfo'
+    },
   ],
   '8': const [
     const {'1': 'info'},
@@ -731,21 +838,24 @@ const PushTxNotificationRequest$json = const {
 };
 
 /// Descriptor for `PushTxNotificationRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List pushTxNotificationRequestDescriptor = $convert.base64Decode('ChlQdXNoVHhOb3RpZmljYXRpb25SZXF1ZXN0EhsKCWRldmljZV9pZBgBIAEoCVIIZGV2aWNlSWQSFAoFdGl0bGUYAiABKAlSBXRpdGxlEhIKBGJvZHkYAyABKAlSBGJvZHkSFwoHdHhfaGFzaBgEIAEoDFIGdHhIYXNoEhYKBnNjcmlwdBgFIAEoDFIGc2NyaXB0EioKEWJsb2NrX2hlaWdodF9oaW50GAYgASgNUg9ibG9ja0hlaWdodEhpbnQSagohYm9sdHpfcmV2ZXJzZV9zd2FwX2xvY2t1cF90eF9pbmZvGAcgASgLMh8uYnJlZXouQm9sdHpSZXZlcnNlU3dhcExvY2t1cFR4SABSHGJvbHR6UmV2ZXJzZVN3YXBMb2NrdXBUeEluZm9CBgoEaW5mbw==');
+final $typed_data.Uint8List pushTxNotificationRequestDescriptor = $convert.base64Decode(
+    'ChlQdXNoVHhOb3RpZmljYXRpb25SZXF1ZXN0EhsKCWRldmljZV9pZBgBIAEoCVIIZGV2aWNlSWQSFAoFdGl0bGUYAiABKAlSBXRpdGxlEhIKBGJvZHkYAyABKAlSBGJvZHkSFwoHdHhfaGFzaBgEIAEoDFIGdHhIYXNoEhYKBnNjcmlwdBgFIAEoDFIGc2NyaXB0EioKEWJsb2NrX2hlaWdodF9oaW50GAYgASgNUg9ibG9ja0hlaWdodEhpbnQSagohYm9sdHpfcmV2ZXJzZV9zd2FwX2xvY2t1cF90eF9pbmZvGAcgASgLMh8uYnJlZXouQm9sdHpSZXZlcnNlU3dhcExvY2t1cFR4SABSHGJvbHR6UmV2ZXJzZVN3YXBMb2NrdXBUeEluZm9CBgoEaW5mbw==');
 @$core.Deprecated('Use pushTxNotificationResponseDescriptor instead')
 const PushTxNotificationResponse$json = const {
   '1': 'PushTxNotificationResponse',
 };
 
 /// Descriptor for `PushTxNotificationResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List pushTxNotificationResponseDescriptor = $convert.base64Decode('ChpQdXNoVHhOb3RpZmljYXRpb25SZXNwb25zZQ==');
+final $typed_data.Uint8List pushTxNotificationResponseDescriptor =
+    $convert.base64Decode('ChpQdXNoVHhOb3RpZmljYXRpb25SZXNwb25zZQ==');
 @$core.Deprecated('Use breezAppVersionsRequestDescriptor instead')
 const BreezAppVersionsRequest$json = const {
   '1': 'BreezAppVersionsRequest',
 };
 
 /// Descriptor for `BreezAppVersionsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List breezAppVersionsRequestDescriptor = $convert.base64Decode('ChdCcmVlekFwcFZlcnNpb25zUmVxdWVzdA==');
+final $typed_data.Uint8List breezAppVersionsRequestDescriptor =
+    $convert.base64Decode('ChdCcmVlekFwcFZlcnNpb25zUmVxdWVzdA==');
 @$core.Deprecated('Use breezAppVersionsReplyDescriptor instead')
 const BreezAppVersionsReply$json = const {
   '1': 'BreezAppVersionsReply',
@@ -755,14 +865,16 @@ const BreezAppVersionsReply$json = const {
 };
 
 /// Descriptor for `BreezAppVersionsReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List breezAppVersionsReplyDescriptor = $convert.base64Decode('ChVCcmVlekFwcFZlcnNpb25zUmVwbHkSGAoHdmVyc2lvbhgBIAMoCVIHdmVyc2lvbg==');
+final $typed_data.Uint8List breezAppVersionsReplyDescriptor =
+    $convert.base64Decode('ChVCcmVlekFwcFZlcnNpb25zUmVwbHkSGAoHdmVyc2lvbhgBIAMoCVIHdmVyc2lvbg==');
 @$core.Deprecated('Use getReverseRoutingNodeRequestDescriptor instead')
 const GetReverseRoutingNodeRequest$json = const {
   '1': 'GetReverseRoutingNodeRequest',
 };
 
 /// Descriptor for `GetReverseRoutingNodeRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getReverseRoutingNodeRequestDescriptor = $convert.base64Decode('ChxHZXRSZXZlcnNlUm91dGluZ05vZGVSZXF1ZXN0');
+final $typed_data.Uint8List getReverseRoutingNodeRequestDescriptor =
+    $convert.base64Decode('ChxHZXRSZXZlcnNlUm91dGluZ05vZGVSZXF1ZXN0');
 @$core.Deprecated('Use getReverseRoutingNodeReplyDescriptor instead')
 const GetReverseRoutingNodeReply$json = const {
   '1': 'GetReverseRoutingNodeReply',
@@ -772,7 +884,8 @@ const GetReverseRoutingNodeReply$json = const {
 };
 
 /// Descriptor for `GetReverseRoutingNodeReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List getReverseRoutingNodeReplyDescriptor = $convert.base64Decode('ChpHZXRSZXZlcnNlUm91dGluZ05vZGVSZXBseRIXCgdub2RlX2lkGAEgASgMUgZub2RlSWQ=');
+final $typed_data.Uint8List getReverseRoutingNodeReplyDescriptor =
+    $convert.base64Decode('ChpHZXRSZXZlcnNlUm91dGluZ05vZGVSZXBseRIXCgdub2RlX2lkGAEgASgMUgZub2RlSWQ=');
 @$core.Deprecated('Use reportPaymentFailureRequestDescriptor instead')
 const ReportPaymentFailureRequest$json = const {
   '1': 'ReportPaymentFailureRequest',
@@ -788,26 +901,36 @@ const ReportPaymentFailureRequest$json = const {
 };
 
 /// Descriptor for `ReportPaymentFailureRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List reportPaymentFailureRequestDescriptor = $convert.base64Decode('ChtSZXBvcnRQYXltZW50RmFpbHVyZVJlcXVlc3QSHwoLc2RrX3ZlcnNpb24YASABKAlSCnNka1ZlcnNpb24SIAoMc2RrX2dpdF9oYXNoGAIgASgJUgpzZGtHaXRIYXNoEhcKB25vZGVfaWQYAyABKAlSBm5vZGVJZBIVCgZsc3BfaWQYBCABKAlSBWxzcElkEhwKCXRpbWVzdGFtcBgFIAEoCVIJdGltZXN0YW1wEhgKB2NvbW1lbnQYBiABKAlSB2NvbW1lbnQSFgoGcmVwb3J0GAcgASgJUgZyZXBvcnQ=');
+final $typed_data.Uint8List reportPaymentFailureRequestDescriptor = $convert.base64Decode(
+    'ChtSZXBvcnRQYXltZW50RmFpbHVyZVJlcXVlc3QSHwoLc2RrX3ZlcnNpb24YASABKAlSCnNka1ZlcnNpb24SIAoMc2RrX2dpdF9oYXNoGAIgASgJUgpzZGtHaXRIYXNoEhcKB25vZGVfaWQYAyABKAlSBm5vZGVJZBIVCgZsc3BfaWQYBCABKAlSBWxzcElkEhwKCXRpbWVzdGFtcBgFIAEoCVIJdGltZXN0YW1wEhgKB2NvbW1lbnQYBiABKAlSB2NvbW1lbnQSFgoGcmVwb3J0GAcgASgJUgZyZXBvcnQ=');
 @$core.Deprecated('Use reportPaymentFailureReplyDescriptor instead')
 const ReportPaymentFailureReply$json = const {
   '1': 'ReportPaymentFailureReply',
 };
 
 /// Descriptor for `ReportPaymentFailureReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List reportPaymentFailureReplyDescriptor = $convert.base64Decode('ChlSZXBvcnRQYXltZW50RmFpbHVyZVJlcGx5');
+final $typed_data.Uint8List reportPaymentFailureReplyDescriptor =
+    $convert.base64Decode('ChlSZXBvcnRQYXltZW50RmFpbHVyZVJlcGx5');
 @$core.Deprecated('Use breezStatusRequestDescriptor instead')
 const BreezStatusRequest$json = const {
   '1': 'BreezStatusRequest',
 };
 
 /// Descriptor for `BreezStatusRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List breezStatusRequestDescriptor = $convert.base64Decode('ChJCcmVlelN0YXR1c1JlcXVlc3Q=');
+final $typed_data.Uint8List breezStatusRequestDescriptor =
+    $convert.base64Decode('ChJCcmVlelN0YXR1c1JlcXVlc3Q=');
 @$core.Deprecated('Use breezStatusReplyDescriptor instead')
 const BreezStatusReply$json = const {
   '1': 'BreezStatusReply',
   '2': const [
-    const {'1': 'status', '3': 1, '4': 1, '5': 14, '6': '.breez.BreezStatusReply.BreezStatus', '10': 'status'},
+    const {
+      '1': 'status',
+      '3': 1,
+      '4': 1,
+      '5': 14,
+      '6': '.breez.BreezStatusReply.BreezStatus',
+      '10': 'status'
+    },
   ],
   '4': const [BreezStatusReply_BreezStatus$json],
 };
@@ -823,19 +946,28 @@ const BreezStatusReply_BreezStatus$json = const {
 };
 
 /// Descriptor for `BreezStatusReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List breezStatusReplyDescriptor = $convert.base64Decode('ChBCcmVlelN0YXR1c1JlcGx5EjsKBnN0YXR1cxgBIAEoDjIjLmJyZWV6LkJyZWV6U3RhdHVzUmVwbHkuQnJlZXpTdGF0dXNSBnN0YXR1cyJHCgtCcmVlelN0YXR1cxIPCgtPUEVSQVRJT05BTBAAEg8KC01BSU5URU5BTkNFEAESFgoSU0VSVklDRV9ESVNSVVBUSU9OEAI=');
+final $typed_data.Uint8List breezStatusReplyDescriptor = $convert.base64Decode(
+    'ChBCcmVlelN0YXR1c1JlcGx5EjsKBnN0YXR1cxgBIAEoDjIjLmJyZWV6LkJyZWV6U3RhdHVzUmVwbHkuQnJlZXpTdGF0dXNSBnN0YXR1cyJHCgtCcmVlelN0YXR1cxIPCgtPUEVSQVRJT05BTBAAEg8KC01BSU5URU5BTkNFEAESFgoSU0VSVklDRV9ESVNSVVBUSU9OEAI=');
 @$core.Deprecated('Use chainApiServersRequestDescriptor instead')
 const ChainApiServersRequest$json = const {
   '1': 'ChainApiServersRequest',
 };
 
 /// Descriptor for `ChainApiServersRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List chainApiServersRequestDescriptor = $convert.base64Decode('ChZDaGFpbkFwaVNlcnZlcnNSZXF1ZXN0');
+final $typed_data.Uint8List chainApiServersRequestDescriptor =
+    $convert.base64Decode('ChZDaGFpbkFwaVNlcnZlcnNSZXF1ZXN0');
 @$core.Deprecated('Use chainApiServersReplyDescriptor instead')
 const ChainApiServersReply$json = const {
   '1': 'ChainApiServersReply',
   '2': const [
-    const {'1': 'servers', '3': 1, '4': 3, '5': 11, '6': '.breez.ChainApiServersReply.ChainAPIServer', '10': 'servers'},
+    const {
+      '1': 'servers',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.breez.ChainApiServersReply.ChainAPIServer',
+      '10': 'servers'
+    },
   ],
   '3': const [ChainApiServersReply_ChainAPIServer$json],
 };
@@ -850,4 +982,5 @@ const ChainApiServersReply_ChainAPIServer$json = const {
 };
 
 /// Descriptor for `ChainApiServersReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List chainApiServersReplyDescriptor = $convert.base64Decode('ChRDaGFpbkFwaVNlcnZlcnNSZXBseRJECgdzZXJ2ZXJzGAEgAygLMiouYnJlZXouQ2hhaW5BcGlTZXJ2ZXJzUmVwbHkuQ2hhaW5BUElTZXJ2ZXJSB3NlcnZlcnMaWQoOQ2hhaW5BUElTZXJ2ZXISHwoLc2VydmVyX3R5cGUYASABKAlSCnNlcnZlclR5cGUSJgoPc2VydmVyX2Jhc2VfdXJsGAIgASgJUg1zZXJ2ZXJCYXNlVXJs');
+final $typed_data.Uint8List chainApiServersReplyDescriptor = $convert.base64Decode(
+    'ChRDaGFpbkFwaVNlcnZlcnNSZXBseRJECgdzZXJ2ZXJzGAEgAygLMiouYnJlZXouQ2hhaW5BcGlTZXJ2ZXJzUmVwbHkuQ2hhaW5BUElTZXJ2ZXJSB3NlcnZlcnMaWQoOQ2hhaW5BUElTZXJ2ZXISHwoLc2VydmVyX3R5cGUYASABKAlSCnNlcnZlclR5cGUSJgoPc2VydmVyX2Jhc2VfdXJsGAIgASgJUg1zZXJ2ZXJCYXNlVXJs');

--- a/lib/services/breez_server/server.dart
+++ b/lib/services/breez_server/server.dart
@@ -42,8 +42,7 @@ class BreezServer {
     return response.breezID;
   }
 
-  Future<String> sendInvoice(
-      String breezId, String bolt11, String payee, Int64 amount) async {
+  Future<String> sendInvoice(String breezId, String bolt11, String payee, Int64 amount) async {
     await _ensureValidChannel();
     var invoicerClient = InvoicerClient(_channel, options: defaultCallOptions);
     var response = await invoicerClient.sendInvoice(PaymentRequest()
@@ -57,18 +56,14 @@ class BreezServer {
 
   Future<String> uploadLogo(List<int> logo) async {
     await _ensureValidChannel();
-    var posClient = PosClient(_channel,
-        options: CallOptions(timeout: const Duration(seconds: 30)));
-    return posClient
-        .uploadLogo(UploadFileRequest()..content = logo)
-        .then((reply) => reply.url);
+    var posClient = PosClient(_channel, options: CallOptions(timeout: const Duration(seconds: 30)));
+    return posClient.uploadLogo(UploadFileRequest()..content = logo).then((reply) => reply.url);
   }
 
-  Future<OrderReply> orderCard(String fullName, String email, String address,
-      String city, String state, String zip, String country) async {
+  Future<OrderReply> orderCard(String fullName, String email, String address, String city, String state,
+      String zip, String country) async {
     await _ensureValidChannel();
-    var cardOrderClient =
-        CardOrdererClient(_channel, options: defaultCallOptions);
+    var cardOrderClient = CardOrdererClient(_channel, options: defaultCallOptions);
     var response = await cardOrderClient.order(OrderRequest()
       ..fullName = fullName
       ..email = email
@@ -90,9 +85,7 @@ class BreezServer {
     await _ensureValidChannel();
     var ctpClient = CTPClient(_channel, options: defaultCallOptions);
     return await ctpClient.joinCTPSession(JoinCTPSessionRequest()
-      ..partyType = payer
-          ? JoinCTPSessionRequest_PartyType.PAYER
-          : JoinCTPSessionRequest_PartyType.PAYEE
+      ..partyType = payer ? JoinCTPSessionRequest_PartyType.PAYER : JoinCTPSessionRequest_PartyType.PAYEE
       ..partyName = userName
       ..notificationToken = notificationToken
       ..sessionID = sessionID ?? "");
@@ -101,8 +94,7 @@ class BreezServer {
   Future<TerminateCTPSessionResponse> terminateSession(String sessionID) async {
     await _ensureValidChannel();
     var ctpClient = CTPClient(_channel, options: defaultCallOptions);
-    return await ctpClient.terminateCTPSession(
-        TerminateCTPSessionRequest()..sessionID = sessionID);
+    return await ctpClient.terminateCTPSession(TerminateCTPSessionRequest()..sessionID = sessionID);
   }
 
   Future _ensureValidChannel() async {
@@ -111,8 +103,7 @@ class BreezServer {
       return;
     }
 
-    var infoClient = InformationClient(_channel,
-        options: CallOptions(timeout: const Duration(seconds: 2)));
+    var infoClient = InformationClient(_channel, options: CallOptions(timeout: const Duration(seconds: 2)));
     try {
       await infoClient.ping(PingRequest());
     } catch (e) {

--- a/lib/services/breez_server/server.dart
+++ b/lib/services/breez_server/server.dart
@@ -11,6 +11,7 @@ final _log = Logger("BreezServer");
 
 //proto command:
 //protoc --dart_out=grpc:lib/services/breez_server/generated/ -Ilib/services/breez_server/protobuf/ lib/services/breez_server/protobuf/breez.proto
+//dart format -l 110 lib/services/breez_server/generated/
 class BreezServer {
   static final defaultCallOptions = CallOptions(
     timeout: const Duration(seconds: 10),
@@ -29,12 +30,14 @@ class BreezServer {
     return response.fullUrl;
   }
 
-  Future<String> registerDevice(String id, String nodeid) async {
+  Future<String> registerDevice(String id, String nodeId) async {
     await _ensureValidChannel();
     var invoicerClient = InvoicerClient(_channel, options: defaultCallOptions);
-    var response = await invoicerClient.registerDevice(RegisterRequest()
-      ..deviceID = id
-      ..lightningID = nodeid);
+    var response = await invoicerClient.registerDevice(
+      RegisterRequest()
+        ..deviceID = id
+        ..lightningID = nodeId,
+    );
     _log.info('registerDevice response: $response');
     return response.breezID;
   }
@@ -121,14 +124,13 @@ class BreezServer {
   Future<ClientChannel> _createChannel() async {
     String configString = await rootBundle.loadString('conf/breez.conf');
     Config config = Config.fromString(configString);
-    var hostdetails =
-        config.get("Application Options", "breezserver").split(':');
-    if (hostdetails.length < 2) {
-      hostdetails.add("443");
+    var hostDetails = config.get("Application Options", "breezserver").split(':');
+    if (hostDetails.length < 2) {
+      hostDetails.add("443");
     }
     return ClientChannel(
-      hostdetails[0],
-      port: int.parse(hostdetails[1]),
+      hostDetails[0],
+      port: int.parse(hostDetails[1]),
       options: const ChannelOptions(credentials: ChannelCredentials.secure()),
     );
   }

--- a/lib/services/breezlib/breez_bridge.dart
+++ b/lib/services/breezlib/breez_bridge.dart
@@ -30,16 +30,14 @@ final _log = Logger("BreezBridge");
 // dart pub global activate protoc_plugin 20.0.1
 class BreezBridge {
   static const _methodChannel = MethodChannel('com.breez.client/breez_lib');
-  static const _eventChannel =
-      EventChannel('com.breez.client/breez_lib_notifications');
+  static const _eventChannel = EventChannel('com.breez.client/breez_lib_notifications');
 
   final DownloadTaskManager downloadManager;
   final Future<SharedPreferences> sharedPreferences;
   String _selectedLspID;
   Completer _readyCompleter = Completer();
   final Completer _startedCompleter = Completer();
-  final StreamController _eventsController =
-      StreamController<NotificationEvent>.broadcast();
+  final StreamController _eventsController = StreamController<NotificationEvent>.broadcast();
   Stream<NotificationEvent> get notificationStream => _eventsController.stream;
   bool ready = false;
   Future<Directory> _tempDirFuture;
@@ -55,8 +53,7 @@ class BreezBridge {
         ready = true;
         _readyCompleter.complete();
       }
-      if (notification.type ==
-          NotificationEvent_NotificationType.LIGHTNING_SERVICE_DOWN) {
+      if (notification.type == NotificationEvent_NotificationType.LIGHTNING_SERVICE_DOWN) {
         _readyCompleter = Completer();
       }
       _eventsController.add(NotificationEvent()..mergeFromBuffer(event));
@@ -76,8 +73,7 @@ class BreezBridge {
     var graphDBName = pathComponents.last;
     pathComponents.removeLast();
     pathComponents.add("MD5SUMS");
-    var checksumURL =
-        graphUri.replace(path: pathComponents.join("/")).toString();
+    var checksumURL = graphUri.replace(path: pathComponents.join("/")).toString();
     _log.info("graph checksum url: $checksumURL");
     var response = await Dio().get(checksumURL);
     var content = response.data.toString();
@@ -99,12 +95,9 @@ class BreezBridge {
     if (downloadURL.isNotEmpty) {
       _log.info("GraphDownloader fetching graph checksum");
       var checksum = await fetchGraphChecksum(downloadURL);
-      _log.info(
-          "GraphDownloader graph checksum = $checksum, downloading graph");
-      _inProgressGraphSync =
-          _graphDownloader.downloadGraph(downloadURL).then((file) async {
-        final fileChecksum =
-            await Md5FileChecksum.getFileChecksum(filePath: file.path);
+      _log.info("GraphDownloader graph checksum = $checksum, downloading graph");
+      _inProgressGraphSync = _graphDownloader.downloadGraph(downloadURL).then((file) async {
+        final fileChecksum = await Md5FileChecksum.getFileChecksum(filePath: file.path);
         var rawBytes = base64.decode(fileChecksum);
         var hexChecksum = HEX.encode(rawBytes);
         if (hexChecksum != checksum) {
@@ -232,8 +225,7 @@ class BreezBridge {
   }
 
   Future<String> getNostrKeyPair() {
-    return _invokeMethodWhenReady("getNostrKeyPair")
-        .then((value) => value as String);
+    return _invokeMethodWhenReady("getNostrKeyPair").then((value) => value as String);
   }
 
   Future<LNUrlPayInfo> fetchLNUrlPayInvoice(PayFetchResponse response) {
@@ -250,8 +242,7 @@ class BreezBridge {
   }
 
   Future<int> lastSyncedHeaderTimestamp() {
-    return _invokeMethodImmediate("lastSyncedHeaderTimestamp")
-        .then((res) => res as int);
+    return _invokeMethodImmediate("lastSyncedHeaderTimestamp").then((res) => res as int);
   }
 
   Future<Account> getAccount() {
@@ -260,8 +251,7 @@ class BreezBridge {
   }
 
   Future<bool> isConnectedToRoutingNode() {
-    return _invokeMethodWhenReady("isConnectedToRoutingNode")
-        .then((result) => result as bool);
+    return _invokeMethodWhenReady("isConnectedToRoutingNode").then((result) => result as bool);
   }
 
   Future connectAccount() {
@@ -269,8 +259,7 @@ class BreezBridge {
   }
 
   Future<LSPList> getLSPList() {
-    return _invokeMethodWhenReady("lspList")
-        .then((result) => LSPList()..mergeFromBuffer(result ?? []));
+    return _invokeMethodWhenReady("lspList").then((result) => LSPList()..mergeFromBuffer(result ?? []));
   }
 
   Future connectToLSP(String lspID) {
@@ -308,8 +297,7 @@ class BreezBridge {
   }
 
   Future<int> maxReverseSwapAmount() {
-    return _invokeMethodWhenReady("maxReverseSwapAmount", {})
-        .then((res) => res as int);
+    return _invokeMethodWhenReady("maxReverseSwapAmount", {}).then((res) => res as int);
   }
 
   Future<ReverseSwapInfo> getReverseSwapPolicy() {
@@ -402,8 +390,7 @@ class BreezBridge {
     return _invokeMethodWhenReady("receiverNode").then((s) => s as String);
   }
 
-  Future<PaymentResponse> sendSpontaneousPayment(
-      String destNode, Int64 amount, String description,
+  Future<PaymentResponse> sendSpontaneousPayment(String destNode, Int64 amount, String description,
       {Int64 feeLimitMsat = Int64.ZERO,
       String groupKey = "",
       String groupName = "",
@@ -604,21 +591,18 @@ class BreezBridge {
       var lsps = await getLSPList();
       if (_selectedLspID != null) {
         request.lspInfo = lsps.lsps[_selectedLspID];
-        request.openingFeeParams =
-            lsps.lsps[_selectedLspID].cheapestOpeningFeeParams;
+        request.openingFeeParams = lsps.lsps[_selectedLspID].cheapestOpeningFeeParams;
       } else {
         // if we only have one lsp in our options, let's use it.
         var keys = lsps.lsps.keys.toList();
         if (keys.length == 1) {
           request.lspInfo = lsps.lsps[keys[0]];
-          request.openingFeeParams =
-              lsps.lsps[keys[0]].cheapestOpeningFeeParams;
+          request.openingFeeParams = lsps.lsps[keys[0]].cheapestOpeningFeeParams;
         }
       }
     }
 
-    return _invokeMethodWhenReady(
-            "addInvoice", {"argument": request.writeToBuffer()})
+    return _invokeMethodWhenReady("addInvoice", {"argument": request.writeToBuffer()})
         .then((res) => AddInvoiceReply()..mergeFromBuffer(res ?? []));
   }
 
@@ -630,20 +614,17 @@ class BreezBridge {
     return _invokeMethodWhenReady(
       "checkLSPClosedChannelMismatch",
       {"argument": request.writeToBuffer()},
-    ).then((res) =>
-        CheckLSPClosedChannelMismatchResponse()..mergeFromBuffer(res ?? []));
+    ).then((res) => CheckLSPClosedChannelMismatchResponse()..mergeFromBuffer(res ?? []));
   }
 
-  Future<ResetClosedChannelChainInfoReply> resetClosedChannelChainInfo(
-      Int64 blockHeight, String chanPoint) {
+  Future<ResetClosedChannelChainInfoReply> resetClosedChannelChainInfo(Int64 blockHeight, String chanPoint) {
     var request = ResetClosedChannelChainInfoRequest()
       ..blockHeight = blockHeight
       ..chanPoint = chanPoint;
     return _invokeMethodWhenReady(
       "resetClosedChannelChainInfo",
       {"argument": request.writeToBuffer()},
-    ).then((res) =>
-        ResetClosedChannelChainInfoReply()..mergeFromBuffer(res ?? []));
+    ).then((res) => ResetClosedChannelChainInfoReply()..mergeFromBuffer(res ?? []));
   }
 
   Future<CreateRatchetSessionReply> createRatchetSession(
@@ -684,8 +665,7 @@ class BreezBridge {
     var request = RatchetEncryptRequest()
       ..message = message
       ..sessionID = sessionID;
-    return _invokeMethodImmediate(
-            "ratchetEncrypt", {"argument": request.writeToBuffer()})
+    return _invokeMethodImmediate("ratchetEncrypt", {"argument": request.writeToBuffer()})
         .then((res) => res as String);
   }
 
@@ -788,8 +768,7 @@ class BreezBridge {
 
   Future<String> validateAddress(String address) {
     address = extractBitcoinAddress(address);
-    return _invokeMethodWhenReady("validateAddress", {"argument": address})
-        .then((response) => address);
+    return _invokeMethodWhenReady("validateAddress", {"argument": address}).then((response) => address);
   }
 
   Future<Int64> getDefaultOnChainFeeRate() {
@@ -814,10 +793,8 @@ class BreezBridge {
     List<int> encryptionKey,
     String encryptionType,
   ) {
-    return _invokeMethodImmediate("setBackupEncryptionKey", {
-      "encryptionKey": encryptionKey,
-      "encryptionType": encryptionType ?? ""
-    });
+    return _invokeMethodImmediate(
+        "setBackupEncryptionKey", {"encryptionKey": encryptionKey, "encryptionType": encryptionType ?? ""});
   }
 
   Future setBackupProvider(String backupProvider, String backupAuthData) {
@@ -828,14 +805,11 @@ class BreezBridge {
   }
 
   Future<String> getAvailableBackups() async {
-    return await _methodChannel
-        .invokeMethod("availableSnapshots")
-        .then((res) => res as String);
+    return await _methodChannel.invokeMethod("availableSnapshots").then((res) => res as String);
   }
 
   Future<int> getLatestBackupTime() async {
-    return _invokeMethodImmediate("latestBackupTime")
-        .then((value) => value as int);
+    return _invokeMethodImmediate("latestBackupTime").then((value) => value as int);
   }
 
   Future<DownloadBackupResponse> downloadBackup(String nodeId) async {
@@ -917,8 +891,7 @@ class BreezBridge {
   }
 
   Future<bool> getTorActive() {
-    return _invokeMethodImmediate('getTorActive')
-        .then((result) => result as bool);
+    return _invokeMethodImmediate('getTorActive').then((result) => result as bool);
   }
 
   Future setBackupTorConfig(TorConfig torConfig) {
@@ -935,9 +908,7 @@ class BreezBridge {
       _log.info("before invoking method $methodName");
     }
     return _readyCompleter.future.then((completed) {
-      return _methodChannel
-          .invokeMethod(methodName, arguments)
-          .catchError((err) {
+      return _methodChannel.invokeMethod(methodName, arguments).catchError((err) {
         if (methodName != "log") {
           _log.severe("failed to invoke method $methodName $err");
         }

--- a/lib/services/breezlib/breez_bridge.dart
+++ b/lib/services/breezlib/breez_bridge.dart
@@ -21,6 +21,7 @@ final _log = Logger("BreezBridge");
 
 // This is the bridge to the native breez library. Protobuf messages are used as the interface and to generate the classes use the command below:
 // protoc --dart_out=grpc:lib/services/breezlib/data/ -Ilib/services/breezlib/protobuf/ lib/services/breezlib/protobuf/messages.proto
+// dart format -l 110 lib/services/breezlib/data/
 // You may need to activate protoc_plugin. See [here](https://pub.dev/packages/protoc_plugin#how-to-build).
 //
 // Due to Flutter SDK restrictions, we need to install a strict version of protoc_plugin
@@ -925,7 +926,7 @@ class BreezBridge {
       'setBackupTorConfig',
       {'argument': torConfig?.writeToBuffer()},
     ).then((_) {
-      _log.info("breez bridge - set backup torconfig");
+      _log.info("breez bridge - set backup TorConfig");
     });
   }
 

--- a/lib/services/breezlib/data/messages.pb.dart
+++ b/lib/services/breezlib/data/messages.pb.dart
@@ -15,99 +15,129 @@ import 'messages.pbenum.dart';
 export 'messages.pbenum.dart';
 
 class ListPaymentsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ListPaymentsRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ListPaymentsRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   ListPaymentsRequest._() : super();
   factory ListPaymentsRequest() => create();
-  factory ListPaymentsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ListPaymentsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ListPaymentsRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ListPaymentsRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ListPaymentsRequest clone() => ListPaymentsRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ListPaymentsRequest copyWith(void Function(ListPaymentsRequest) updates) => super.copyWith((message) => updates(message as ListPaymentsRequest)) as ListPaymentsRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ListPaymentsRequest copyWith(void Function(ListPaymentsRequest) updates) =>
+      super.copyWith((message) => updates(message as ListPaymentsRequest))
+          as ListPaymentsRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ListPaymentsRequest create() => ListPaymentsRequest._();
   ListPaymentsRequest createEmptyInstance() => create();
   static $pb.PbList<ListPaymentsRequest> createRepeated() => $pb.PbList<ListPaymentsRequest>();
   @$core.pragma('dart2js:noInline')
-  static ListPaymentsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPaymentsRequest>(create);
+  static ListPaymentsRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListPaymentsRequest>(create);
   static ListPaymentsRequest? _defaultInstance;
 }
 
 class RestartDaemonRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RestartDaemonRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RestartDaemonRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   RestartDaemonRequest._() : super();
   factory RestartDaemonRequest() => create();
-  factory RestartDaemonRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RestartDaemonRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RestartDaemonRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RestartDaemonRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RestartDaemonRequest clone() => RestartDaemonRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RestartDaemonRequest copyWith(void Function(RestartDaemonRequest) updates) => super.copyWith((message) => updates(message as RestartDaemonRequest)) as RestartDaemonRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RestartDaemonRequest copyWith(void Function(RestartDaemonRequest) updates) =>
+      super.copyWith((message) => updates(message as RestartDaemonRequest))
+          as RestartDaemonRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RestartDaemonRequest create() => RestartDaemonRequest._();
   RestartDaemonRequest createEmptyInstance() => create();
   static $pb.PbList<RestartDaemonRequest> createRepeated() => $pb.PbList<RestartDaemonRequest>();
   @$core.pragma('dart2js:noInline')
-  static RestartDaemonRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RestartDaemonRequest>(create);
+  static RestartDaemonRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RestartDaemonRequest>(create);
   static RestartDaemonRequest? _defaultInstance;
 }
 
 class RestartDaemonReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RestartDaemonReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RestartDaemonReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   RestartDaemonReply._() : super();
   factory RestartDaemonReply() => create();
-  factory RestartDaemonReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RestartDaemonReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RestartDaemonReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RestartDaemonReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RestartDaemonReply clone() => RestartDaemonReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RestartDaemonReply copyWith(void Function(RestartDaemonReply) updates) => super.copyWith((message) => updates(message as RestartDaemonReply)) as RestartDaemonReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RestartDaemonReply copyWith(void Function(RestartDaemonReply) updates) =>
+      super.copyWith((message) => updates(message as RestartDaemonReply))
+          as RestartDaemonReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RestartDaemonReply create() => RestartDaemonReply._();
   RestartDaemonReply createEmptyInstance() => create();
   static $pb.PbList<RestartDaemonReply> createRepeated() => $pb.PbList<RestartDaemonReply>();
   @$core.pragma('dart2js:noInline')
-  static RestartDaemonReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RestartDaemonReply>(create);
+  static RestartDaemonReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RestartDaemonReply>(create);
   static RestartDaemonReply? _defaultInstance;
 }
 
 class AddFundInitRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddFundInitRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'notificationToken', protoName: 'notificationToken')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddFundInitRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'notificationToken',
+        protoName: 'notificationToken')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lspID', protoName: 'lspID')
-    ..aOM<OpeningFeeParams>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'openingFeeParams', subBuilder: OpeningFeeParams.create)
-    ..hasRequiredFields = false
-  ;
+    ..aOM<OpeningFeeParams>(
+        3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'openingFeeParams',
+        subBuilder: OpeningFeeParams.create)
+    ..hasRequiredFields = false;
 
   AddFundInitRequest._() : super();
   factory AddFundInitRequest({
@@ -127,31 +157,39 @@ class AddFundInitRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory AddFundInitRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory AddFundInitRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory AddFundInitRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory AddFundInitRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   AddFundInitRequest clone() => AddFundInitRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  AddFundInitRequest copyWith(void Function(AddFundInitRequest) updates) => super.copyWith((message) => updates(message as AddFundInitRequest)) as AddFundInitRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  AddFundInitRequest copyWith(void Function(AddFundInitRequest) updates) =>
+      super.copyWith((message) => updates(message as AddFundInitRequest))
+          as AddFundInitRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AddFundInitRequest create() => AddFundInitRequest._();
   AddFundInitRequest createEmptyInstance() => create();
   static $pb.PbList<AddFundInitRequest> createRepeated() => $pb.PbList<AddFundInitRequest>();
   @$core.pragma('dart2js:noInline')
-  static AddFundInitRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundInitRequest>(create);
+  static AddFundInitRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundInitRequest>(create);
   static AddFundInitRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get notificationToken => $_getSZ(0);
   @$pb.TagNumber(1)
-  set notificationToken($core.String v) { $_setString(0, v); }
+  set notificationToken($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasNotificationToken() => $_has(0);
   @$pb.TagNumber(1)
@@ -160,7 +198,10 @@ class AddFundInitRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get lspID => $_getSZ(1);
   @$pb.TagNumber(2)
-  set lspID($core.String v) { $_setString(1, v); }
+  set lspID($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasLspID() => $_has(1);
   @$pb.TagNumber(2)
@@ -169,7 +210,10 @@ class AddFundInitRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   OpeningFeeParams get openingFeeParams => $_getN(2);
   @$pb.TagNumber(3)
-  set openingFeeParams(OpeningFeeParams v) { setField(3, v); }
+  set openingFeeParams(OpeningFeeParams v) {
+    setField(3, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasOpeningFeeParams() => $_has(2);
   @$pb.TagNumber(3)
@@ -179,10 +223,14 @@ class AddFundInitRequest extends $pb.GeneratedMessage {
 }
 
 class FundStatusRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'FundStatusRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'notificationToken', protoName: 'notificationToken')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'FundStatusRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'notificationToken',
+        protoName: 'notificationToken')
+    ..hasRequiredFields = false;
 
   FundStatusRequest._() : super();
   factory FundStatusRequest({
@@ -194,31 +242,39 @@ class FundStatusRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory FundStatusRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory FundStatusRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory FundStatusRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory FundStatusRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   FundStatusRequest clone() => FundStatusRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  FundStatusRequest copyWith(void Function(FundStatusRequest) updates) => super.copyWith((message) => updates(message as FundStatusRequest)) as FundStatusRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  FundStatusRequest copyWith(void Function(FundStatusRequest) updates) =>
+      super.copyWith((message) => updates(message as FundStatusRequest))
+          as FundStatusRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static FundStatusRequest create() => FundStatusRequest._();
   FundStatusRequest createEmptyInstance() => create();
   static $pb.PbList<FundStatusRequest> createRepeated() => $pb.PbList<FundStatusRequest>();
   @$core.pragma('dart2js:noInline')
-  static FundStatusRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<FundStatusRequest>(create);
+  static FundStatusRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<FundStatusRequest>(create);
   static FundStatusRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get notificationToken => $_getSZ(0);
   @$pb.TagNumber(1)
-  set notificationToken($core.String v) { $_setString(0, v); }
+  set notificationToken($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasNotificationToken() => $_has(0);
   @$pb.TagNumber(1)
@@ -226,11 +282,15 @@ class FundStatusRequest extends $pb.GeneratedMessage {
 }
 
 class AddInvoiceReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddInvoiceReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentRequest', protoName: 'paymentRequest')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddInvoiceReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentRequest',
+        protoName: 'paymentRequest')
     ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lspFee')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   AddInvoiceReply._() : super();
   factory AddInvoiceReply({
@@ -246,31 +306,38 @@ class AddInvoiceReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory AddInvoiceReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory AddInvoiceReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory AddInvoiceReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory AddInvoiceReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   AddInvoiceReply clone() => AddInvoiceReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  AddInvoiceReply copyWith(void Function(AddInvoiceReply) updates) => super.copyWith((message) => updates(message as AddInvoiceReply)) as AddInvoiceReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  AddInvoiceReply copyWith(void Function(AddInvoiceReply) updates) =>
+      super.copyWith((message) => updates(message as AddInvoiceReply))
+          as AddInvoiceReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AddInvoiceReply create() => AddInvoiceReply._();
   AddInvoiceReply createEmptyInstance() => create();
   static $pb.PbList<AddInvoiceReply> createRepeated() => $pb.PbList<AddInvoiceReply>();
   @$core.pragma('dart2js:noInline')
-  static AddInvoiceReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddInvoiceReply>(create);
+  static AddInvoiceReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddInvoiceReply>(create);
   static AddInvoiceReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get paymentRequest => $_getSZ(0);
   @$pb.TagNumber(1)
-  set paymentRequest($core.String v) { $_setString(0, v); }
+  set paymentRequest($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasPaymentRequest() => $_has(0);
   @$pb.TagNumber(1)
@@ -279,7 +346,10 @@ class AddInvoiceReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get lspFee => $_getI64(1);
   @$pb.TagNumber(2)
-  set lspFee($fixnum.Int64 v) { $_setInt64(1, v); }
+  set lspFee($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasLspFee() => $_has(1);
   @$pb.TagNumber(2)
@@ -287,11 +357,17 @@ class AddInvoiceReply extends $pb.GeneratedMessage {
 }
 
 class ChainStatus extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ChainStatus', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..a<$core.int>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'blockHeight', $pb.PbFieldType.OU3, protoName: 'blockHeight')
-    ..aOB(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'syncedToChain', protoName: 'syncedToChain')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ChainStatus',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..a<$core.int>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'blockHeight',
+        $pb.PbFieldType.OU3,
+        protoName: 'blockHeight')
+    ..aOB(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'syncedToChain',
+        protoName: 'syncedToChain')
+    ..hasRequiredFields = false;
 
   ChainStatus._() : super();
   factory ChainStatus({
@@ -307,31 +383,38 @@ class ChainStatus extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ChainStatus.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ChainStatus.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ChainStatus.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ChainStatus.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ChainStatus clone() => ChainStatus()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ChainStatus copyWith(void Function(ChainStatus) updates) => super.copyWith((message) => updates(message as ChainStatus)) as ChainStatus; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ChainStatus copyWith(void Function(ChainStatus) updates) =>
+      super.copyWith((message) => updates(message as ChainStatus))
+          as ChainStatus; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ChainStatus create() => ChainStatus._();
   ChainStatus createEmptyInstance() => create();
   static $pb.PbList<ChainStatus> createRepeated() => $pb.PbList<ChainStatus>();
   @$core.pragma('dart2js:noInline')
-  static ChainStatus getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChainStatus>(create);
+  static ChainStatus getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChainStatus>(create);
   static ChainStatus? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get blockHeight => $_getIZ(0);
   @$pb.TagNumber(1)
-  set blockHeight($core.int v) { $_setUnsignedInt32(0, v); }
+  set blockHeight($core.int v) {
+    $_setUnsignedInt32(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasBlockHeight() => $_has(0);
   @$pb.TagNumber(1)
@@ -340,7 +423,10 @@ class ChainStatus extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get syncedToChain => $_getBF(1);
   @$pb.TagNumber(2)
-  set syncedToChain($core.bool v) { $_setBool(1, v); }
+  set syncedToChain($core.bool v) {
+    $_setBool(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasSyncedToChain() => $_has(1);
   @$pb.TagNumber(2)
@@ -348,25 +434,42 @@ class ChainStatus extends $pb.GeneratedMessage {
 }
 
 class Account extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Account', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Account',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'id')
     ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'balance')
-    ..aInt64(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'walletBalance', protoName: 'walletBalance')
-    ..e<Account_AccountStatus>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'status', $pb.PbFieldType.OE, defaultOrMaker: Account_AccountStatus.DISCONNECTED, valueOf: Account_AccountStatus.valueOf, enumValues: Account_AccountStatus.values)
-    ..aInt64(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxAllowedToReceive', protoName: 'maxAllowedToReceive')
-    ..aInt64(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxAllowedToPay', protoName: 'maxAllowedToPay')
-    ..aInt64(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxPaymentAmount', protoName: 'maxPaymentAmount')
-    ..aInt64(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'routingNodeFee', protoName: 'routingNodeFee')
+    ..aInt64(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'walletBalance',
+        protoName: 'walletBalance')
+    ..e<Account_AccountStatus>(
+        4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'status', $pb.PbFieldType.OE,
+        defaultOrMaker: Account_AccountStatus.DISCONNECTED,
+        valueOf: Account_AccountStatus.valueOf,
+        enumValues: Account_AccountStatus.values)
+    ..aInt64(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxAllowedToReceive',
+        protoName: 'maxAllowedToReceive')
+    ..aInt64(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxAllowedToPay',
+        protoName: 'maxAllowedToPay')
+    ..aInt64(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxPaymentAmount',
+        protoName: 'maxPaymentAmount')
+    ..aInt64(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'routingNodeFee',
+        protoName: 'routingNodeFee')
     ..aOB(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'enabled')
-    ..aInt64(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxChanReserve', protoName: 'maxChanReserve')
-    ..aOS(11, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'channelPoint', protoName: 'channelPoint')
-    ..aOB(12, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'readyForPayments', protoName: 'readyForPayments')
-    ..aInt64(13, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'tipHeight', protoName: 'tipHeight')
-    ..pPS(14, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'connectedPeers', protoName: 'connectedPeers')
+    ..aInt64(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxChanReserve',
+        protoName: 'maxChanReserve')
+    ..aOS(11, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'channelPoint',
+        protoName: 'channelPoint')
+    ..aOB(12, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'readyForPayments',
+        protoName: 'readyForPayments')
+    ..aInt64(13, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'tipHeight',
+        protoName: 'tipHeight')
+    ..pPS(14, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'connectedPeers',
+        protoName: 'connectedPeers')
     ..aInt64(15, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxInboundLiquidity')
     ..pPS(16, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'unconfirmedChannels')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   Account._() : super();
   factory Account({
@@ -438,18 +541,20 @@ class Account extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory Account.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Account.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory Account.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Account.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   Account clone() => Account()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Account copyWith(void Function(Account) updates) => super.copyWith((message) => updates(message as Account)) as Account; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Account copyWith(void Function(Account) updates) =>
+      super.copyWith((message) => updates(message as Account)) as Account; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Account create() => Account._();
@@ -462,7 +567,10 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) { $_setString(0, v); }
+  set id($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
@@ -471,7 +579,10 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get balance => $_getI64(1);
   @$pb.TagNumber(2)
-  set balance($fixnum.Int64 v) { $_setInt64(1, v); }
+  set balance($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasBalance() => $_has(1);
   @$pb.TagNumber(2)
@@ -480,7 +591,10 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get walletBalance => $_getI64(2);
   @$pb.TagNumber(3)
-  set walletBalance($fixnum.Int64 v) { $_setInt64(2, v); }
+  set walletBalance($fixnum.Int64 v) {
+    $_setInt64(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasWalletBalance() => $_has(2);
   @$pb.TagNumber(3)
@@ -489,7 +603,10 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   Account_AccountStatus get status => $_getN(3);
   @$pb.TagNumber(4)
-  set status(Account_AccountStatus v) { setField(4, v); }
+  set status(Account_AccountStatus v) {
+    setField(4, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasStatus() => $_has(3);
   @$pb.TagNumber(4)
@@ -498,7 +615,10 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $fixnum.Int64 get maxAllowedToReceive => $_getI64(4);
   @$pb.TagNumber(5)
-  set maxAllowedToReceive($fixnum.Int64 v) { $_setInt64(4, v); }
+  set maxAllowedToReceive($fixnum.Int64 v) {
+    $_setInt64(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasMaxAllowedToReceive() => $_has(4);
   @$pb.TagNumber(5)
@@ -507,7 +627,10 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get maxAllowedToPay => $_getI64(5);
   @$pb.TagNumber(6)
-  set maxAllowedToPay($fixnum.Int64 v) { $_setInt64(5, v); }
+  set maxAllowedToPay($fixnum.Int64 v) {
+    $_setInt64(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasMaxAllowedToPay() => $_has(5);
   @$pb.TagNumber(6)
@@ -516,7 +639,10 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $fixnum.Int64 get maxPaymentAmount => $_getI64(6);
   @$pb.TagNumber(7)
-  set maxPaymentAmount($fixnum.Int64 v) { $_setInt64(6, v); }
+  set maxPaymentAmount($fixnum.Int64 v) {
+    $_setInt64(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasMaxPaymentAmount() => $_has(6);
   @$pb.TagNumber(7)
@@ -525,7 +651,10 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $fixnum.Int64 get routingNodeFee => $_getI64(7);
   @$pb.TagNumber(8)
-  set routingNodeFee($fixnum.Int64 v) { $_setInt64(7, v); }
+  set routingNodeFee($fixnum.Int64 v) {
+    $_setInt64(7, v);
+  }
+
   @$pb.TagNumber(8)
   $core.bool hasRoutingNodeFee() => $_has(7);
   @$pb.TagNumber(8)
@@ -534,7 +663,10 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.bool get enabled => $_getBF(8);
   @$pb.TagNumber(9)
-  set enabled($core.bool v) { $_setBool(8, v); }
+  set enabled($core.bool v) {
+    $_setBool(8, v);
+  }
+
   @$pb.TagNumber(9)
   $core.bool hasEnabled() => $_has(8);
   @$pb.TagNumber(9)
@@ -543,7 +675,10 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $fixnum.Int64 get maxChanReserve => $_getI64(9);
   @$pb.TagNumber(10)
-  set maxChanReserve($fixnum.Int64 v) { $_setInt64(9, v); }
+  set maxChanReserve($fixnum.Int64 v) {
+    $_setInt64(9, v);
+  }
+
   @$pb.TagNumber(10)
   $core.bool hasMaxChanReserve() => $_has(9);
   @$pb.TagNumber(10)
@@ -552,7 +687,10 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $core.String get channelPoint => $_getSZ(10);
   @$pb.TagNumber(11)
-  set channelPoint($core.String v) { $_setString(10, v); }
+  set channelPoint($core.String v) {
+    $_setString(10, v);
+  }
+
   @$pb.TagNumber(11)
   $core.bool hasChannelPoint() => $_has(10);
   @$pb.TagNumber(11)
@@ -561,7 +699,10 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(12)
   $core.bool get readyForPayments => $_getBF(11);
   @$pb.TagNumber(12)
-  set readyForPayments($core.bool v) { $_setBool(11, v); }
+  set readyForPayments($core.bool v) {
+    $_setBool(11, v);
+  }
+
   @$pb.TagNumber(12)
   $core.bool hasReadyForPayments() => $_has(11);
   @$pb.TagNumber(12)
@@ -570,7 +711,10 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(13)
   $fixnum.Int64 get tipHeight => $_getI64(12);
   @$pb.TagNumber(13)
-  set tipHeight($fixnum.Int64 v) { $_setInt64(12, v); }
+  set tipHeight($fixnum.Int64 v) {
+    $_setInt64(12, v);
+  }
+
   @$pb.TagNumber(13)
   $core.bool hasTipHeight() => $_has(12);
   @$pb.TagNumber(13)
@@ -582,7 +726,10 @@ class Account extends $pb.GeneratedMessage {
   @$pb.TagNumber(15)
   $fixnum.Int64 get maxInboundLiquidity => $_getI64(14);
   @$pb.TagNumber(15)
-  set maxInboundLiquidity($fixnum.Int64 v) { $_setInt64(14, v); }
+  set maxInboundLiquidity($fixnum.Int64 v) {
+    $_setInt64(14, v);
+  }
+
   @$pb.TagNumber(15)
   $core.bool hasMaxInboundLiquidity() => $_has(14);
   @$pb.TagNumber(15)
@@ -593,31 +740,60 @@ class Account extends $pb.GeneratedMessage {
 }
 
 class Payment extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Payment', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..e<Payment_PaymentType>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'type', $pb.PbFieldType.OE, defaultOrMaker: Payment_PaymentType.DEPOSIT, valueOf: Payment_PaymentType.valueOf, enumValues: Payment_PaymentType.values)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Payment',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..e<Payment_PaymentType>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'type', $pb.PbFieldType.OE,
+        defaultOrMaker: Payment_PaymentType.DEPOSIT,
+        valueOf: Payment_PaymentType.valueOf,
+        enumValues: Payment_PaymentType.values)
     ..aInt64(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'amount')
-    ..aInt64(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'creationTimestamp', protoName: 'creationTimestamp')
-    ..aOM<InvoiceMemo>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'invoiceMemo', protoName: 'invoiceMemo', subBuilder: InvoiceMemo.create)
-    ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'redeemTxID', protoName: 'redeemTxID')
-    ..aOS(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentHash', protoName: 'paymentHash')
+    ..aInt64(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'creationTimestamp',
+        protoName: 'creationTimestamp')
+    ..aOM<InvoiceMemo>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'invoiceMemo',
+        protoName: 'invoiceMemo', subBuilder: InvoiceMemo.create)
+    ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'redeemTxID',
+        protoName: 'redeemTxID')
+    ..aOS(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentHash',
+        protoName: 'paymentHash')
     ..aOS(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'destination')
-    ..a<$core.int>(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'PendingExpirationHeight', $pb.PbFieldType.OU3, protoName: 'PendingExpirationHeight')
-    ..aInt64(11, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'PendingExpirationTimestamp', protoName: 'PendingExpirationTimestamp')
+    ..a<$core.int>(
+        10,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'PendingExpirationHeight',
+        $pb.PbFieldType.OU3,
+        protoName: 'PendingExpirationHeight')
+    ..aInt64(
+        11, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'PendingExpirationTimestamp',
+        protoName: 'PendingExpirationTimestamp')
     ..aInt64(12, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'fee')
     ..aOS(13, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'preimage')
-    ..aOS(14, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'closedChannelPoint', protoName: 'closedChannelPoint')
-    ..aOB(15, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'isChannelPending', protoName: 'isChannelPending')
-    ..aOB(16, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'isChannelCloseConfimed', protoName: 'isChannelCloseConfimed')
-    ..aOS(17, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'closedChannelTxID', protoName: 'closedChannelTxID')
-    ..aOB(18, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'isKeySend', protoName: 'isKeySend')
-    ..aOB(19, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'PendingFull', protoName: 'PendingFull')
-    ..aOS(20, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'closedChannelRemoteTxID', protoName: 'closedChannelRemoteTxID')
-    ..aOS(21, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'closedChannelSweepTxID', protoName: 'closedChannelSweepTxID')
-    ..aOS(22, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'groupKey', protoName: 'groupKey')
-    ..aOS(23, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'groupName', protoName: 'groupName')
-    ..aOM<LNUrlPayInfo>(24, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lnurlPayInfo', protoName: 'lnurlPayInfo', subBuilder: LNUrlPayInfo.create)
-    ..hasRequiredFields = false
-  ;
+    ..aOS(14, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'closedChannelPoint',
+        protoName: 'closedChannelPoint')
+    ..aOB(15, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'isChannelPending',
+        protoName: 'isChannelPending')
+    ..aOB(16, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'isChannelCloseConfimed',
+        protoName: 'isChannelCloseConfimed')
+    ..aOS(17, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'closedChannelTxID',
+        protoName: 'closedChannelTxID')
+    ..aOB(18, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'isKeySend',
+        protoName: 'isKeySend')
+    ..aOB(19, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'PendingFull',
+        protoName: 'PendingFull')
+    ..aOS(20, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'closedChannelRemoteTxID',
+        protoName: 'closedChannelRemoteTxID')
+    ..aOS(21, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'closedChannelSweepTxID',
+        protoName: 'closedChannelSweepTxID')
+    ..aOS(22, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'groupKey',
+        protoName: 'groupKey')
+    ..aOS(23, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'groupName',
+        protoName: 'groupName')
+    ..aOM<LNUrlPayInfo>(
+        24, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lnurlPayInfo',
+        protoName: 'lnurlPayInfo', subBuilder: LNUrlPayInfo.create)
+    ..hasRequiredFields = false;
 
   Payment._() : super();
   factory Payment({
@@ -713,18 +889,20 @@ class Payment extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory Payment.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Payment.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory Payment.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Payment.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   Payment clone() => Payment()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Payment copyWith(void Function(Payment) updates) => super.copyWith((message) => updates(message as Payment)) as Payment; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Payment copyWith(void Function(Payment) updates) =>
+      super.copyWith((message) => updates(message as Payment)) as Payment; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Payment create() => Payment._();
@@ -737,7 +915,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   Payment_PaymentType get type => $_getN(0);
   @$pb.TagNumber(1)
-  set type(Payment_PaymentType v) { setField(1, v); }
+  set type(Payment_PaymentType v) {
+    setField(1, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasType() => $_has(0);
   @$pb.TagNumber(1)
@@ -746,7 +927,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get amount => $_getI64(1);
   @$pb.TagNumber(3)
-  set amount($fixnum.Int64 v) { $_setInt64(1, v); }
+  set amount($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasAmount() => $_has(1);
   @$pb.TagNumber(3)
@@ -755,7 +939,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get creationTimestamp => $_getI64(2);
   @$pb.TagNumber(4)
-  set creationTimestamp($fixnum.Int64 v) { $_setInt64(2, v); }
+  set creationTimestamp($fixnum.Int64 v) {
+    $_setInt64(2, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasCreationTimestamp() => $_has(2);
   @$pb.TagNumber(4)
@@ -764,7 +951,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   InvoiceMemo get invoiceMemo => $_getN(3);
   @$pb.TagNumber(6)
-  set invoiceMemo(InvoiceMemo v) { setField(6, v); }
+  set invoiceMemo(InvoiceMemo v) {
+    setField(6, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasInvoiceMemo() => $_has(3);
   @$pb.TagNumber(6)
@@ -775,7 +965,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.String get redeemTxID => $_getSZ(4);
   @$pb.TagNumber(7)
-  set redeemTxID($core.String v) { $_setString(4, v); }
+  set redeemTxID($core.String v) {
+    $_setString(4, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasRedeemTxID() => $_has(4);
   @$pb.TagNumber(7)
@@ -784,7 +977,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.String get paymentHash => $_getSZ(5);
   @$pb.TagNumber(8)
-  set paymentHash($core.String v) { $_setString(5, v); }
+  set paymentHash($core.String v) {
+    $_setString(5, v);
+  }
+
   @$pb.TagNumber(8)
   $core.bool hasPaymentHash() => $_has(5);
   @$pb.TagNumber(8)
@@ -793,7 +989,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.String get destination => $_getSZ(6);
   @$pb.TagNumber(9)
-  set destination($core.String v) { $_setString(6, v); }
+  set destination($core.String v) {
+    $_setString(6, v);
+  }
+
   @$pb.TagNumber(9)
   $core.bool hasDestination() => $_has(6);
   @$pb.TagNumber(9)
@@ -802,7 +1001,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $core.int get pendingExpirationHeight => $_getIZ(7);
   @$pb.TagNumber(10)
-  set pendingExpirationHeight($core.int v) { $_setUnsignedInt32(7, v); }
+  set pendingExpirationHeight($core.int v) {
+    $_setUnsignedInt32(7, v);
+  }
+
   @$pb.TagNumber(10)
   $core.bool hasPendingExpirationHeight() => $_has(7);
   @$pb.TagNumber(10)
@@ -811,7 +1013,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $fixnum.Int64 get pendingExpirationTimestamp => $_getI64(8);
   @$pb.TagNumber(11)
-  set pendingExpirationTimestamp($fixnum.Int64 v) { $_setInt64(8, v); }
+  set pendingExpirationTimestamp($fixnum.Int64 v) {
+    $_setInt64(8, v);
+  }
+
   @$pb.TagNumber(11)
   $core.bool hasPendingExpirationTimestamp() => $_has(8);
   @$pb.TagNumber(11)
@@ -820,7 +1025,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(12)
   $fixnum.Int64 get fee => $_getI64(9);
   @$pb.TagNumber(12)
-  set fee($fixnum.Int64 v) { $_setInt64(9, v); }
+  set fee($fixnum.Int64 v) {
+    $_setInt64(9, v);
+  }
+
   @$pb.TagNumber(12)
   $core.bool hasFee() => $_has(9);
   @$pb.TagNumber(12)
@@ -829,7 +1037,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(13)
   $core.String get preimage => $_getSZ(10);
   @$pb.TagNumber(13)
-  set preimage($core.String v) { $_setString(10, v); }
+  set preimage($core.String v) {
+    $_setString(10, v);
+  }
+
   @$pb.TagNumber(13)
   $core.bool hasPreimage() => $_has(10);
   @$pb.TagNumber(13)
@@ -838,7 +1049,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(14)
   $core.String get closedChannelPoint => $_getSZ(11);
   @$pb.TagNumber(14)
-  set closedChannelPoint($core.String v) { $_setString(11, v); }
+  set closedChannelPoint($core.String v) {
+    $_setString(11, v);
+  }
+
   @$pb.TagNumber(14)
   $core.bool hasClosedChannelPoint() => $_has(11);
   @$pb.TagNumber(14)
@@ -847,7 +1061,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(15)
   $core.bool get isChannelPending => $_getBF(12);
   @$pb.TagNumber(15)
-  set isChannelPending($core.bool v) { $_setBool(12, v); }
+  set isChannelPending($core.bool v) {
+    $_setBool(12, v);
+  }
+
   @$pb.TagNumber(15)
   $core.bool hasIsChannelPending() => $_has(12);
   @$pb.TagNumber(15)
@@ -856,7 +1073,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(16)
   $core.bool get isChannelCloseConfimed => $_getBF(13);
   @$pb.TagNumber(16)
-  set isChannelCloseConfimed($core.bool v) { $_setBool(13, v); }
+  set isChannelCloseConfimed($core.bool v) {
+    $_setBool(13, v);
+  }
+
   @$pb.TagNumber(16)
   $core.bool hasIsChannelCloseConfimed() => $_has(13);
   @$pb.TagNumber(16)
@@ -865,7 +1085,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(17)
   $core.String get closedChannelTxID => $_getSZ(14);
   @$pb.TagNumber(17)
-  set closedChannelTxID($core.String v) { $_setString(14, v); }
+  set closedChannelTxID($core.String v) {
+    $_setString(14, v);
+  }
+
   @$pb.TagNumber(17)
   $core.bool hasClosedChannelTxID() => $_has(14);
   @$pb.TagNumber(17)
@@ -874,7 +1097,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(18)
   $core.bool get isKeySend => $_getBF(15);
   @$pb.TagNumber(18)
-  set isKeySend($core.bool v) { $_setBool(15, v); }
+  set isKeySend($core.bool v) {
+    $_setBool(15, v);
+  }
+
   @$pb.TagNumber(18)
   $core.bool hasIsKeySend() => $_has(15);
   @$pb.TagNumber(18)
@@ -883,7 +1109,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(19)
   $core.bool get pendingFull => $_getBF(16);
   @$pb.TagNumber(19)
-  set pendingFull($core.bool v) { $_setBool(16, v); }
+  set pendingFull($core.bool v) {
+    $_setBool(16, v);
+  }
+
   @$pb.TagNumber(19)
   $core.bool hasPendingFull() => $_has(16);
   @$pb.TagNumber(19)
@@ -892,7 +1121,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(20)
   $core.String get closedChannelRemoteTxID => $_getSZ(17);
   @$pb.TagNumber(20)
-  set closedChannelRemoteTxID($core.String v) { $_setString(17, v); }
+  set closedChannelRemoteTxID($core.String v) {
+    $_setString(17, v);
+  }
+
   @$pb.TagNumber(20)
   $core.bool hasClosedChannelRemoteTxID() => $_has(17);
   @$pb.TagNumber(20)
@@ -901,7 +1133,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(21)
   $core.String get closedChannelSweepTxID => $_getSZ(18);
   @$pb.TagNumber(21)
-  set closedChannelSweepTxID($core.String v) { $_setString(18, v); }
+  set closedChannelSweepTxID($core.String v) {
+    $_setString(18, v);
+  }
+
   @$pb.TagNumber(21)
   $core.bool hasClosedChannelSweepTxID() => $_has(18);
   @$pb.TagNumber(21)
@@ -910,7 +1145,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(22)
   $core.String get groupKey => $_getSZ(19);
   @$pb.TagNumber(22)
-  set groupKey($core.String v) { $_setString(19, v); }
+  set groupKey($core.String v) {
+    $_setString(19, v);
+  }
+
   @$pb.TagNumber(22)
   $core.bool hasGroupKey() => $_has(19);
   @$pb.TagNumber(22)
@@ -919,7 +1157,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(23)
   $core.String get groupName => $_getSZ(20);
   @$pb.TagNumber(23)
-  set groupName($core.String v) { $_setString(20, v); }
+  set groupName($core.String v) {
+    $_setString(20, v);
+  }
+
   @$pb.TagNumber(23)
   $core.bool hasGroupName() => $_has(20);
   @$pb.TagNumber(23)
@@ -928,7 +1169,10 @@ class Payment extends $pb.GeneratedMessage {
   @$pb.TagNumber(24)
   LNUrlPayInfo get lnurlPayInfo => $_getN(21);
   @$pb.TagNumber(24)
-  set lnurlPayInfo(LNUrlPayInfo v) { setField(24, v); }
+  set lnurlPayInfo(LNUrlPayInfo v) {
+    setField(24, v);
+  }
+
   @$pb.TagNumber(24)
   $core.bool hasLnurlPayInfo() => $_has(21);
   @$pb.TagNumber(24)
@@ -938,10 +1182,15 @@ class Payment extends $pb.GeneratedMessage {
 }
 
 class PaymentsList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PaymentsList', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..pc<Payment>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentsList', $pb.PbFieldType.PM, protoName: 'paymentsList', subBuilder: Payment.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PaymentsList',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..pc<Payment>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentsList',
+        $pb.PbFieldType.PM,
+        protoName: 'paymentsList', subBuilder: Payment.create)
+    ..hasRequiredFields = false;
 
   PaymentsList._() : super();
   factory PaymentsList({
@@ -953,25 +1202,29 @@ class PaymentsList extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory PaymentsList.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PaymentsList.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory PaymentsList.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory PaymentsList.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   PaymentsList clone() => PaymentsList()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  PaymentsList copyWith(void Function(PaymentsList) updates) => super.copyWith((message) => updates(message as PaymentsList)) as PaymentsList; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  PaymentsList copyWith(void Function(PaymentsList) updates) =>
+      super.copyWith((message) => updates(message as PaymentsList))
+          as PaymentsList; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PaymentsList create() => PaymentsList._();
   PaymentsList createEmptyInstance() => create();
   static $pb.PbList<PaymentsList> createRepeated() => $pb.PbList<PaymentsList>();
   @$core.pragma('dart2js:noInline')
-  static PaymentsList getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PaymentsList>(create);
+  static PaymentsList getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PaymentsList>(create);
   static PaymentsList? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -979,11 +1232,16 @@ class PaymentsList extends $pb.GeneratedMessage {
 }
 
 class PaymentResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PaymentResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentError', protoName: 'paymentError')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'traceReport', protoName: 'traceReport')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PaymentResponse',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentError',
+        protoName: 'paymentError')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'traceReport',
+        protoName: 'traceReport')
+    ..hasRequiredFields = false;
 
   PaymentResponse._() : super();
   factory PaymentResponse({
@@ -999,31 +1257,38 @@ class PaymentResponse extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory PaymentResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PaymentResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory PaymentResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory PaymentResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   PaymentResponse clone() => PaymentResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  PaymentResponse copyWith(void Function(PaymentResponse) updates) => super.copyWith((message) => updates(message as PaymentResponse)) as PaymentResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  PaymentResponse copyWith(void Function(PaymentResponse) updates) =>
+      super.copyWith((message) => updates(message as PaymentResponse))
+          as PaymentResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PaymentResponse create() => PaymentResponse._();
   PaymentResponse createEmptyInstance() => create();
   static $pb.PbList<PaymentResponse> createRepeated() => $pb.PbList<PaymentResponse>();
   @$core.pragma('dart2js:noInline')
-  static PaymentResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PaymentResponse>(create);
+  static PaymentResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PaymentResponse>(create);
   static PaymentResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get paymentError => $_getSZ(0);
   @$pb.TagNumber(1)
-  set paymentError($core.String v) { $_setString(0, v); }
+  set paymentError($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasPaymentError() => $_has(0);
   @$pb.TagNumber(1)
@@ -1032,7 +1297,10 @@ class PaymentResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get traceReport => $_getSZ(1);
   @$pb.TagNumber(2)
-  set traceReport($core.String v) { $_setString(1, v); }
+  set traceReport($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasTraceReport() => $_has(1);
   @$pb.TagNumber(2)
@@ -1040,11 +1308,15 @@ class PaymentResponse extends $pb.GeneratedMessage {
 }
 
 class SendWalletCoinsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SendWalletCoinsRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SendWalletCoinsRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'address')
-    ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'satPerByteFee', protoName: 'satPerByteFee')
-    ..hasRequiredFields = false
-  ;
+    ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'satPerByteFee',
+        protoName: 'satPerByteFee')
+    ..hasRequiredFields = false;
 
   SendWalletCoinsRequest._() : super();
   factory SendWalletCoinsRequest({
@@ -1060,31 +1332,39 @@ class SendWalletCoinsRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory SendWalletCoinsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory SendWalletCoinsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory SendWalletCoinsRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory SendWalletCoinsRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   SendWalletCoinsRequest clone() => SendWalletCoinsRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  SendWalletCoinsRequest copyWith(void Function(SendWalletCoinsRequest) updates) => super.copyWith((message) => updates(message as SendWalletCoinsRequest)) as SendWalletCoinsRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  SendWalletCoinsRequest copyWith(void Function(SendWalletCoinsRequest) updates) =>
+      super.copyWith((message) => updates(message as SendWalletCoinsRequest))
+          as SendWalletCoinsRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SendWalletCoinsRequest create() => SendWalletCoinsRequest._();
   SendWalletCoinsRequest createEmptyInstance() => create();
   static $pb.PbList<SendWalletCoinsRequest> createRepeated() => $pb.PbList<SendWalletCoinsRequest>();
   @$core.pragma('dart2js:noInline')
-  static SendWalletCoinsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SendWalletCoinsRequest>(create);
+  static SendWalletCoinsRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SendWalletCoinsRequest>(create);
   static SendWalletCoinsRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) { $_setString(0, v); }
+  set address($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -1093,7 +1373,10 @@ class SendWalletCoinsRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get satPerByteFee => $_getI64(1);
   @$pb.TagNumber(2)
-  set satPerByteFee($fixnum.Int64 v) { $_setInt64(1, v); }
+  set satPerByteFee($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasSatPerByteFee() => $_has(1);
   @$pb.TagNumber(2)
@@ -1101,12 +1384,16 @@ class SendWalletCoinsRequest extends $pb.GeneratedMessage {
 }
 
 class PayInvoiceRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PayInvoiceRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PayInvoiceRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aInt64(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'amount')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentRequest', protoName: 'paymentRequest')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentRequest',
+        protoName: 'paymentRequest')
     ..aInt64(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'fee')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   PayInvoiceRequest._() : super();
   factory PayInvoiceRequest({
@@ -1126,31 +1413,39 @@ class PayInvoiceRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory PayInvoiceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PayInvoiceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory PayInvoiceRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory PayInvoiceRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   PayInvoiceRequest clone() => PayInvoiceRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  PayInvoiceRequest copyWith(void Function(PayInvoiceRequest) updates) => super.copyWith((message) => updates(message as PayInvoiceRequest)) as PayInvoiceRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  PayInvoiceRequest copyWith(void Function(PayInvoiceRequest) updates) =>
+      super.copyWith((message) => updates(message as PayInvoiceRequest))
+          as PayInvoiceRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PayInvoiceRequest create() => PayInvoiceRequest._();
   PayInvoiceRequest createEmptyInstance() => create();
   static $pb.PbList<PayInvoiceRequest> createRepeated() => $pb.PbList<PayInvoiceRequest>();
   @$core.pragma('dart2js:noInline')
-  static PayInvoiceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PayInvoiceRequest>(create);
+  static PayInvoiceRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PayInvoiceRequest>(create);
   static PayInvoiceRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get amount => $_getI64(0);
   @$pb.TagNumber(1)
-  set amount($fixnum.Int64 v) { $_setInt64(0, v); }
+  set amount($fixnum.Int64 v) {
+    $_setInt64(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasAmount() => $_has(0);
   @$pb.TagNumber(1)
@@ -1159,7 +1454,10 @@ class PayInvoiceRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get paymentRequest => $_getSZ(1);
   @$pb.TagNumber(2)
-  set paymentRequest($core.String v) { $_setString(1, v); }
+  set paymentRequest($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasPaymentRequest() => $_has(1);
   @$pb.TagNumber(2)
@@ -1168,7 +1466,10 @@ class PayInvoiceRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get fee => $_getI64(2);
   @$pb.TagNumber(3)
-  set fee($fixnum.Int64 v) { $_setInt64(2, v); }
+  set fee($fixnum.Int64 v) {
+    $_setInt64(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasFee() => $_has(2);
   @$pb.TagNumber(3)
@@ -1176,16 +1477,28 @@ class PayInvoiceRequest extends $pb.GeneratedMessage {
 }
 
 class SpontaneousPaymentRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SpontaneousPaymentRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SpontaneousPaymentRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aInt64(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'amount')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'destNode', protoName: 'destNode')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'destNode',
+        protoName: 'destNode')
     ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'description')
-    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'groupKey', protoName: 'groupKey')
-    ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'groupName', protoName: 'groupName')
-    ..aInt64(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'feeLimitMsat', protoName: 'feeLimitMsat')
-    ..m<$fixnum.Int64, $core.String>(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'tlv', entryClassName: 'SpontaneousPaymentRequest.TlvEntry', keyFieldType: $pb.PbFieldType.O6, valueFieldType: $pb.PbFieldType.OS, packageName: const $pb.PackageName('data'))
-    ..hasRequiredFields = false
-  ;
+    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'groupKey',
+        protoName: 'groupKey')
+    ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'groupName',
+        protoName: 'groupName')
+    ..aInt64(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'feeLimitMsat',
+        protoName: 'feeLimitMsat')
+    ..m<$fixnum.Int64, $core.String>(
+        7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'tlv',
+        entryClassName: 'SpontaneousPaymentRequest.TlvEntry',
+        keyFieldType: $pb.PbFieldType.O6,
+        valueFieldType: $pb.PbFieldType.OS,
+        packageName: const $pb.PackageName('data'))
+    ..hasRequiredFields = false;
 
   SpontaneousPaymentRequest._() : super();
   factory SpontaneousPaymentRequest({
@@ -1221,31 +1534,39 @@ class SpontaneousPaymentRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory SpontaneousPaymentRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory SpontaneousPaymentRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory SpontaneousPaymentRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory SpontaneousPaymentRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   SpontaneousPaymentRequest clone() => SpontaneousPaymentRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  SpontaneousPaymentRequest copyWith(void Function(SpontaneousPaymentRequest) updates) => super.copyWith((message) => updates(message as SpontaneousPaymentRequest)) as SpontaneousPaymentRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  SpontaneousPaymentRequest copyWith(void Function(SpontaneousPaymentRequest) updates) =>
+      super.copyWith((message) => updates(message as SpontaneousPaymentRequest))
+          as SpontaneousPaymentRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SpontaneousPaymentRequest create() => SpontaneousPaymentRequest._();
   SpontaneousPaymentRequest createEmptyInstance() => create();
   static $pb.PbList<SpontaneousPaymentRequest> createRepeated() => $pb.PbList<SpontaneousPaymentRequest>();
   @$core.pragma('dart2js:noInline')
-  static SpontaneousPaymentRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SpontaneousPaymentRequest>(create);
+  static SpontaneousPaymentRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SpontaneousPaymentRequest>(create);
   static SpontaneousPaymentRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get amount => $_getI64(0);
   @$pb.TagNumber(1)
-  set amount($fixnum.Int64 v) { $_setInt64(0, v); }
+  set amount($fixnum.Int64 v) {
+    $_setInt64(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasAmount() => $_has(0);
   @$pb.TagNumber(1)
@@ -1254,7 +1575,10 @@ class SpontaneousPaymentRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get destNode => $_getSZ(1);
   @$pb.TagNumber(2)
-  set destNode($core.String v) { $_setString(1, v); }
+  set destNode($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasDestNode() => $_has(1);
   @$pb.TagNumber(2)
@@ -1263,7 +1587,10 @@ class SpontaneousPaymentRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get description => $_getSZ(2);
   @$pb.TagNumber(3)
-  set description($core.String v) { $_setString(2, v); }
+  set description($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasDescription() => $_has(2);
   @$pb.TagNumber(3)
@@ -1272,7 +1599,10 @@ class SpontaneousPaymentRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get groupKey => $_getSZ(3);
   @$pb.TagNumber(4)
-  set groupKey($core.String v) { $_setString(3, v); }
+  set groupKey($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasGroupKey() => $_has(3);
   @$pb.TagNumber(4)
@@ -1281,7 +1611,10 @@ class SpontaneousPaymentRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get groupName => $_getSZ(4);
   @$pb.TagNumber(5)
-  set groupName($core.String v) { $_setString(4, v); }
+  set groupName($core.String v) {
+    $_setString(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasGroupName() => $_has(4);
   @$pb.TagNumber(5)
@@ -1290,7 +1623,10 @@ class SpontaneousPaymentRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get feeLimitMsat => $_getI64(5);
   @$pb.TagNumber(6)
-  set feeLimitMsat($fixnum.Int64 v) { $_setInt64(5, v); }
+  set feeLimitMsat($fixnum.Int64 v) {
+    $_setInt64(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasFeeLimitMsat() => $_has(5);
   @$pb.TagNumber(6)
@@ -1301,18 +1637,27 @@ class SpontaneousPaymentRequest extends $pb.GeneratedMessage {
 }
 
 class InvoiceMemo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'InvoiceMemo', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'InvoiceMemo',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'description')
     ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'amount')
-    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'payeeName', protoName: 'payeeName')
-    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'payeeImageURL', protoName: 'payeeImageURL')
-    ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'payerName', protoName: 'payerName')
-    ..aOS(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'payerImageURL', protoName: 'payerImageURL')
-    ..aOB(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'transferRequest', protoName: 'transferRequest')
+    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'payeeName',
+        protoName: 'payeeName')
+    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'payeeImageURL',
+        protoName: 'payeeImageURL')
+    ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'payerName',
+        protoName: 'payerName')
+    ..aOS(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'payerImageURL',
+        protoName: 'payerImageURL')
+    ..aOB(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'transferRequest',
+        protoName: 'transferRequest')
     ..aInt64(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'expiry')
-    ..a<$core.List<$core.int>>(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'preimage', $pb.PbFieldType.OY)
-    ..hasRequiredFields = false
-  ;
+    ..a<$core.List<$core.int>>(9,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'preimage', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
 
   InvoiceMemo._() : super();
   factory InvoiceMemo({
@@ -1356,31 +1701,38 @@ class InvoiceMemo extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory InvoiceMemo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory InvoiceMemo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory InvoiceMemo.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory InvoiceMemo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   InvoiceMemo clone() => InvoiceMemo()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  InvoiceMemo copyWith(void Function(InvoiceMemo) updates) => super.copyWith((message) => updates(message as InvoiceMemo)) as InvoiceMemo; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  InvoiceMemo copyWith(void Function(InvoiceMemo) updates) =>
+      super.copyWith((message) => updates(message as InvoiceMemo))
+          as InvoiceMemo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static InvoiceMemo create() => InvoiceMemo._();
   InvoiceMemo createEmptyInstance() => create();
   static $pb.PbList<InvoiceMemo> createRepeated() => $pb.PbList<InvoiceMemo>();
   @$core.pragma('dart2js:noInline')
-  static InvoiceMemo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<InvoiceMemo>(create);
+  static InvoiceMemo getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<InvoiceMemo>(create);
   static InvoiceMemo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get description => $_getSZ(0);
   @$pb.TagNumber(1)
-  set description($core.String v) { $_setString(0, v); }
+  set description($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasDescription() => $_has(0);
   @$pb.TagNumber(1)
@@ -1389,7 +1741,10 @@ class InvoiceMemo extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amount => $_getI64(1);
   @$pb.TagNumber(2)
-  set amount($fixnum.Int64 v) { $_setInt64(1, v); }
+  set amount($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasAmount() => $_has(1);
   @$pb.TagNumber(2)
@@ -1398,7 +1753,10 @@ class InvoiceMemo extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get payeeName => $_getSZ(2);
   @$pb.TagNumber(3)
-  set payeeName($core.String v) { $_setString(2, v); }
+  set payeeName($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasPayeeName() => $_has(2);
   @$pb.TagNumber(3)
@@ -1407,7 +1765,10 @@ class InvoiceMemo extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get payeeImageURL => $_getSZ(3);
   @$pb.TagNumber(4)
-  set payeeImageURL($core.String v) { $_setString(3, v); }
+  set payeeImageURL($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasPayeeImageURL() => $_has(3);
   @$pb.TagNumber(4)
@@ -1416,7 +1777,10 @@ class InvoiceMemo extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get payerName => $_getSZ(4);
   @$pb.TagNumber(5)
-  set payerName($core.String v) { $_setString(4, v); }
+  set payerName($core.String v) {
+    $_setString(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasPayerName() => $_has(4);
   @$pb.TagNumber(5)
@@ -1425,7 +1789,10 @@ class InvoiceMemo extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.String get payerImageURL => $_getSZ(5);
   @$pb.TagNumber(6)
-  set payerImageURL($core.String v) { $_setString(5, v); }
+  set payerImageURL($core.String v) {
+    $_setString(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasPayerImageURL() => $_has(5);
   @$pb.TagNumber(6)
@@ -1434,7 +1801,10 @@ class InvoiceMemo extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.bool get transferRequest => $_getBF(6);
   @$pb.TagNumber(7)
-  set transferRequest($core.bool v) { $_setBool(6, v); }
+  set transferRequest($core.bool v) {
+    $_setBool(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasTransferRequest() => $_has(6);
   @$pb.TagNumber(7)
@@ -1443,7 +1813,10 @@ class InvoiceMemo extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $fixnum.Int64 get expiry => $_getI64(7);
   @$pb.TagNumber(8)
-  set expiry($fixnum.Int64 v) { $_setInt64(7, v); }
+  set expiry($fixnum.Int64 v) {
+    $_setInt64(7, v);
+  }
+
   @$pb.TagNumber(8)
   $core.bool hasExpiry() => $_has(7);
   @$pb.TagNumber(8)
@@ -1452,7 +1825,10 @@ class InvoiceMemo extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.List<$core.int> get preimage => $_getN(8);
   @$pb.TagNumber(9)
-  set preimage($core.List<$core.int> v) { $_setBytes(8, v); }
+  set preimage($core.List<$core.int> v) {
+    $_setBytes(8, v);
+  }
+
   @$pb.TagNumber(9)
   $core.bool hasPreimage() => $_has(8);
   @$pb.TagNumber(9)
@@ -1460,12 +1836,20 @@ class InvoiceMemo extends $pb.GeneratedMessage {
 }
 
 class AddInvoiceRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddInvoiceRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..aOM<InvoiceMemo>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'invoiceDetails', protoName: 'invoiceDetails', subBuilder: InvoiceMemo.create)
-    ..aOM<LSPInformation>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lspInfo', protoName: 'lspInfo', subBuilder: LSPInformation.create)
-    ..aOM<OpeningFeeParams>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'openingFeeParams', subBuilder: OpeningFeeParams.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddInvoiceRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..aOM<InvoiceMemo>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'invoiceDetails',
+        protoName: 'invoiceDetails', subBuilder: InvoiceMemo.create)
+    ..aOM<LSPInformation>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lspInfo',
+        protoName: 'lspInfo', subBuilder: LSPInformation.create)
+    ..aOM<OpeningFeeParams>(
+        3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'openingFeeParams',
+        subBuilder: OpeningFeeParams.create)
+    ..hasRequiredFields = false;
 
   AddInvoiceRequest._() : super();
   factory AddInvoiceRequest({
@@ -1485,31 +1869,39 @@ class AddInvoiceRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory AddInvoiceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory AddInvoiceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory AddInvoiceRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory AddInvoiceRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   AddInvoiceRequest clone() => AddInvoiceRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  AddInvoiceRequest copyWith(void Function(AddInvoiceRequest) updates) => super.copyWith((message) => updates(message as AddInvoiceRequest)) as AddInvoiceRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  AddInvoiceRequest copyWith(void Function(AddInvoiceRequest) updates) =>
+      super.copyWith((message) => updates(message as AddInvoiceRequest))
+          as AddInvoiceRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AddInvoiceRequest create() => AddInvoiceRequest._();
   AddInvoiceRequest createEmptyInstance() => create();
   static $pb.PbList<AddInvoiceRequest> createRepeated() => $pb.PbList<AddInvoiceRequest>();
   @$core.pragma('dart2js:noInline')
-  static AddInvoiceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddInvoiceRequest>(create);
+  static AddInvoiceRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddInvoiceRequest>(create);
   static AddInvoiceRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   InvoiceMemo get invoiceDetails => $_getN(0);
   @$pb.TagNumber(1)
-  set invoiceDetails(InvoiceMemo v) { setField(1, v); }
+  set invoiceDetails(InvoiceMemo v) {
+    setField(1, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasInvoiceDetails() => $_has(0);
   @$pb.TagNumber(1)
@@ -1520,7 +1912,10 @@ class AddInvoiceRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   LSPInformation get lspInfo => $_getN(1);
   @$pb.TagNumber(2)
-  set lspInfo(LSPInformation v) { setField(2, v); }
+  set lspInfo(LSPInformation v) {
+    setField(2, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasLspInfo() => $_has(1);
   @$pb.TagNumber(2)
@@ -1531,7 +1926,10 @@ class AddInvoiceRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   OpeningFeeParams get openingFeeParams => $_getN(2);
   @$pb.TagNumber(3)
-  set openingFeeParams(OpeningFeeParams v) { setField(3, v); }
+  set openingFeeParams(OpeningFeeParams v) {
+    setField(3, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasOpeningFeeParams() => $_has(2);
   @$pb.TagNumber(3)
@@ -1541,12 +1939,17 @@ class AddInvoiceRequest extends $pb.GeneratedMessage {
 }
 
 class Invoice extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Invoice', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..aOM<InvoiceMemo>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'memo', subBuilder: InvoiceMemo.create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Invoice',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..aOM<InvoiceMemo>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'memo',
+        subBuilder: InvoiceMemo.create)
     ..aOB(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'settled')
-    ..aInt64(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'amtPaid', protoName: 'amtPaid')
-    ..hasRequiredFields = false
-  ;
+    ..aInt64(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'amtPaid',
+        protoName: 'amtPaid')
+    ..hasRequiredFields = false;
 
   Invoice._() : super();
   factory Invoice({
@@ -1566,18 +1969,20 @@ class Invoice extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory Invoice.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Invoice.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory Invoice.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Invoice.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   Invoice clone() => Invoice()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Invoice copyWith(void Function(Invoice) updates) => super.copyWith((message) => updates(message as Invoice)) as Invoice; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Invoice copyWith(void Function(Invoice) updates) =>
+      super.copyWith((message) => updates(message as Invoice)) as Invoice; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Invoice create() => Invoice._();
@@ -1590,7 +1995,10 @@ class Invoice extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   InvoiceMemo get memo => $_getN(0);
   @$pb.TagNumber(1)
-  set memo(InvoiceMemo v) { setField(1, v); }
+  set memo(InvoiceMemo v) {
+    setField(1, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasMemo() => $_has(0);
   @$pb.TagNumber(1)
@@ -1601,7 +2009,10 @@ class Invoice extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get settled => $_getBF(1);
   @$pb.TagNumber(2)
-  set settled($core.bool v) { $_setBool(1, v); }
+  set settled($core.bool v) {
+    $_setBool(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasSettled() => $_has(1);
   @$pb.TagNumber(2)
@@ -1610,7 +2021,10 @@ class Invoice extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get amtPaid => $_getI64(2);
   @$pb.TagNumber(3)
-  set amtPaid($fixnum.Int64 v) { $_setInt64(2, v); }
+  set amtPaid($fixnum.Int64 v) {
+    $_setInt64(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasAmtPaid() => $_has(2);
   @$pb.TagNumber(3)
@@ -1618,11 +2032,18 @@ class Invoice extends $pb.GeneratedMessage {
 }
 
 class CheckLSPClosedChannelMismatchRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CheckLSPClosedChannelMismatchRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..aOM<LSPInformation>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lspInfo', protoName: 'lspInfo', subBuilder: LSPInformation.create)
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'chanPoint', protoName: 'chanPoint')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'CheckLSPClosedChannelMismatchRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..aOM<LSPInformation>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lspInfo',
+        protoName: 'lspInfo', subBuilder: LSPInformation.create)
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'chanPoint',
+        protoName: 'chanPoint')
+    ..hasRequiredFields = false;
 
   CheckLSPClosedChannelMismatchRequest._() : super();
   factory CheckLSPClosedChannelMismatchRequest({
@@ -1638,31 +2059,42 @@ class CheckLSPClosedChannelMismatchRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory CheckLSPClosedChannelMismatchRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory CheckLSPClosedChannelMismatchRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  CheckLSPClosedChannelMismatchRequest clone() => CheckLSPClosedChannelMismatchRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  CheckLSPClosedChannelMismatchRequest copyWith(void Function(CheckLSPClosedChannelMismatchRequest) updates) => super.copyWith((message) => updates(message as CheckLSPClosedChannelMismatchRequest)) as CheckLSPClosedChannelMismatchRequest; // ignore: deprecated_member_use
+  factory CheckLSPClosedChannelMismatchRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory CheckLSPClosedChannelMismatchRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  CheckLSPClosedChannelMismatchRequest clone() =>
+      CheckLSPClosedChannelMismatchRequest()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  CheckLSPClosedChannelMismatchRequest copyWith(
+          void Function(CheckLSPClosedChannelMismatchRequest) updates) =>
+      super.copyWith((message) => updates(message as CheckLSPClosedChannelMismatchRequest))
+          as CheckLSPClosedChannelMismatchRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CheckLSPClosedChannelMismatchRequest create() => CheckLSPClosedChannelMismatchRequest._();
   CheckLSPClosedChannelMismatchRequest createEmptyInstance() => create();
-  static $pb.PbList<CheckLSPClosedChannelMismatchRequest> createRepeated() => $pb.PbList<CheckLSPClosedChannelMismatchRequest>();
+  static $pb.PbList<CheckLSPClosedChannelMismatchRequest> createRepeated() =>
+      $pb.PbList<CheckLSPClosedChannelMismatchRequest>();
   @$core.pragma('dart2js:noInline')
-  static CheckLSPClosedChannelMismatchRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CheckLSPClosedChannelMismatchRequest>(create);
+  static CheckLSPClosedChannelMismatchRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CheckLSPClosedChannelMismatchRequest>(create);
   static CheckLSPClosedChannelMismatchRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   LSPInformation get lspInfo => $_getN(0);
   @$pb.TagNumber(1)
-  set lspInfo(LSPInformation v) { setField(1, v); }
+  set lspInfo(LSPInformation v) {
+    setField(1, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasLspInfo() => $_has(0);
   @$pb.TagNumber(1)
@@ -1673,7 +2105,10 @@ class CheckLSPClosedChannelMismatchRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get chanPoint => $_getSZ(1);
   @$pb.TagNumber(2)
-  set chanPoint($core.String v) { $_setString(1, v); }
+  set chanPoint($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasChanPoint() => $_has(1);
   @$pb.TagNumber(2)
@@ -1681,10 +2116,15 @@ class CheckLSPClosedChannelMismatchRequest extends $pb.GeneratedMessage {
 }
 
 class CheckLSPClosedChannelMismatchResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CheckLSPClosedChannelMismatchResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'CheckLSPClosedChannelMismatchResponse',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOB(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'mismatch')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   CheckLSPClosedChannelMismatchResponse._() : super();
   factory CheckLSPClosedChannelMismatchResponse({
@@ -1696,31 +2136,42 @@ class CheckLSPClosedChannelMismatchResponse extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory CheckLSPClosedChannelMismatchResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory CheckLSPClosedChannelMismatchResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  CheckLSPClosedChannelMismatchResponse clone() => CheckLSPClosedChannelMismatchResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  CheckLSPClosedChannelMismatchResponse copyWith(void Function(CheckLSPClosedChannelMismatchResponse) updates) => super.copyWith((message) => updates(message as CheckLSPClosedChannelMismatchResponse)) as CheckLSPClosedChannelMismatchResponse; // ignore: deprecated_member_use
+  factory CheckLSPClosedChannelMismatchResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory CheckLSPClosedChannelMismatchResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  CheckLSPClosedChannelMismatchResponse clone() =>
+      CheckLSPClosedChannelMismatchResponse()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  CheckLSPClosedChannelMismatchResponse copyWith(
+          void Function(CheckLSPClosedChannelMismatchResponse) updates) =>
+      super.copyWith((message) => updates(message as CheckLSPClosedChannelMismatchResponse))
+          as CheckLSPClosedChannelMismatchResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CheckLSPClosedChannelMismatchResponse create() => CheckLSPClosedChannelMismatchResponse._();
   CheckLSPClosedChannelMismatchResponse createEmptyInstance() => create();
-  static $pb.PbList<CheckLSPClosedChannelMismatchResponse> createRepeated() => $pb.PbList<CheckLSPClosedChannelMismatchResponse>();
+  static $pb.PbList<CheckLSPClosedChannelMismatchResponse> createRepeated() =>
+      $pb.PbList<CheckLSPClosedChannelMismatchResponse>();
   @$core.pragma('dart2js:noInline')
-  static CheckLSPClosedChannelMismatchResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CheckLSPClosedChannelMismatchResponse>(create);
+  static CheckLSPClosedChannelMismatchResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CheckLSPClosedChannelMismatchResponse>(create);
   static CheckLSPClosedChannelMismatchResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get mismatch => $_getBF(0);
   @$pb.TagNumber(1)
-  set mismatch($core.bool v) { $_setBool(0, v); }
+  set mismatch($core.bool v) {
+    $_setBool(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasMismatch() => $_has(0);
   @$pb.TagNumber(1)
@@ -1728,11 +2179,18 @@ class CheckLSPClosedChannelMismatchResponse extends $pb.GeneratedMessage {
 }
 
 class ResetClosedChannelChainInfoRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ResetClosedChannelChainInfoRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'chanPoint', protoName: 'chanPoint')
-    ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'blockHeight', protoName: 'blockHeight')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'ResetClosedChannelChainInfoRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'chanPoint',
+        protoName: 'chanPoint')
+    ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'blockHeight',
+        protoName: 'blockHeight')
+    ..hasRequiredFields = false;
 
   ResetClosedChannelChainInfoRequest._() : super();
   factory ResetClosedChannelChainInfoRequest({
@@ -1748,31 +2206,40 @@ class ResetClosedChannelChainInfoRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ResetClosedChannelChainInfoRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ResetClosedChannelChainInfoRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ResetClosedChannelChainInfoRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ResetClosedChannelChainInfoRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ResetClosedChannelChainInfoRequest clone() => ResetClosedChannelChainInfoRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ResetClosedChannelChainInfoRequest copyWith(void Function(ResetClosedChannelChainInfoRequest) updates) => super.copyWith((message) => updates(message as ResetClosedChannelChainInfoRequest)) as ResetClosedChannelChainInfoRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ResetClosedChannelChainInfoRequest copyWith(void Function(ResetClosedChannelChainInfoRequest) updates) =>
+      super.copyWith((message) => updates(message as ResetClosedChannelChainInfoRequest))
+          as ResetClosedChannelChainInfoRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ResetClosedChannelChainInfoRequest create() => ResetClosedChannelChainInfoRequest._();
   ResetClosedChannelChainInfoRequest createEmptyInstance() => create();
-  static $pb.PbList<ResetClosedChannelChainInfoRequest> createRepeated() => $pb.PbList<ResetClosedChannelChainInfoRequest>();
+  static $pb.PbList<ResetClosedChannelChainInfoRequest> createRepeated() =>
+      $pb.PbList<ResetClosedChannelChainInfoRequest>();
   @$core.pragma('dart2js:noInline')
-  static ResetClosedChannelChainInfoRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ResetClosedChannelChainInfoRequest>(create);
+  static ResetClosedChannelChainInfoRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ResetClosedChannelChainInfoRequest>(create);
   static ResetClosedChannelChainInfoRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get chanPoint => $_getSZ(0);
   @$pb.TagNumber(1)
-  set chanPoint($core.String v) { $_setString(0, v); }
+  set chanPoint($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasChanPoint() => $_has(0);
   @$pb.TagNumber(1)
@@ -1781,7 +2248,10 @@ class ResetClosedChannelChainInfoRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get blockHeight => $_getI64(1);
   @$pb.TagNumber(2)
-  set blockHeight($fixnum.Int64 v) { $_setInt64(1, v); }
+  set blockHeight($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasBlockHeight() => $_has(1);
   @$pb.TagNumber(2)
@@ -1789,40 +2259,58 @@ class ResetClosedChannelChainInfoRequest extends $pb.GeneratedMessage {
 }
 
 class ResetClosedChannelChainInfoReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ResetClosedChannelChainInfoReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'ResetClosedChannelChainInfoReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   ResetClosedChannelChainInfoReply._() : super();
   factory ResetClosedChannelChainInfoReply() => create();
-  factory ResetClosedChannelChainInfoReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ResetClosedChannelChainInfoReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ResetClosedChannelChainInfoReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ResetClosedChannelChainInfoReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ResetClosedChannelChainInfoReply clone() => ResetClosedChannelChainInfoReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ResetClosedChannelChainInfoReply copyWith(void Function(ResetClosedChannelChainInfoReply) updates) => super.copyWith((message) => updates(message as ResetClosedChannelChainInfoReply)) as ResetClosedChannelChainInfoReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ResetClosedChannelChainInfoReply copyWith(void Function(ResetClosedChannelChainInfoReply) updates) =>
+      super.copyWith((message) => updates(message as ResetClosedChannelChainInfoReply))
+          as ResetClosedChannelChainInfoReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ResetClosedChannelChainInfoReply create() => ResetClosedChannelChainInfoReply._();
   ResetClosedChannelChainInfoReply createEmptyInstance() => create();
-  static $pb.PbList<ResetClosedChannelChainInfoReply> createRepeated() => $pb.PbList<ResetClosedChannelChainInfoReply>();
+  static $pb.PbList<ResetClosedChannelChainInfoReply> createRepeated() =>
+      $pb.PbList<ResetClosedChannelChainInfoReply>();
   @$core.pragma('dart2js:noInline')
-  static ResetClosedChannelChainInfoReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ResetClosedChannelChainInfoReply>(create);
+  static ResetClosedChannelChainInfoReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ResetClosedChannelChainInfoReply>(create);
   static ResetClosedChannelChainInfoReply? _defaultInstance;
 }
 
 class NotificationEvent extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'NotificationEvent', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..e<NotificationEvent_NotificationType>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'type', $pb.PbFieldType.OE, defaultOrMaker: NotificationEvent_NotificationType.READY, valueOf: NotificationEvent_NotificationType.valueOf, enumValues: NotificationEvent_NotificationType.values)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'NotificationEvent',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..e<NotificationEvent_NotificationType>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'type', $pb.PbFieldType.OE,
+        defaultOrMaker: NotificationEvent_NotificationType.READY,
+        valueOf: NotificationEvent_NotificationType.valueOf,
+        enumValues: NotificationEvent_NotificationType.values)
     ..pPS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'data')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   NotificationEvent._() : super();
   factory NotificationEvent({
@@ -1838,31 +2326,39 @@ class NotificationEvent extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory NotificationEvent.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory NotificationEvent.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory NotificationEvent.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory NotificationEvent.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   NotificationEvent clone() => NotificationEvent()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  NotificationEvent copyWith(void Function(NotificationEvent) updates) => super.copyWith((message) => updates(message as NotificationEvent)) as NotificationEvent; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  NotificationEvent copyWith(void Function(NotificationEvent) updates) =>
+      super.copyWith((message) => updates(message as NotificationEvent))
+          as NotificationEvent; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static NotificationEvent create() => NotificationEvent._();
   NotificationEvent createEmptyInstance() => create();
   static $pb.PbList<NotificationEvent> createRepeated() => $pb.PbList<NotificationEvent>();
   @$core.pragma('dart2js:noInline')
-  static NotificationEvent getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NotificationEvent>(create);
+  static NotificationEvent getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NotificationEvent>(create);
   static NotificationEvent? _defaultInstance;
 
   @$pb.TagNumber(1)
   NotificationEvent_NotificationType get type => $_getN(0);
   @$pb.TagNumber(1)
-  set type(NotificationEvent_NotificationType v) { setField(1, v); }
+  set type(NotificationEvent_NotificationType v) {
+    setField(1, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasType() => $_has(0);
   @$pb.TagNumber(1)
@@ -1873,15 +2369,23 @@ class NotificationEvent extends $pb.GeneratedMessage {
 }
 
 class AddFundInitReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddFundInitReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddFundInitReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'address')
-    ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxAllowedDeposit', protoName: 'maxAllowedDeposit')
-    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'errorMessage', protoName: 'errorMessage')
-    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'backupJson', protoName: 'backupJson')
-    ..aInt64(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'requiredReserve', protoName: 'requiredReserve')
-    ..aInt64(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'minAllowedDeposit', protoName: 'minAllowedDeposit')
-    ..hasRequiredFields = false
-  ;
+    ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxAllowedDeposit',
+        protoName: 'maxAllowedDeposit')
+    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'errorMessage',
+        protoName: 'errorMessage')
+    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'backupJson',
+        protoName: 'backupJson')
+    ..aInt64(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'requiredReserve',
+        protoName: 'requiredReserve')
+    ..aInt64(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'minAllowedDeposit',
+        protoName: 'minAllowedDeposit')
+    ..hasRequiredFields = false;
 
   AddFundInitReply._() : super();
   factory AddFundInitReply({
@@ -1913,31 +2417,39 @@ class AddFundInitReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory AddFundInitReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory AddFundInitReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory AddFundInitReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory AddFundInitReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   AddFundInitReply clone() => AddFundInitReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  AddFundInitReply copyWith(void Function(AddFundInitReply) updates) => super.copyWith((message) => updates(message as AddFundInitReply)) as AddFundInitReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  AddFundInitReply copyWith(void Function(AddFundInitReply) updates) =>
+      super.copyWith((message) => updates(message as AddFundInitReply))
+          as AddFundInitReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AddFundInitReply create() => AddFundInitReply._();
   AddFundInitReply createEmptyInstance() => create();
   static $pb.PbList<AddFundInitReply> createRepeated() => $pb.PbList<AddFundInitReply>();
   @$core.pragma('dart2js:noInline')
-  static AddFundInitReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundInitReply>(create);
+  static AddFundInitReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundInitReply>(create);
   static AddFundInitReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) { $_setString(0, v); }
+  set address($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -1946,7 +2458,10 @@ class AddFundInitReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get maxAllowedDeposit => $_getI64(1);
   @$pb.TagNumber(2)
-  set maxAllowedDeposit($fixnum.Int64 v) { $_setInt64(1, v); }
+  set maxAllowedDeposit($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasMaxAllowedDeposit() => $_has(1);
   @$pb.TagNumber(2)
@@ -1955,7 +2470,10 @@ class AddFundInitReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get errorMessage => $_getSZ(2);
   @$pb.TagNumber(3)
-  set errorMessage($core.String v) { $_setString(2, v); }
+  set errorMessage($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasErrorMessage() => $_has(2);
   @$pb.TagNumber(3)
@@ -1964,7 +2482,10 @@ class AddFundInitReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get backupJson => $_getSZ(3);
   @$pb.TagNumber(4)
-  set backupJson($core.String v) { $_setString(3, v); }
+  set backupJson($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasBackupJson() => $_has(3);
   @$pb.TagNumber(4)
@@ -1973,7 +2494,10 @@ class AddFundInitReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $fixnum.Int64 get requiredReserve => $_getI64(4);
   @$pb.TagNumber(5)
-  set requiredReserve($fixnum.Int64 v) { $_setInt64(4, v); }
+  set requiredReserve($fixnum.Int64 v) {
+    $_setInt64(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasRequiredReserve() => $_has(4);
   @$pb.TagNumber(5)
@@ -1982,7 +2506,10 @@ class AddFundInitReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get minAllowedDeposit => $_getI64(5);
   @$pb.TagNumber(6)
-  set minAllowedDeposit($fixnum.Int64 v) { $_setInt64(5, v); }
+  set minAllowedDeposit($fixnum.Int64 v) {
+    $_setInt64(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasMinAllowedDeposit() => $_has(5);
   @$pb.TagNumber(6)
@@ -1990,10 +2517,14 @@ class AddFundInitReply extends $pb.GeneratedMessage {
 }
 
 class AddFundReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddFundReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'errorMessage', protoName: 'errorMessage')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddFundReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'errorMessage',
+        protoName: 'errorMessage')
+    ..hasRequiredFields = false;
 
   AddFundReply._() : super();
   factory AddFundReply({
@@ -2005,31 +2536,38 @@ class AddFundReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory AddFundReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory AddFundReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory AddFundReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory AddFundReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   AddFundReply clone() => AddFundReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  AddFundReply copyWith(void Function(AddFundReply) updates) => super.copyWith((message) => updates(message as AddFundReply)) as AddFundReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  AddFundReply copyWith(void Function(AddFundReply) updates) =>
+      super.copyWith((message) => updates(message as AddFundReply))
+          as AddFundReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AddFundReply create() => AddFundReply._();
   AddFundReply createEmptyInstance() => create();
   static $pb.PbList<AddFundReply> createRepeated() => $pb.PbList<AddFundReply>();
   @$core.pragma('dart2js:noInline')
-  static AddFundReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundReply>(create);
+  static AddFundReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundReply>(create);
   static AddFundReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get errorMessage => $_getSZ(0);
   @$pb.TagNumber(1)
-  set errorMessage($core.String v) { $_setString(0, v); }
+  set errorMessage($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasErrorMessage() => $_has(0);
   @$pb.TagNumber(1)
@@ -2037,13 +2575,18 @@ class AddFundReply extends $pb.GeneratedMessage {
 }
 
 class RefundRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RefundRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RefundRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'address')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'refundAddress', protoName: 'refundAddress')
-    ..a<$core.int>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'targetConf', $pb.PbFieldType.O3)
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'refundAddress',
+        protoName: 'refundAddress')
+    ..a<$core.int>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'targetConf',
+        $pb.PbFieldType.O3)
     ..aInt64(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'satPerByte')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   RefundRequest._() : super();
   factory RefundRequest({
@@ -2067,31 +2610,38 @@ class RefundRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RefundRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RefundRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RefundRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RefundRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RefundRequest clone() => RefundRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RefundRequest copyWith(void Function(RefundRequest) updates) => super.copyWith((message) => updates(message as RefundRequest)) as RefundRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RefundRequest copyWith(void Function(RefundRequest) updates) =>
+      super.copyWith((message) => updates(message as RefundRequest))
+          as RefundRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RefundRequest create() => RefundRequest._();
   RefundRequest createEmptyInstance() => create();
   static $pb.PbList<RefundRequest> createRepeated() => $pb.PbList<RefundRequest>();
   @$core.pragma('dart2js:noInline')
-  static RefundRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RefundRequest>(create);
+  static RefundRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RefundRequest>(create);
   static RefundRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) { $_setString(0, v); }
+  set address($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -2100,7 +2650,10 @@ class RefundRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get refundAddress => $_getSZ(1);
   @$pb.TagNumber(2)
-  set refundAddress($core.String v) { $_setString(1, v); }
+  set refundAddress($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasRefundAddress() => $_has(1);
   @$pb.TagNumber(2)
@@ -2109,7 +2662,10 @@ class RefundRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.int get targetConf => $_getIZ(2);
   @$pb.TagNumber(3)
-  set targetConf($core.int v) { $_setSignedInt32(2, v); }
+  set targetConf($core.int v) {
+    $_setSignedInt32(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasTargetConf() => $_has(2);
   @$pb.TagNumber(3)
@@ -2118,7 +2674,10 @@ class RefundRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get satPerByte => $_getI64(3);
   @$pb.TagNumber(4)
-  set satPerByte($fixnum.Int64 v) { $_setInt64(3, v); }
+  set satPerByte($fixnum.Int64 v) {
+    $_setInt64(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasSatPerByte() => $_has(3);
   @$pb.TagNumber(4)
@@ -2126,11 +2685,18 @@ class RefundRequest extends $pb.GeneratedMessage {
 }
 
 class AddFundError extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddFundError', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..aOM<SwapAddressInfo>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'swapAddressInfo', protoName: 'swapAddressInfo', subBuilder: SwapAddressInfo.create)
-    ..a<$core.double>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'hoursToUnlock', $pb.PbFieldType.OF, protoName: 'hoursToUnlock')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AddFundError',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..aOM<SwapAddressInfo>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'swapAddressInfo',
+        protoName: 'swapAddressInfo', subBuilder: SwapAddressInfo.create)
+    ..a<$core.double>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'hoursToUnlock',
+        $pb.PbFieldType.OF,
+        protoName: 'hoursToUnlock')
+    ..hasRequiredFields = false;
 
   AddFundError._() : super();
   factory AddFundError({
@@ -2146,31 +2712,38 @@ class AddFundError extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory AddFundError.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory AddFundError.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory AddFundError.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory AddFundError.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   AddFundError clone() => AddFundError()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  AddFundError copyWith(void Function(AddFundError) updates) => super.copyWith((message) => updates(message as AddFundError)) as AddFundError; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  AddFundError copyWith(void Function(AddFundError) updates) =>
+      super.copyWith((message) => updates(message as AddFundError))
+          as AddFundError; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AddFundError create() => AddFundError._();
   AddFundError createEmptyInstance() => create();
   static $pb.PbList<AddFundError> createRepeated() => $pb.PbList<AddFundError>();
   @$core.pragma('dart2js:noInline')
-  static AddFundError getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundError>(create);
+  static AddFundError getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AddFundError>(create);
   static AddFundError? _defaultInstance;
 
   @$pb.TagNumber(1)
   SwapAddressInfo get swapAddressInfo => $_getN(0);
   @$pb.TagNumber(1)
-  set swapAddressInfo(SwapAddressInfo v) { setField(1, v); }
+  set swapAddressInfo(SwapAddressInfo v) {
+    setField(1, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasSwapAddressInfo() => $_has(0);
   @$pb.TagNumber(1)
@@ -2181,7 +2754,10 @@ class AddFundError extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.double get hoursToUnlock => $_getN(1);
   @$pb.TagNumber(2)
-  set hoursToUnlock($core.double v) { $_setFloat(1, v); }
+  set hoursToUnlock($core.double v) {
+    $_setFloat(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasHoursToUnlock() => $_has(1);
   @$pb.TagNumber(2)
@@ -2189,12 +2765,30 @@ class AddFundError extends $pb.GeneratedMessage {
 }
 
 class FundStatusReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'FundStatusReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..pc<SwapAddressInfo>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'unConfirmedAddresses', $pb.PbFieldType.PM, protoName: 'unConfirmedAddresses', subBuilder: SwapAddressInfo.create)
-    ..pc<SwapAddressInfo>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'confirmedAddresses', $pb.PbFieldType.PM, protoName: 'confirmedAddresses', subBuilder: SwapAddressInfo.create)
-    ..pc<SwapAddressInfo>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'refundableAddresses', $pb.PbFieldType.PM, protoName: 'refundableAddresses', subBuilder: SwapAddressInfo.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'FundStatusReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..pc<SwapAddressInfo>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'unConfirmedAddresses',
+        $pb.PbFieldType.PM,
+        protoName: 'unConfirmedAddresses',
+        subBuilder: SwapAddressInfo.create)
+    ..pc<SwapAddressInfo>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'confirmedAddresses',
+        $pb.PbFieldType.PM,
+        protoName: 'confirmedAddresses',
+        subBuilder: SwapAddressInfo.create)
+    ..pc<SwapAddressInfo>(
+        3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'refundableAddresses',
+        $pb.PbFieldType.PM,
+        protoName: 'refundableAddresses',
+        subBuilder: SwapAddressInfo.create)
+    ..hasRequiredFields = false;
 
   FundStatusReply._() : super();
   factory FundStatusReply({
@@ -2214,25 +2808,29 @@ class FundStatusReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory FundStatusReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory FundStatusReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory FundStatusReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory FundStatusReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   FundStatusReply clone() => FundStatusReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  FundStatusReply copyWith(void Function(FundStatusReply) updates) => super.copyWith((message) => updates(message as FundStatusReply)) as FundStatusReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  FundStatusReply copyWith(void Function(FundStatusReply) updates) =>
+      super.copyWith((message) => updates(message as FundStatusReply))
+          as FundStatusReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static FundStatusReply create() => FundStatusReply._();
   FundStatusReply createEmptyInstance() => create();
   static $pb.PbList<FundStatusReply> createRepeated() => $pb.PbList<FundStatusReply>();
   @$core.pragma('dart2js:noInline')
-  static FundStatusReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<FundStatusReply>(create);
+  static FundStatusReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<FundStatusReply>(create);
   static FundStatusReply? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -2246,11 +2844,14 @@ class FundStatusReply extends $pb.GeneratedMessage {
 }
 
 class RemoveFundRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RemoveFundRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RemoveFundRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'address')
     ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'amount')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   RemoveFundRequest._() : super();
   factory RemoveFundRequest({
@@ -2266,31 +2867,39 @@ class RemoveFundRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RemoveFundRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RemoveFundRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RemoveFundRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RemoveFundRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RemoveFundRequest clone() => RemoveFundRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RemoveFundRequest copyWith(void Function(RemoveFundRequest) updates) => super.copyWith((message) => updates(message as RemoveFundRequest)) as RemoveFundRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RemoveFundRequest copyWith(void Function(RemoveFundRequest) updates) =>
+      super.copyWith((message) => updates(message as RemoveFundRequest))
+          as RemoveFundRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RemoveFundRequest create() => RemoveFundRequest._();
   RemoveFundRequest createEmptyInstance() => create();
   static $pb.PbList<RemoveFundRequest> createRepeated() => $pb.PbList<RemoveFundRequest>();
   @$core.pragma('dart2js:noInline')
-  static RemoveFundRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFundRequest>(create);
+  static RemoveFundRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFundRequest>(create);
   static RemoveFundRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) { $_setString(0, v); }
+  set address($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -2299,7 +2908,10 @@ class RemoveFundRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amount => $_getI64(1);
   @$pb.TagNumber(2)
-  set amount($fixnum.Int64 v) { $_setInt64(1, v); }
+  set amount($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasAmount() => $_has(1);
   @$pb.TagNumber(2)
@@ -2307,11 +2919,15 @@ class RemoveFundRequest extends $pb.GeneratedMessage {
 }
 
 class RemoveFundReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RemoveFundReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RemoveFundReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'txid')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'errorMessage', protoName: 'errorMessage')
-    ..hasRequiredFields = false
-  ;
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'errorMessage',
+        protoName: 'errorMessage')
+    ..hasRequiredFields = false;
 
   RemoveFundReply._() : super();
   factory RemoveFundReply({
@@ -2327,31 +2943,38 @@ class RemoveFundReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RemoveFundReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RemoveFundReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RemoveFundReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RemoveFundReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RemoveFundReply clone() => RemoveFundReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RemoveFundReply copyWith(void Function(RemoveFundReply) updates) => super.copyWith((message) => updates(message as RemoveFundReply)) as RemoveFundReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RemoveFundReply copyWith(void Function(RemoveFundReply) updates) =>
+      super.copyWith((message) => updates(message as RemoveFundReply))
+          as RemoveFundReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RemoveFundReply create() => RemoveFundReply._();
   RemoveFundReply createEmptyInstance() => create();
   static $pb.PbList<RemoveFundReply> createRepeated() => $pb.PbList<RemoveFundReply>();
   @$core.pragma('dart2js:noInline')
-  static RemoveFundReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFundReply>(create);
+  static RemoveFundReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RemoveFundReply>(create);
   static RemoveFundReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get txid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set txid($core.String v) { $_setString(0, v); }
+  set txid($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasTxid() => $_has(0);
   @$pb.TagNumber(1)
@@ -2360,7 +2983,10 @@ class RemoveFundReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get errorMessage => $_getSZ(1);
   @$pb.TagNumber(2)
-  set errorMessage($core.String v) { $_setString(1, v); }
+  set errorMessage($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasErrorMessage() => $_has(1);
   @$pb.TagNumber(2)
@@ -2368,21 +2994,43 @@ class RemoveFundReply extends $pb.GeneratedMessage {
 }
 
 class SwapAddressInfo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SwapAddressInfo', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SwapAddressInfo',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'address')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'PaymentHash', protoName: 'PaymentHash')
-    ..aInt64(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'ConfirmedAmount', protoName: 'ConfirmedAmount')
-    ..pPS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'ConfirmedTransactionIds', protoName: 'ConfirmedTransactionIds')
-    ..aInt64(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'PaidAmount', protoName: 'PaidAmount')
-    ..a<$core.int>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lockHeight', $pb.PbFieldType.OU3, protoName: 'lockHeight')
-    ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'errorMessage', protoName: 'errorMessage')
-    ..aOS(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lastRefundTxID', protoName: 'lastRefundTxID')
-    ..e<SwapError>(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'swapError', $pb.PbFieldType.OE, protoName: 'swapError', defaultOrMaker: SwapError.NO_ERROR, valueOf: SwapError.valueOf, enumValues: SwapError.values)
-    ..aOS(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'FundingTxID', protoName: 'FundingTxID')
-    ..a<$core.double>(11, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'hoursToUnlock', $pb.PbFieldType.OF, protoName: 'hoursToUnlock')
-    ..aOB(12, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'nonBlocking', protoName: 'nonBlocking')
-    ..hasRequiredFields = false
-  ;
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'PaymentHash',
+        protoName: 'PaymentHash')
+    ..aInt64(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'ConfirmedAmount',
+        protoName: 'ConfirmedAmount')
+    ..pPS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'ConfirmedTransactionIds',
+        protoName: 'ConfirmedTransactionIds')
+    ..aInt64(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'PaidAmount',
+        protoName: 'PaidAmount')
+    ..a<$core.int>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lockHeight',
+        $pb.PbFieldType.OU3,
+        protoName: 'lockHeight')
+    ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'errorMessage',
+        protoName: 'errorMessage')
+    ..aOS(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lastRefundTxID',
+        protoName: 'lastRefundTxID')
+    ..e<SwapError>(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'swapError',
+        $pb.PbFieldType.OE,
+        protoName: 'swapError',
+        defaultOrMaker: SwapError.NO_ERROR,
+        valueOf: SwapError.valueOf,
+        enumValues: SwapError.values)
+    ..aOS(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'FundingTxID',
+        protoName: 'FundingTxID')
+    ..a<$core.double>(
+        11,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'hoursToUnlock',
+        $pb.PbFieldType.OF,
+        protoName: 'hoursToUnlock')
+    ..aOB(12, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'nonBlocking',
+        protoName: 'nonBlocking')
+    ..hasRequiredFields = false;
 
   SwapAddressInfo._() : super();
   factory SwapAddressInfo({
@@ -2438,31 +3086,38 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory SwapAddressInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory SwapAddressInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory SwapAddressInfo.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory SwapAddressInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   SwapAddressInfo clone() => SwapAddressInfo()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  SwapAddressInfo copyWith(void Function(SwapAddressInfo) updates) => super.copyWith((message) => updates(message as SwapAddressInfo)) as SwapAddressInfo; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  SwapAddressInfo copyWith(void Function(SwapAddressInfo) updates) =>
+      super.copyWith((message) => updates(message as SwapAddressInfo))
+          as SwapAddressInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SwapAddressInfo create() => SwapAddressInfo._();
   SwapAddressInfo createEmptyInstance() => create();
   static $pb.PbList<SwapAddressInfo> createRepeated() => $pb.PbList<SwapAddressInfo>();
   @$core.pragma('dart2js:noInline')
-  static SwapAddressInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SwapAddressInfo>(create);
+  static SwapAddressInfo getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SwapAddressInfo>(create);
   static SwapAddressInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) { $_setString(0, v); }
+  set address($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -2471,7 +3126,10 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get paymentHash => $_getSZ(1);
   @$pb.TagNumber(2)
-  set paymentHash($core.String v) { $_setString(1, v); }
+  set paymentHash($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasPaymentHash() => $_has(1);
   @$pb.TagNumber(2)
@@ -2480,7 +3138,10 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get confirmedAmount => $_getI64(2);
   @$pb.TagNumber(3)
-  set confirmedAmount($fixnum.Int64 v) { $_setInt64(2, v); }
+  set confirmedAmount($fixnum.Int64 v) {
+    $_setInt64(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasConfirmedAmount() => $_has(2);
   @$pb.TagNumber(3)
@@ -2492,7 +3153,10 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $fixnum.Int64 get paidAmount => $_getI64(4);
   @$pb.TagNumber(5)
-  set paidAmount($fixnum.Int64 v) { $_setInt64(4, v); }
+  set paidAmount($fixnum.Int64 v) {
+    $_setInt64(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasPaidAmount() => $_has(4);
   @$pb.TagNumber(5)
@@ -2501,7 +3165,10 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.int get lockHeight => $_getIZ(5);
   @$pb.TagNumber(6)
-  set lockHeight($core.int v) { $_setUnsignedInt32(5, v); }
+  set lockHeight($core.int v) {
+    $_setUnsignedInt32(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasLockHeight() => $_has(5);
   @$pb.TagNumber(6)
@@ -2510,7 +3177,10 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.String get errorMessage => $_getSZ(6);
   @$pb.TagNumber(7)
-  set errorMessage($core.String v) { $_setString(6, v); }
+  set errorMessage($core.String v) {
+    $_setString(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasErrorMessage() => $_has(6);
   @$pb.TagNumber(7)
@@ -2519,7 +3189,10 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.String get lastRefundTxID => $_getSZ(7);
   @$pb.TagNumber(8)
-  set lastRefundTxID($core.String v) { $_setString(7, v); }
+  set lastRefundTxID($core.String v) {
+    $_setString(7, v);
+  }
+
   @$pb.TagNumber(8)
   $core.bool hasLastRefundTxID() => $_has(7);
   @$pb.TagNumber(8)
@@ -2528,7 +3201,10 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   SwapError get swapError => $_getN(8);
   @$pb.TagNumber(9)
-  set swapError(SwapError v) { setField(9, v); }
+  set swapError(SwapError v) {
+    setField(9, v);
+  }
+
   @$pb.TagNumber(9)
   $core.bool hasSwapError() => $_has(8);
   @$pb.TagNumber(9)
@@ -2537,7 +3213,10 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $core.String get fundingTxID => $_getSZ(9);
   @$pb.TagNumber(10)
-  set fundingTxID($core.String v) { $_setString(9, v); }
+  set fundingTxID($core.String v) {
+    $_setString(9, v);
+  }
+
   @$pb.TagNumber(10)
   $core.bool hasFundingTxID() => $_has(9);
   @$pb.TagNumber(10)
@@ -2546,7 +3225,10 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $core.double get hoursToUnlock => $_getN(10);
   @$pb.TagNumber(11)
-  set hoursToUnlock($core.double v) { $_setFloat(10, v); }
+  set hoursToUnlock($core.double v) {
+    $_setFloat(10, v);
+  }
+
   @$pb.TagNumber(11)
   $core.bool hasHoursToUnlock() => $_has(10);
   @$pb.TagNumber(11)
@@ -2555,7 +3237,10 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(12)
   $core.bool get nonBlocking => $_getBF(11);
   @$pb.TagNumber(12)
-  set nonBlocking($core.bool v) { $_setBool(11, v); }
+  set nonBlocking($core.bool v) {
+    $_setBool(11, v);
+  }
+
   @$pb.TagNumber(12)
   $core.bool hasNonBlocking() => $_has(11);
   @$pb.TagNumber(12)
@@ -2563,10 +3248,15 @@ class SwapAddressInfo extends $pb.GeneratedMessage {
 }
 
 class SwapAddressList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SwapAddressList', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..pc<SwapAddressInfo>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'addresses', $pb.PbFieldType.PM, subBuilder: SwapAddressInfo.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SwapAddressList',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..pc<SwapAddressInfo>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'addresses',
+        $pb.PbFieldType.PM,
+        subBuilder: SwapAddressInfo.create)
+    ..hasRequiredFields = false;
 
   SwapAddressList._() : super();
   factory SwapAddressList({
@@ -2578,25 +3268,29 @@ class SwapAddressList extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory SwapAddressList.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory SwapAddressList.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory SwapAddressList.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory SwapAddressList.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   SwapAddressList clone() => SwapAddressList()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  SwapAddressList copyWith(void Function(SwapAddressList) updates) => super.copyWith((message) => updates(message as SwapAddressList)) as SwapAddressList; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  SwapAddressList copyWith(void Function(SwapAddressList) updates) =>
+      super.copyWith((message) => updates(message as SwapAddressList))
+          as SwapAddressList; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SwapAddressList create() => SwapAddressList._();
   SwapAddressList createEmptyInstance() => create();
   static $pb.PbList<SwapAddressList> createRepeated() => $pb.PbList<SwapAddressList>();
   @$core.pragma('dart2js:noInline')
-  static SwapAddressList getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SwapAddressList>(create);
+  static SwapAddressList getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SwapAddressList>(create);
   static SwapAddressList? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -2604,13 +3298,20 @@ class SwapAddressList extends $pb.GeneratedMessage {
 }
 
 class CreateRatchetSessionRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CreateRatchetSessionRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CreateRatchetSessionRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'secret')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'remotePubKey', protoName: 'remotePubKey')
-    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sessionID', protoName: 'sessionID')
-    ..a<$fixnum.Int64>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'expiry', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
-    ..hasRequiredFields = false
-  ;
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'remotePubKey',
+        protoName: 'remotePubKey')
+    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sessionID',
+        protoName: 'sessionID')
+    ..a<$fixnum.Int64>(
+        4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'expiry', $pb.PbFieldType.OU6,
+        defaultOrMaker: $fixnum.Int64.ZERO)
+    ..hasRequiredFields = false;
 
   CreateRatchetSessionRequest._() : super();
   factory CreateRatchetSessionRequest({
@@ -2634,31 +3335,40 @@ class CreateRatchetSessionRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory CreateRatchetSessionRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory CreateRatchetSessionRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory CreateRatchetSessionRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory CreateRatchetSessionRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   CreateRatchetSessionRequest clone() => CreateRatchetSessionRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  CreateRatchetSessionRequest copyWith(void Function(CreateRatchetSessionRequest) updates) => super.copyWith((message) => updates(message as CreateRatchetSessionRequest)) as CreateRatchetSessionRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  CreateRatchetSessionRequest copyWith(void Function(CreateRatchetSessionRequest) updates) =>
+      super.copyWith((message) => updates(message as CreateRatchetSessionRequest))
+          as CreateRatchetSessionRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CreateRatchetSessionRequest create() => CreateRatchetSessionRequest._();
   CreateRatchetSessionRequest createEmptyInstance() => create();
-  static $pb.PbList<CreateRatchetSessionRequest> createRepeated() => $pb.PbList<CreateRatchetSessionRequest>();
+  static $pb.PbList<CreateRatchetSessionRequest> createRepeated() =>
+      $pb.PbList<CreateRatchetSessionRequest>();
   @$core.pragma('dart2js:noInline')
-  static CreateRatchetSessionRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateRatchetSessionRequest>(create);
+  static CreateRatchetSessionRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateRatchetSessionRequest>(create);
   static CreateRatchetSessionRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get secret => $_getSZ(0);
   @$pb.TagNumber(1)
-  set secret($core.String v) { $_setString(0, v); }
+  set secret($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasSecret() => $_has(0);
   @$pb.TagNumber(1)
@@ -2667,7 +3377,10 @@ class CreateRatchetSessionRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get remotePubKey => $_getSZ(1);
   @$pb.TagNumber(2)
-  set remotePubKey($core.String v) { $_setString(1, v); }
+  set remotePubKey($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasRemotePubKey() => $_has(1);
   @$pb.TagNumber(2)
@@ -2676,7 +3389,10 @@ class CreateRatchetSessionRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get sessionID => $_getSZ(2);
   @$pb.TagNumber(3)
-  set sessionID($core.String v) { $_setString(2, v); }
+  set sessionID($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasSessionID() => $_has(2);
   @$pb.TagNumber(3)
@@ -2685,7 +3401,10 @@ class CreateRatchetSessionRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get expiry => $_getI64(3);
   @$pb.TagNumber(4)
-  set expiry($fixnum.Int64 v) { $_setInt64(3, v); }
+  set expiry($fixnum.Int64 v) {
+    $_setInt64(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasExpiry() => $_has(3);
   @$pb.TagNumber(4)
@@ -2693,12 +3412,17 @@ class CreateRatchetSessionRequest extends $pb.GeneratedMessage {
 }
 
 class CreateRatchetSessionReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CreateRatchetSessionReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sessionID', protoName: 'sessionID')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CreateRatchetSessionReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sessionID',
+        protoName: 'sessionID')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'secret')
-    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pubKey', protoName: 'pubKey')
-    ..hasRequiredFields = false
-  ;
+    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pubKey',
+        protoName: 'pubKey')
+    ..hasRequiredFields = false;
 
   CreateRatchetSessionReply._() : super();
   factory CreateRatchetSessionReply({
@@ -2718,31 +3442,39 @@ class CreateRatchetSessionReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory CreateRatchetSessionReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory CreateRatchetSessionReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory CreateRatchetSessionReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory CreateRatchetSessionReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   CreateRatchetSessionReply clone() => CreateRatchetSessionReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  CreateRatchetSessionReply copyWith(void Function(CreateRatchetSessionReply) updates) => super.copyWith((message) => updates(message as CreateRatchetSessionReply)) as CreateRatchetSessionReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  CreateRatchetSessionReply copyWith(void Function(CreateRatchetSessionReply) updates) =>
+      super.copyWith((message) => updates(message as CreateRatchetSessionReply))
+          as CreateRatchetSessionReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CreateRatchetSessionReply create() => CreateRatchetSessionReply._();
   CreateRatchetSessionReply createEmptyInstance() => create();
   static $pb.PbList<CreateRatchetSessionReply> createRepeated() => $pb.PbList<CreateRatchetSessionReply>();
   @$core.pragma('dart2js:noInline')
-  static CreateRatchetSessionReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateRatchetSessionReply>(create);
+  static CreateRatchetSessionReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateRatchetSessionReply>(create);
   static CreateRatchetSessionReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sessionID => $_getSZ(0);
   @$pb.TagNumber(1)
-  set sessionID($core.String v) { $_setString(0, v); }
+  set sessionID($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasSessionID() => $_has(0);
   @$pb.TagNumber(1)
@@ -2751,7 +3483,10 @@ class CreateRatchetSessionReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get secret => $_getSZ(1);
   @$pb.TagNumber(2)
-  set secret($core.String v) { $_setString(1, v); }
+  set secret($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasSecret() => $_has(1);
   @$pb.TagNumber(2)
@@ -2760,7 +3495,10 @@ class CreateRatchetSessionReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get pubKey => $_getSZ(2);
   @$pb.TagNumber(3)
-  set pubKey($core.String v) { $_setString(2, v); }
+  set pubKey($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasPubKey() => $_has(2);
   @$pb.TagNumber(3)
@@ -2768,12 +3506,17 @@ class CreateRatchetSessionReply extends $pb.GeneratedMessage {
 }
 
 class RatchetSessionInfoReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RatchetSessionInfoReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sessionID', protoName: 'sessionID')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RatchetSessionInfoReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sessionID',
+        protoName: 'sessionID')
     ..aOB(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'initiated')
-    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'userInfo', protoName: 'userInfo')
-    ..hasRequiredFields = false
-  ;
+    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'userInfo',
+        protoName: 'userInfo')
+    ..hasRequiredFields = false;
 
   RatchetSessionInfoReply._() : super();
   factory RatchetSessionInfoReply({
@@ -2793,31 +3536,39 @@ class RatchetSessionInfoReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RatchetSessionInfoReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RatchetSessionInfoReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RatchetSessionInfoReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RatchetSessionInfoReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RatchetSessionInfoReply clone() => RatchetSessionInfoReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RatchetSessionInfoReply copyWith(void Function(RatchetSessionInfoReply) updates) => super.copyWith((message) => updates(message as RatchetSessionInfoReply)) as RatchetSessionInfoReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RatchetSessionInfoReply copyWith(void Function(RatchetSessionInfoReply) updates) =>
+      super.copyWith((message) => updates(message as RatchetSessionInfoReply))
+          as RatchetSessionInfoReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RatchetSessionInfoReply create() => RatchetSessionInfoReply._();
   RatchetSessionInfoReply createEmptyInstance() => create();
   static $pb.PbList<RatchetSessionInfoReply> createRepeated() => $pb.PbList<RatchetSessionInfoReply>();
   @$core.pragma('dart2js:noInline')
-  static RatchetSessionInfoReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatchetSessionInfoReply>(create);
+  static RatchetSessionInfoReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatchetSessionInfoReply>(create);
   static RatchetSessionInfoReply? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sessionID => $_getSZ(0);
   @$pb.TagNumber(1)
-  set sessionID($core.String v) { $_setString(0, v); }
+  set sessionID($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasSessionID() => $_has(0);
   @$pb.TagNumber(1)
@@ -2826,7 +3577,10 @@ class RatchetSessionInfoReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get initiated => $_getBF(1);
   @$pb.TagNumber(2)
-  set initiated($core.bool v) { $_setBool(1, v); }
+  set initiated($core.bool v) {
+    $_setBool(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasInitiated() => $_has(1);
   @$pb.TagNumber(2)
@@ -2835,7 +3589,10 @@ class RatchetSessionInfoReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get userInfo => $_getSZ(2);
   @$pb.TagNumber(3)
-  set userInfo($core.String v) { $_setString(2, v); }
+  set userInfo($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasUserInfo() => $_has(2);
   @$pb.TagNumber(3)
@@ -2843,11 +3600,16 @@ class RatchetSessionInfoReply extends $pb.GeneratedMessage {
 }
 
 class RatchetSessionSetInfoRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RatchetSessionSetInfoRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sessionID', protoName: 'sessionID')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'userInfo', protoName: 'userInfo')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RatchetSessionSetInfoRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sessionID',
+        protoName: 'sessionID')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'userInfo',
+        protoName: 'userInfo')
+    ..hasRequiredFields = false;
 
   RatchetSessionSetInfoRequest._() : super();
   factory RatchetSessionSetInfoRequest({
@@ -2863,31 +3625,40 @@ class RatchetSessionSetInfoRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RatchetSessionSetInfoRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RatchetSessionSetInfoRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RatchetSessionSetInfoRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RatchetSessionSetInfoRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RatchetSessionSetInfoRequest clone() => RatchetSessionSetInfoRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RatchetSessionSetInfoRequest copyWith(void Function(RatchetSessionSetInfoRequest) updates) => super.copyWith((message) => updates(message as RatchetSessionSetInfoRequest)) as RatchetSessionSetInfoRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RatchetSessionSetInfoRequest copyWith(void Function(RatchetSessionSetInfoRequest) updates) =>
+      super.copyWith((message) => updates(message as RatchetSessionSetInfoRequest))
+          as RatchetSessionSetInfoRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RatchetSessionSetInfoRequest create() => RatchetSessionSetInfoRequest._();
   RatchetSessionSetInfoRequest createEmptyInstance() => create();
-  static $pb.PbList<RatchetSessionSetInfoRequest> createRepeated() => $pb.PbList<RatchetSessionSetInfoRequest>();
+  static $pb.PbList<RatchetSessionSetInfoRequest> createRepeated() =>
+      $pb.PbList<RatchetSessionSetInfoRequest>();
   @$core.pragma('dart2js:noInline')
-  static RatchetSessionSetInfoRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatchetSessionSetInfoRequest>(create);
+  static RatchetSessionSetInfoRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatchetSessionSetInfoRequest>(create);
   static RatchetSessionSetInfoRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sessionID => $_getSZ(0);
   @$pb.TagNumber(1)
-  set sessionID($core.String v) { $_setString(0, v); }
+  set sessionID($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasSessionID() => $_has(0);
   @$pb.TagNumber(1)
@@ -2896,7 +3667,10 @@ class RatchetSessionSetInfoRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get userInfo => $_getSZ(1);
   @$pb.TagNumber(2)
-  set userInfo($core.String v) { $_setString(1, v); }
+  set userInfo($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasUserInfo() => $_has(1);
   @$pb.TagNumber(2)
@@ -2904,11 +3678,15 @@ class RatchetSessionSetInfoRequest extends $pb.GeneratedMessage {
 }
 
 class RatchetEncryptRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RatchetEncryptRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sessionID', protoName: 'sessionID')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RatchetEncryptRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sessionID',
+        protoName: 'sessionID')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'message')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   RatchetEncryptRequest._() : super();
   factory RatchetEncryptRequest({
@@ -2924,31 +3702,39 @@ class RatchetEncryptRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RatchetEncryptRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RatchetEncryptRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RatchetEncryptRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RatchetEncryptRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RatchetEncryptRequest clone() => RatchetEncryptRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RatchetEncryptRequest copyWith(void Function(RatchetEncryptRequest) updates) => super.copyWith((message) => updates(message as RatchetEncryptRequest)) as RatchetEncryptRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RatchetEncryptRequest copyWith(void Function(RatchetEncryptRequest) updates) =>
+      super.copyWith((message) => updates(message as RatchetEncryptRequest))
+          as RatchetEncryptRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RatchetEncryptRequest create() => RatchetEncryptRequest._();
   RatchetEncryptRequest createEmptyInstance() => create();
   static $pb.PbList<RatchetEncryptRequest> createRepeated() => $pb.PbList<RatchetEncryptRequest>();
   @$core.pragma('dart2js:noInline')
-  static RatchetEncryptRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatchetEncryptRequest>(create);
+  static RatchetEncryptRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatchetEncryptRequest>(create);
   static RatchetEncryptRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sessionID => $_getSZ(0);
   @$pb.TagNumber(1)
-  set sessionID($core.String v) { $_setString(0, v); }
+  set sessionID($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasSessionID() => $_has(0);
   @$pb.TagNumber(1)
@@ -2957,7 +3743,10 @@ class RatchetEncryptRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get message => $_getSZ(1);
   @$pb.TagNumber(2)
-  set message($core.String v) { $_setString(1, v); }
+  set message($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasMessage() => $_has(1);
   @$pb.TagNumber(2)
@@ -2965,11 +3754,16 @@ class RatchetEncryptRequest extends $pb.GeneratedMessage {
 }
 
 class RatchetDecryptRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RatchetDecryptRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sessionID', protoName: 'sessionID')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'encryptedMessage', protoName: 'encryptedMessage')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RatchetDecryptRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sessionID',
+        protoName: 'sessionID')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'encryptedMessage',
+        protoName: 'encryptedMessage')
+    ..hasRequiredFields = false;
 
   RatchetDecryptRequest._() : super();
   factory RatchetDecryptRequest({
@@ -2985,31 +3779,39 @@ class RatchetDecryptRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory RatchetDecryptRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory RatchetDecryptRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory RatchetDecryptRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory RatchetDecryptRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   RatchetDecryptRequest clone() => RatchetDecryptRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  RatchetDecryptRequest copyWith(void Function(RatchetDecryptRequest) updates) => super.copyWith((message) => updates(message as RatchetDecryptRequest)) as RatchetDecryptRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  RatchetDecryptRequest copyWith(void Function(RatchetDecryptRequest) updates) =>
+      super.copyWith((message) => updates(message as RatchetDecryptRequest))
+          as RatchetDecryptRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RatchetDecryptRequest create() => RatchetDecryptRequest._();
   RatchetDecryptRequest createEmptyInstance() => create();
   static $pb.PbList<RatchetDecryptRequest> createRepeated() => $pb.PbList<RatchetDecryptRequest>();
   @$core.pragma('dart2js:noInline')
-  static RatchetDecryptRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatchetDecryptRequest>(create);
+  static RatchetDecryptRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RatchetDecryptRequest>(create);
   static RatchetDecryptRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sessionID => $_getSZ(0);
   @$pb.TagNumber(1)
-  set sessionID($core.String v) { $_setString(0, v); }
+  set sessionID($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasSessionID() => $_has(0);
   @$pb.TagNumber(1)
@@ -3018,7 +3820,10 @@ class RatchetDecryptRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get encryptedMessage => $_getSZ(1);
   @$pb.TagNumber(2)
-  set encryptedMessage($core.String v) { $_setString(1, v); }
+  set encryptedMessage($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasEncryptedMessage() => $_has(1);
   @$pb.TagNumber(2)
@@ -3026,11 +3831,16 @@ class RatchetDecryptRequest extends $pb.GeneratedMessage {
 }
 
 class BootstrapFilesRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'BootstrapFilesRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'WorkingDir', protoName: 'WorkingDir')
-    ..pPS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'FullPaths', protoName: 'FullPaths')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'BootstrapFilesRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'WorkingDir',
+        protoName: 'WorkingDir')
+    ..pPS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'FullPaths',
+        protoName: 'FullPaths')
+    ..hasRequiredFields = false;
 
   BootstrapFilesRequest._() : super();
   factory BootstrapFilesRequest({
@@ -3046,31 +3856,39 @@ class BootstrapFilesRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory BootstrapFilesRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory BootstrapFilesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory BootstrapFilesRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory BootstrapFilesRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   BootstrapFilesRequest clone() => BootstrapFilesRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  BootstrapFilesRequest copyWith(void Function(BootstrapFilesRequest) updates) => super.copyWith((message) => updates(message as BootstrapFilesRequest)) as BootstrapFilesRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  BootstrapFilesRequest copyWith(void Function(BootstrapFilesRequest) updates) =>
+      super.copyWith((message) => updates(message as BootstrapFilesRequest))
+          as BootstrapFilesRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static BootstrapFilesRequest create() => BootstrapFilesRequest._();
   BootstrapFilesRequest createEmptyInstance() => create();
   static $pb.PbList<BootstrapFilesRequest> createRepeated() => $pb.PbList<BootstrapFilesRequest>();
   @$core.pragma('dart2js:noInline')
-  static BootstrapFilesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BootstrapFilesRequest>(create);
+  static BootstrapFilesRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BootstrapFilesRequest>(create);
   static BootstrapFilesRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get workingDir => $_getSZ(0);
   @$pb.TagNumber(1)
-  set workingDir($core.String v) { $_setString(0, v); }
+  set workingDir($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasWorkingDir() => $_has(0);
   @$pb.TagNumber(1)
@@ -3081,11 +3899,15 @@ class BootstrapFilesRequest extends $pb.GeneratedMessage {
 }
 
 class Peers extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Peers', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..aOB(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'isDefault', protoName: 'isDefault')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Peers',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..aOB(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'isDefault',
+        protoName: 'isDefault')
     ..pPS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'peer')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   Peers._() : super();
   factory Peers({
@@ -3101,18 +3923,20 @@ class Peers extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory Peers.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Peers.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory Peers.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Peers.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   Peers clone() => Peers()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Peers copyWith(void Function(Peers) updates) => super.copyWith((message) => updates(message as Peers)) as Peers; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Peers copyWith(void Function(Peers) updates) =>
+      super.copyWith((message) => updates(message as Peers)) as Peers; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Peers create() => Peers._();
@@ -3125,7 +3949,10 @@ class Peers extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.bool get isDefault => $_getBF(0);
   @$pb.TagNumber(1)
-  set isDefault($core.bool v) { $_setBool(0, v); }
+  set isDefault($core.bool v) {
+    $_setBool(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasIsDefault() => $_has(0);
   @$pb.TagNumber(1)
@@ -3136,12 +3963,16 @@ class Peers extends $pb.GeneratedMessage {
 }
 
 class TxSpentURL extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'TxSpentURL', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'TxSpentURL',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'URL', protoName: 'URL')
-    ..aOB(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'isDefault', protoName: 'isDefault')
+    ..aOB(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'isDefault',
+        protoName: 'isDefault')
     ..aOB(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'disabled')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   TxSpentURL._() : super();
   factory TxSpentURL({
@@ -3161,31 +3992,38 @@ class TxSpentURL extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory TxSpentURL.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory TxSpentURL.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory TxSpentURL.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory TxSpentURL.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   TxSpentURL clone() => TxSpentURL()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  TxSpentURL copyWith(void Function(TxSpentURL) updates) => super.copyWith((message) => updates(message as TxSpentURL)) as TxSpentURL; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  TxSpentURL copyWith(void Function(TxSpentURL) updates) =>
+      super.copyWith((message) => updates(message as TxSpentURL))
+          as TxSpentURL; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static TxSpentURL create() => TxSpentURL._();
   TxSpentURL createEmptyInstance() => create();
   static $pb.PbList<TxSpentURL> createRepeated() => $pb.PbList<TxSpentURL>();
   @$core.pragma('dart2js:noInline')
-  static TxSpentURL getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxSpentURL>(create);
+  static TxSpentURL getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TxSpentURL>(create);
   static TxSpentURL? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get uRL => $_getSZ(0);
   @$pb.TagNumber(1)
-  set uRL($core.String v) { $_setString(0, v); }
+  set uRL($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasURL() => $_has(0);
   @$pb.TagNumber(1)
@@ -3194,7 +4032,10 @@ class TxSpentURL extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get isDefault => $_getBF(1);
   @$pb.TagNumber(2)
-  set isDefault($core.bool v) { $_setBool(1, v); }
+  set isDefault($core.bool v) {
+    $_setBool(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasIsDefault() => $_has(1);
   @$pb.TagNumber(2)
@@ -3203,7 +4044,10 @@ class TxSpentURL extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get disabled => $_getBF(2);
   @$pb.TagNumber(3)
-  set disabled($core.bool v) { $_setBool(2, v); }
+  set disabled($core.bool v) {
+    $_setBool(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasDisabled() => $_has(2);
   @$pb.TagNumber(3)
@@ -3211,11 +4055,15 @@ class TxSpentURL extends $pb.GeneratedMessage {
 }
 
 class rate extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'rate', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'rate',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'coin')
-    ..a<$core.double>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'value', $pb.PbFieldType.OD)
-    ..hasRequiredFields = false
-  ;
+    ..a<$core.double>(
+        2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'value', $pb.PbFieldType.OD)
+    ..hasRequiredFields = false;
 
   rate._() : super();
   factory rate({
@@ -3231,18 +4079,19 @@ class rate extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory rate.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory rate.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory rate.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory rate.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   rate clone() => rate()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  rate copyWith(void Function(rate) updates) => super.copyWith((message) => updates(message as rate)) as rate; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  rate copyWith(void Function(rate) updates) =>
+      super.copyWith((message) => updates(message as rate)) as rate; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static rate create() => rate._();
@@ -3255,7 +4104,10 @@ class rate extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get coin => $_getSZ(0);
   @$pb.TagNumber(1)
-  set coin($core.String v) { $_setString(0, v); }
+  set coin($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasCoin() => $_has(0);
   @$pb.TagNumber(1)
@@ -3264,7 +4116,10 @@ class rate extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.double get value => $_getN(1);
   @$pb.TagNumber(2)
-  set value($core.double v) { $_setDouble(1, v); }
+  set value($core.double v) {
+    $_setDouble(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasValue() => $_has(1);
   @$pb.TagNumber(2)
@@ -3272,10 +4127,15 @@ class rate extends $pb.GeneratedMessage {
 }
 
 class Rates extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Rates', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..pc<rate>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'rates', $pb.PbFieldType.PM, subBuilder: rate.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Rates',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..pc<rate>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'rates', $pb.PbFieldType.PM,
+        subBuilder: rate.create)
+    ..hasRequiredFields = false;
 
   Rates._() : super();
   factory Rates({
@@ -3287,18 +4147,20 @@ class Rates extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory Rates.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Rates.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory Rates.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Rates.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   Rates clone() => Rates()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Rates copyWith(void Function(Rates) updates) => super.copyWith((message) => updates(message as Rates)) as Rates; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Rates copyWith(void Function(Rates) updates) =>
+      super.copyWith((message) => updates(message as Rates)) as Rates; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Rates create() => Rates._();
@@ -3313,26 +4175,37 @@ class Rates extends $pb.GeneratedMessage {
 }
 
 class LSPInformation extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LSPInformation', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LSPInformation',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'id')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name')
     ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'widgetUrl')
     ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pubkey')
     ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'host')
     ..aInt64(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'channelCapacity')
-    ..a<$core.int>(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'targetConf', $pb.PbFieldType.O3)
+    ..a<$core.int>(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'targetConf',
+        $pb.PbFieldType.O3)
     ..aInt64(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'baseFeeMsat')
-    ..a<$core.double>(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'feeRate', $pb.PbFieldType.OD)
-    ..a<$core.int>(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'timeLockDelta', $pb.PbFieldType.OU3)
+    ..a<$core.double>(
+        9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'feeRate', $pb.PbFieldType.OD)
+    ..a<$core.int>(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'timeLockDelta',
+        $pb.PbFieldType.OU3)
     ..aInt64(11, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'minHtlcMsat')
     ..aInt64(12, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'channelFeePermyriad')
-    ..a<$core.List<$core.int>>(13, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lspPubkey', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(13,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lspPubkey', $pb.PbFieldType.OY)
     ..aInt64(14, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxInactiveDuration')
     ..aInt64(15, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'channelMinimumFeeMsat')
-    ..aOM<OpeningFeeParams>(16, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'cheapestOpeningFeeParams', subBuilder: OpeningFeeParams.create)
-    ..aOM<OpeningFeeParams>(17, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'longestValidOpeningFeeParams', subBuilder: OpeningFeeParams.create)
-    ..hasRequiredFields = false
-  ;
+    ..aOM<OpeningFeeParams>(
+        16, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'cheapestOpeningFeeParams',
+        subBuilder: OpeningFeeParams.create)
+    ..aOM<OpeningFeeParams>(17,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'longestValidOpeningFeeParams',
+        subBuilder: OpeningFeeParams.create)
+    ..hasRequiredFields = false;
 
   LSPInformation._() : super();
   factory LSPInformation({
@@ -3347,13 +4220,10 @@ class LSPInformation extends $pb.GeneratedMessage {
     $core.double? feeRate,
     $core.int? timeLockDelta,
     $fixnum.Int64? minHtlcMsat,
-  @$core.Deprecated('This field is deprecated.')
-    $fixnum.Int64? channelFeePermyriad,
+    @$core.Deprecated('This field is deprecated.') $fixnum.Int64? channelFeePermyriad,
     $core.List<$core.int>? lspPubkey,
-  @$core.Deprecated('This field is deprecated.')
-    $fixnum.Int64? maxInactiveDuration,
-  @$core.Deprecated('This field is deprecated.')
-    $fixnum.Int64? channelMinimumFeeMsat,
+    @$core.Deprecated('This field is deprecated.') $fixnum.Int64? maxInactiveDuration,
+    @$core.Deprecated('This field is deprecated.') $fixnum.Int64? channelMinimumFeeMsat,
     OpeningFeeParams? cheapestOpeningFeeParams,
     OpeningFeeParams? longestValidOpeningFeeParams,
   }) {
@@ -3414,31 +4284,38 @@ class LSPInformation extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory LSPInformation.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory LSPInformation.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory LSPInformation.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LSPInformation.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   LSPInformation clone() => LSPInformation()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  LSPInformation copyWith(void Function(LSPInformation) updates) => super.copyWith((message) => updates(message as LSPInformation)) as LSPInformation; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  LSPInformation copyWith(void Function(LSPInformation) updates) =>
+      super.copyWith((message) => updates(message as LSPInformation))
+          as LSPInformation; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LSPInformation create() => LSPInformation._();
   LSPInformation createEmptyInstance() => create();
   static $pb.PbList<LSPInformation> createRepeated() => $pb.PbList<LSPInformation>();
   @$core.pragma('dart2js:noInline')
-  static LSPInformation getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LSPInformation>(create);
+  static LSPInformation getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LSPInformation>(create);
   static LSPInformation? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) { $_setString(0, v); }
+  set id($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
@@ -3447,7 +4324,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get name => $_getSZ(1);
   @$pb.TagNumber(2)
-  set name($core.String v) { $_setString(1, v); }
+  set name($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasName() => $_has(1);
   @$pb.TagNumber(2)
@@ -3456,7 +4336,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get widgetUrl => $_getSZ(2);
   @$pb.TagNumber(3)
-  set widgetUrl($core.String v) { $_setString(2, v); }
+  set widgetUrl($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasWidgetUrl() => $_has(2);
   @$pb.TagNumber(3)
@@ -3465,7 +4348,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get pubkey => $_getSZ(3);
   @$pb.TagNumber(4)
-  set pubkey($core.String v) { $_setString(3, v); }
+  set pubkey($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasPubkey() => $_has(3);
   @$pb.TagNumber(4)
@@ -3474,7 +4360,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get host => $_getSZ(4);
   @$pb.TagNumber(5)
-  set host($core.String v) { $_setString(4, v); }
+  set host($core.String v) {
+    $_setString(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasHost() => $_has(4);
   @$pb.TagNumber(5)
@@ -3483,7 +4372,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get channelCapacity => $_getI64(5);
   @$pb.TagNumber(6)
-  set channelCapacity($fixnum.Int64 v) { $_setInt64(5, v); }
+  set channelCapacity($fixnum.Int64 v) {
+    $_setInt64(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasChannelCapacity() => $_has(5);
   @$pb.TagNumber(6)
@@ -3492,7 +4384,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.int get targetConf => $_getIZ(6);
   @$pb.TagNumber(7)
-  set targetConf($core.int v) { $_setSignedInt32(6, v); }
+  set targetConf($core.int v) {
+    $_setSignedInt32(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasTargetConf() => $_has(6);
   @$pb.TagNumber(7)
@@ -3501,7 +4396,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $fixnum.Int64 get baseFeeMsat => $_getI64(7);
   @$pb.TagNumber(8)
-  set baseFeeMsat($fixnum.Int64 v) { $_setInt64(7, v); }
+  set baseFeeMsat($fixnum.Int64 v) {
+    $_setInt64(7, v);
+  }
+
   @$pb.TagNumber(8)
   $core.bool hasBaseFeeMsat() => $_has(7);
   @$pb.TagNumber(8)
@@ -3510,7 +4408,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.double get feeRate => $_getN(8);
   @$pb.TagNumber(9)
-  set feeRate($core.double v) { $_setDouble(8, v); }
+  set feeRate($core.double v) {
+    $_setDouble(8, v);
+  }
+
   @$pb.TagNumber(9)
   $core.bool hasFeeRate() => $_has(8);
   @$pb.TagNumber(9)
@@ -3519,7 +4420,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $core.int get timeLockDelta => $_getIZ(9);
   @$pb.TagNumber(10)
-  set timeLockDelta($core.int v) { $_setUnsignedInt32(9, v); }
+  set timeLockDelta($core.int v) {
+    $_setUnsignedInt32(9, v);
+  }
+
   @$pb.TagNumber(10)
   $core.bool hasTimeLockDelta() => $_has(9);
   @$pb.TagNumber(10)
@@ -3528,7 +4432,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $fixnum.Int64 get minHtlcMsat => $_getI64(10);
   @$pb.TagNumber(11)
-  set minHtlcMsat($fixnum.Int64 v) { $_setInt64(10, v); }
+  set minHtlcMsat($fixnum.Int64 v) {
+    $_setInt64(10, v);
+  }
+
   @$pb.TagNumber(11)
   $core.bool hasMinHtlcMsat() => $_has(10);
   @$pb.TagNumber(11)
@@ -3539,7 +4446,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   $fixnum.Int64 get channelFeePermyriad => $_getI64(11);
   @$core.Deprecated('This field is deprecated.')
   @$pb.TagNumber(12)
-  set channelFeePermyriad($fixnum.Int64 v) { $_setInt64(11, v); }
+  set channelFeePermyriad($fixnum.Int64 v) {
+    $_setInt64(11, v);
+  }
+
   @$core.Deprecated('This field is deprecated.')
   @$pb.TagNumber(12)
   $core.bool hasChannelFeePermyriad() => $_has(11);
@@ -3550,7 +4460,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(13)
   $core.List<$core.int> get lspPubkey => $_getN(12);
   @$pb.TagNumber(13)
-  set lspPubkey($core.List<$core.int> v) { $_setBytes(12, v); }
+  set lspPubkey($core.List<$core.int> v) {
+    $_setBytes(12, v);
+  }
+
   @$pb.TagNumber(13)
   $core.bool hasLspPubkey() => $_has(12);
   @$pb.TagNumber(13)
@@ -3561,7 +4474,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   $fixnum.Int64 get maxInactiveDuration => $_getI64(13);
   @$core.Deprecated('This field is deprecated.')
   @$pb.TagNumber(14)
-  set maxInactiveDuration($fixnum.Int64 v) { $_setInt64(13, v); }
+  set maxInactiveDuration($fixnum.Int64 v) {
+    $_setInt64(13, v);
+  }
+
   @$core.Deprecated('This field is deprecated.')
   @$pb.TagNumber(14)
   $core.bool hasMaxInactiveDuration() => $_has(13);
@@ -3574,7 +4490,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   $fixnum.Int64 get channelMinimumFeeMsat => $_getI64(14);
   @$core.Deprecated('This field is deprecated.')
   @$pb.TagNumber(15)
-  set channelMinimumFeeMsat($fixnum.Int64 v) { $_setInt64(14, v); }
+  set channelMinimumFeeMsat($fixnum.Int64 v) {
+    $_setInt64(14, v);
+  }
+
   @$core.Deprecated('This field is deprecated.')
   @$pb.TagNumber(15)
   $core.bool hasChannelMinimumFeeMsat() => $_has(14);
@@ -3585,7 +4504,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(16)
   OpeningFeeParams get cheapestOpeningFeeParams => $_getN(15);
   @$pb.TagNumber(16)
-  set cheapestOpeningFeeParams(OpeningFeeParams v) { setField(16, v); }
+  set cheapestOpeningFeeParams(OpeningFeeParams v) {
+    setField(16, v);
+  }
+
   @$pb.TagNumber(16)
   $core.bool hasCheapestOpeningFeeParams() => $_has(15);
   @$pb.TagNumber(16)
@@ -3596,7 +4518,10 @@ class LSPInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(17)
   OpeningFeeParams get longestValidOpeningFeeParams => $_getN(16);
   @$pb.TagNumber(17)
-  set longestValidOpeningFeeParams(OpeningFeeParams v) { setField(17, v); }
+  set longestValidOpeningFeeParams(OpeningFeeParams v) {
+    setField(17, v);
+  }
+
   @$pb.TagNumber(17)
   $core.bool hasLongestValidOpeningFeeParams() => $_has(16);
   @$pb.TagNumber(17)
@@ -3606,15 +4531,25 @@ class LSPInformation extends $pb.GeneratedMessage {
 }
 
 class OpeningFeeParams extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'OpeningFeeParams', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..a<$fixnum.Int64>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'minMsat', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
-    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'proportional', $pb.PbFieldType.OU3)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'OpeningFeeParams',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'minMsat',
+        $pb.PbFieldType.OU6,
+        defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'proportional',
+        $pb.PbFieldType.OU3)
     ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'validUntil')
-    ..a<$core.int>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxIdleTime', $pb.PbFieldType.OU3)
-    ..a<$core.int>(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxClientToSelfDelay', $pb.PbFieldType.OU3)
+    ..a<$core.int>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxIdleTime',
+        $pb.PbFieldType.OU3)
+    ..a<$core.int>(
+        5,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxClientToSelfDelay',
+        $pb.PbFieldType.OU3)
     ..aOS(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'promise')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   OpeningFeeParams._() : super();
   factory OpeningFeeParams({
@@ -3646,31 +4581,39 @@ class OpeningFeeParams extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory OpeningFeeParams.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory OpeningFeeParams.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory OpeningFeeParams.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory OpeningFeeParams.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   OpeningFeeParams clone() => OpeningFeeParams()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  OpeningFeeParams copyWith(void Function(OpeningFeeParams) updates) => super.copyWith((message) => updates(message as OpeningFeeParams)) as OpeningFeeParams; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  OpeningFeeParams copyWith(void Function(OpeningFeeParams) updates) =>
+      super.copyWith((message) => updates(message as OpeningFeeParams))
+          as OpeningFeeParams; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static OpeningFeeParams create() => OpeningFeeParams._();
   OpeningFeeParams createEmptyInstance() => create();
   static $pb.PbList<OpeningFeeParams> createRepeated() => $pb.PbList<OpeningFeeParams>();
   @$core.pragma('dart2js:noInline')
-  static OpeningFeeParams getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OpeningFeeParams>(create);
+  static OpeningFeeParams getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<OpeningFeeParams>(create);
   static OpeningFeeParams? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get minMsat => $_getI64(0);
   @$pb.TagNumber(1)
-  set minMsat($fixnum.Int64 v) { $_setInt64(0, v); }
+  set minMsat($fixnum.Int64 v) {
+    $_setInt64(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasMinMsat() => $_has(0);
   @$pb.TagNumber(1)
@@ -3679,7 +4622,10 @@ class OpeningFeeParams extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get proportional => $_getIZ(1);
   @$pb.TagNumber(2)
-  set proportional($core.int v) { $_setUnsignedInt32(1, v); }
+  set proportional($core.int v) {
+    $_setUnsignedInt32(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasProportional() => $_has(1);
   @$pb.TagNumber(2)
@@ -3688,7 +4634,10 @@ class OpeningFeeParams extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get validUntil => $_getSZ(2);
   @$pb.TagNumber(3)
-  set validUntil($core.String v) { $_setString(2, v); }
+  set validUntil($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasValidUntil() => $_has(2);
   @$pb.TagNumber(3)
@@ -3697,7 +4646,10 @@ class OpeningFeeParams extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.int get maxIdleTime => $_getIZ(3);
   @$pb.TagNumber(4)
-  set maxIdleTime($core.int v) { $_setUnsignedInt32(3, v); }
+  set maxIdleTime($core.int v) {
+    $_setUnsignedInt32(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasMaxIdleTime() => $_has(3);
   @$pb.TagNumber(4)
@@ -3706,7 +4658,10 @@ class OpeningFeeParams extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.int get maxClientToSelfDelay => $_getIZ(4);
   @$pb.TagNumber(5)
-  set maxClientToSelfDelay($core.int v) { $_setUnsignedInt32(4, v); }
+  set maxClientToSelfDelay($core.int v) {
+    $_setUnsignedInt32(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasMaxClientToSelfDelay() => $_has(4);
   @$pb.TagNumber(5)
@@ -3715,7 +4670,10 @@ class OpeningFeeParams extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.String get promise => $_getSZ(5);
   @$pb.TagNumber(6)
-  set promise($core.String v) { $_setString(5, v); }
+  set promise($core.String v) {
+    $_setString(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasPromise() => $_has(5);
   @$pb.TagNumber(6)
@@ -3723,39 +4681,55 @@ class OpeningFeeParams extends $pb.GeneratedMessage {
 }
 
 class LSPListRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LSPListRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LSPListRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   LSPListRequest._() : super();
   factory LSPListRequest() => create();
-  factory LSPListRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory LSPListRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory LSPListRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LSPListRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   LSPListRequest clone() => LSPListRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  LSPListRequest copyWith(void Function(LSPListRequest) updates) => super.copyWith((message) => updates(message as LSPListRequest)) as LSPListRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  LSPListRequest copyWith(void Function(LSPListRequest) updates) =>
+      super.copyWith((message) => updates(message as LSPListRequest))
+          as LSPListRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LSPListRequest create() => LSPListRequest._();
   LSPListRequest createEmptyInstance() => create();
   static $pb.PbList<LSPListRequest> createRepeated() => $pb.PbList<LSPListRequest>();
   @$core.pragma('dart2js:noInline')
-  static LSPListRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LSPListRequest>(create);
+  static LSPListRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LSPListRequest>(create);
   static LSPListRequest? _defaultInstance;
 }
 
 class LSPList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LSPList', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..m<$core.String, LSPInformation>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lsps', entryClassName: 'LSPList.LspsEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OM, valueCreator: LSPInformation.create, packageName: const $pb.PackageName('data'))
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LSPList',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..m<$core.String, LSPInformation>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lsps',
+        entryClassName: 'LSPList.LspsEntry',
+        keyFieldType: $pb.PbFieldType.OS,
+        valueFieldType: $pb.PbFieldType.OM,
+        valueCreator: LSPInformation.create,
+        packageName: const $pb.PackageName('data'))
+    ..hasRequiredFields = false;
 
   LSPList._() : super();
   factory LSPList({
@@ -3767,18 +4741,20 @@ class LSPList extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory LSPList.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory LSPList.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory LSPList.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LSPList.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   LSPList clone() => LSPList()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  LSPList copyWith(void Function(LSPList) updates) => super.copyWith((message) => updates(message as LSPList)) as LSPList; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  LSPList copyWith(void Function(LSPList) updates) =>
+      super.copyWith((message) => updates(message as LSPList)) as LSPList; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LSPList create() => LSPList._();
@@ -3793,10 +4769,18 @@ class LSPList extends $pb.GeneratedMessage {
 }
 
 class LSPActivity extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LSPActivity', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..m<$core.String, $fixnum.Int64>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'activity', entryClassName: 'LSPActivity.ActivityEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.O6, packageName: const $pb.PackageName('data'))
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LSPActivity',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..m<$core.String, $fixnum.Int64>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'activity',
+        entryClassName: 'LSPActivity.ActivityEntry',
+        keyFieldType: $pb.PbFieldType.OS,
+        valueFieldType: $pb.PbFieldType.O6,
+        packageName: const $pb.PackageName('data'))
+    ..hasRequiredFields = false;
 
   LSPActivity._() : super();
   factory LSPActivity({
@@ -3808,25 +4792,29 @@ class LSPActivity extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory LSPActivity.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory LSPActivity.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory LSPActivity.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LSPActivity.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   LSPActivity clone() => LSPActivity()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  LSPActivity copyWith(void Function(LSPActivity) updates) => super.copyWith((message) => updates(message as LSPActivity)) as LSPActivity; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  LSPActivity copyWith(void Function(LSPActivity) updates) =>
+      super.copyWith((message) => updates(message as LSPActivity))
+          as LSPActivity; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LSPActivity create() => LSPActivity._();
   LSPActivity createEmptyInstance() => create();
   static $pb.PbList<LSPActivity> createRepeated() => $pb.PbList<LSPActivity>();
   @$core.pragma('dart2js:noInline')
-  static LSPActivity getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LSPActivity>(create);
+  static LSPActivity getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LSPActivity>(create);
   static LSPActivity? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -3834,10 +4822,13 @@ class LSPActivity extends $pb.GeneratedMessage {
 }
 
 class ConnectLSPRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ConnectLSPRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ConnectLSPRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lspId')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   ConnectLSPRequest._() : super();
   factory ConnectLSPRequest({
@@ -3849,31 +4840,39 @@ class ConnectLSPRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ConnectLSPRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ConnectLSPRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ConnectLSPRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ConnectLSPRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ConnectLSPRequest clone() => ConnectLSPRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ConnectLSPRequest copyWith(void Function(ConnectLSPRequest) updates) => super.copyWith((message) => updates(message as ConnectLSPRequest)) as ConnectLSPRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ConnectLSPRequest copyWith(void Function(ConnectLSPRequest) updates) =>
+      super.copyWith((message) => updates(message as ConnectLSPRequest))
+          as ConnectLSPRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ConnectLSPRequest create() => ConnectLSPRequest._();
   ConnectLSPRequest createEmptyInstance() => create();
   static $pb.PbList<ConnectLSPRequest> createRepeated() => $pb.PbList<ConnectLSPRequest>();
   @$core.pragma('dart2js:noInline')
-  static ConnectLSPRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectLSPRequest>(create);
+  static ConnectLSPRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectLSPRequest>(create);
   static ConnectLSPRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get lspId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set lspId($core.String v) { $_setString(0, v); }
+  set lspId($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasLspId() => $_has(0);
   @$pb.TagNumber(1)
@@ -3881,58 +4880,67 @@ class ConnectLSPRequest extends $pb.GeneratedMessage {
 }
 
 class ConnectLSPReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ConnectLSPReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ConnectLSPReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   ConnectLSPReply._() : super();
   factory ConnectLSPReply() => create();
-  factory ConnectLSPReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ConnectLSPReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ConnectLSPReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ConnectLSPReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ConnectLSPReply clone() => ConnectLSPReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ConnectLSPReply copyWith(void Function(ConnectLSPReply) updates) => super.copyWith((message) => updates(message as ConnectLSPReply)) as ConnectLSPReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ConnectLSPReply copyWith(void Function(ConnectLSPReply) updates) =>
+      super.copyWith((message) => updates(message as ConnectLSPReply))
+          as ConnectLSPReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ConnectLSPReply create() => ConnectLSPReply._();
   ConnectLSPReply createEmptyInstance() => create();
   static $pb.PbList<ConnectLSPReply> createRepeated() => $pb.PbList<ConnectLSPReply>();
   @$core.pragma('dart2js:noInline')
-  static ConnectLSPReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectLSPReply>(create);
+  static ConnectLSPReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectLSPReply>(create);
   static ConnectLSPReply? _defaultInstance;
 }
 
-enum LNUrlResponse_Action {
-  withdraw, 
-  channel, 
-  auth, 
-  payResponse1, 
-  notSet
-}
+enum LNUrlResponse_Action { withdraw, channel, auth, payResponse1, notSet }
 
 class LNUrlResponse extends $pb.GeneratedMessage {
   static const $core.Map<$core.int, LNUrlResponse_Action> _LNUrlResponse_ActionByTag = {
-    1 : LNUrlResponse_Action.withdraw,
-    2 : LNUrlResponse_Action.channel,
-    3 : LNUrlResponse_Action.auth,
-    4 : LNUrlResponse_Action.payResponse1,
-    0 : LNUrlResponse_Action.notSet
+    1: LNUrlResponse_Action.withdraw,
+    2: LNUrlResponse_Action.channel,
+    3: LNUrlResponse_Action.auth,
+    4: LNUrlResponse_Action.payResponse1,
+    0: LNUrlResponse_Action.notSet
   };
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNUrlResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNUrlResponse',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..oo(0, [1, 2, 3, 4])
-    ..aOM<LNUrlWithdraw>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'withdraw', subBuilder: LNUrlWithdraw.create)
-    ..aOM<LNURLChannel>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'channel', subBuilder: LNURLChannel.create)
-    ..aOM<LNURLAuth>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'auth', subBuilder: LNURLAuth.create)
-    ..aOM<LNURLPayResponse1>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'payResponse1', protoName: 'payResponse1', subBuilder: LNURLPayResponse1.create)
-    ..hasRequiredFields = false
-  ;
+    ..aOM<LNUrlWithdraw>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'withdraw',
+        subBuilder: LNUrlWithdraw.create)
+    ..aOM<LNURLChannel>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'channel',
+        subBuilder: LNURLChannel.create)
+    ..aOM<LNURLAuth>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'auth',
+        subBuilder: LNURLAuth.create)
+    ..aOM<LNURLPayResponse1>(
+        4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'payResponse1',
+        protoName: 'payResponse1', subBuilder: LNURLPayResponse1.create)
+    ..hasRequiredFields = false;
 
   LNUrlResponse._() : super();
   factory LNUrlResponse({
@@ -3956,25 +4964,29 @@ class LNUrlResponse extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory LNUrlResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory LNUrlResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory LNUrlResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LNUrlResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   LNUrlResponse clone() => LNUrlResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  LNUrlResponse copyWith(void Function(LNUrlResponse) updates) => super.copyWith((message) => updates(message as LNUrlResponse)) as LNUrlResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  LNUrlResponse copyWith(void Function(LNUrlResponse) updates) =>
+      super.copyWith((message) => updates(message as LNUrlResponse))
+          as LNUrlResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LNUrlResponse create() => LNUrlResponse._();
   LNUrlResponse createEmptyInstance() => create();
   static $pb.PbList<LNUrlResponse> createRepeated() => $pb.PbList<LNUrlResponse>();
   @$core.pragma('dart2js:noInline')
-  static LNUrlResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNUrlResponse>(create);
+  static LNUrlResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNUrlResponse>(create);
   static LNUrlResponse? _defaultInstance;
 
   LNUrlResponse_Action whichAction() => _LNUrlResponse_ActionByTag[$_whichOneof(0)]!;
@@ -3983,7 +4995,10 @@ class LNUrlResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   LNUrlWithdraw get withdraw => $_getN(0);
   @$pb.TagNumber(1)
-  set withdraw(LNUrlWithdraw v) { setField(1, v); }
+  set withdraw(LNUrlWithdraw v) {
+    setField(1, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasWithdraw() => $_has(0);
   @$pb.TagNumber(1)
@@ -3994,7 +5009,10 @@ class LNUrlResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   LNURLChannel get channel => $_getN(1);
   @$pb.TagNumber(2)
-  set channel(LNURLChannel v) { setField(2, v); }
+  set channel(LNURLChannel v) {
+    setField(2, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasChannel() => $_has(1);
   @$pb.TagNumber(2)
@@ -4005,7 +5023,10 @@ class LNUrlResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   LNURLAuth get auth => $_getN(2);
   @$pb.TagNumber(3)
-  set auth(LNURLAuth v) { setField(3, v); }
+  set auth(LNURLAuth v) {
+    setField(3, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasAuth() => $_has(2);
   @$pb.TagNumber(3)
@@ -4016,7 +5037,10 @@ class LNUrlResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   LNURLPayResponse1 get payResponse1 => $_getN(3);
   @$pb.TagNumber(4)
-  set payResponse1(LNURLPayResponse1 v) { setField(4, v); }
+  set payResponse1(LNURLPayResponse1 v) {
+    setField(4, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasPayResponse1() => $_has(3);
   @$pb.TagNumber(4)
@@ -4026,12 +5050,15 @@ class LNUrlResponse extends $pb.GeneratedMessage {
 }
 
 class LNUrlWithdraw extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNUrlWithdraw', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNUrlWithdraw',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aInt64(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'minAmount')
     ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxAmount')
     ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'defaultDescription')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   LNUrlWithdraw._() : super();
   factory LNUrlWithdraw({
@@ -4051,31 +5078,38 @@ class LNUrlWithdraw extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory LNUrlWithdraw.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory LNUrlWithdraw.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory LNUrlWithdraw.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LNUrlWithdraw.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   LNUrlWithdraw clone() => LNUrlWithdraw()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  LNUrlWithdraw copyWith(void Function(LNUrlWithdraw) updates) => super.copyWith((message) => updates(message as LNUrlWithdraw)) as LNUrlWithdraw; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  LNUrlWithdraw copyWith(void Function(LNUrlWithdraw) updates) =>
+      super.copyWith((message) => updates(message as LNUrlWithdraw))
+          as LNUrlWithdraw; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LNUrlWithdraw create() => LNUrlWithdraw._();
   LNUrlWithdraw createEmptyInstance() => create();
   static $pb.PbList<LNUrlWithdraw> createRepeated() => $pb.PbList<LNUrlWithdraw>();
   @$core.pragma('dart2js:noInline')
-  static LNUrlWithdraw getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNUrlWithdraw>(create);
+  static LNUrlWithdraw getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNUrlWithdraw>(create);
   static LNUrlWithdraw? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get minAmount => $_getI64(0);
   @$pb.TagNumber(1)
-  set minAmount($fixnum.Int64 v) { $_setInt64(0, v); }
+  set minAmount($fixnum.Int64 v) {
+    $_setInt64(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasMinAmount() => $_has(0);
   @$pb.TagNumber(1)
@@ -4084,7 +5118,10 @@ class LNUrlWithdraw extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get maxAmount => $_getI64(1);
   @$pb.TagNumber(2)
-  set maxAmount($fixnum.Int64 v) { $_setInt64(1, v); }
+  set maxAmount($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasMaxAmount() => $_has(1);
   @$pb.TagNumber(2)
@@ -4093,7 +5130,10 @@ class LNUrlWithdraw extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get defaultDescription => $_getSZ(2);
   @$pb.TagNumber(3)
-  set defaultDescription($core.String v) { $_setString(2, v); }
+  set defaultDescription($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasDefaultDescription() => $_has(2);
   @$pb.TagNumber(3)
@@ -4101,12 +5141,15 @@ class LNUrlWithdraw extends $pb.GeneratedMessage {
 }
 
 class LNURLChannel extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNURLChannel', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNURLChannel',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'k1')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'callback')
     ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'uri')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   LNURLChannel._() : super();
   factory LNURLChannel({
@@ -4126,31 +5169,38 @@ class LNURLChannel extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory LNURLChannel.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory LNURLChannel.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory LNURLChannel.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LNURLChannel.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   LNURLChannel clone() => LNURLChannel()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  LNURLChannel copyWith(void Function(LNURLChannel) updates) => super.copyWith((message) => updates(message as LNURLChannel)) as LNURLChannel; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  LNURLChannel copyWith(void Function(LNURLChannel) updates) =>
+      super.copyWith((message) => updates(message as LNURLChannel))
+          as LNURLChannel; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LNURLChannel create() => LNURLChannel._();
   LNURLChannel createEmptyInstance() => create();
   static $pb.PbList<LNURLChannel> createRepeated() => $pb.PbList<LNURLChannel>();
   @$core.pragma('dart2js:noInline')
-  static LNURLChannel getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNURLChannel>(create);
+  static LNURLChannel getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNURLChannel>(create);
   static LNURLChannel? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get k1 => $_getSZ(0);
   @$pb.TagNumber(1)
-  set k1($core.String v) { $_setString(0, v); }
+  set k1($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasK1() => $_has(0);
   @$pb.TagNumber(1)
@@ -4159,7 +5209,10 @@ class LNURLChannel extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get callback => $_getSZ(1);
   @$pb.TagNumber(2)
-  set callback($core.String v) { $_setString(1, v); }
+  set callback($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasCallback() => $_has(1);
   @$pb.TagNumber(2)
@@ -4168,7 +5221,10 @@ class LNURLChannel extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get uri => $_getSZ(2);
   @$pb.TagNumber(3)
-  set uri($core.String v) { $_setString(2, v); }
+  set uri($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasUri() => $_has(2);
   @$pb.TagNumber(3)
@@ -4176,14 +5232,17 @@ class LNURLChannel extends $pb.GeneratedMessage {
 }
 
 class LNURLAuth extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNURLAuth', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNURLAuth',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'tag')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'k1')
     ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'callback')
     ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'host')
     ..aOB(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'jwt')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   LNURLAuth._() : super();
   factory LNURLAuth({
@@ -4211,18 +5270,21 @@ class LNURLAuth extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory LNURLAuth.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory LNURLAuth.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory LNURLAuth.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LNURLAuth.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   LNURLAuth clone() => LNURLAuth()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  LNURLAuth copyWith(void Function(LNURLAuth) updates) => super.copyWith((message) => updates(message as LNURLAuth)) as LNURLAuth; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  LNURLAuth copyWith(void Function(LNURLAuth) updates) =>
+      super.copyWith((message) => updates(message as LNURLAuth))
+          as LNURLAuth; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LNURLAuth create() => LNURLAuth._();
@@ -4235,7 +5297,10 @@ class LNURLAuth extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get tag => $_getSZ(0);
   @$pb.TagNumber(1)
-  set tag($core.String v) { $_setString(0, v); }
+  set tag($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasTag() => $_has(0);
   @$pb.TagNumber(1)
@@ -4244,7 +5309,10 @@ class LNURLAuth extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get k1 => $_getSZ(1);
   @$pb.TagNumber(2)
-  set k1($core.String v) { $_setString(1, v); }
+  set k1($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasK1() => $_has(1);
   @$pb.TagNumber(2)
@@ -4253,7 +5321,10 @@ class LNURLAuth extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get callback => $_getSZ(2);
   @$pb.TagNumber(3)
-  set callback($core.String v) { $_setString(2, v); }
+  set callback($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasCallback() => $_has(2);
   @$pb.TagNumber(3)
@@ -4262,7 +5333,10 @@ class LNURLAuth extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get host => $_getSZ(3);
   @$pb.TagNumber(4)
-  set host($core.String v) { $_setString(3, v); }
+  set host($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasHost() => $_has(3);
   @$pb.TagNumber(4)
@@ -4271,7 +5345,10 @@ class LNURLAuth extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.bool get jwt => $_getBF(4);
   @$pb.TagNumber(5)
-  set jwt($core.bool v) { $_setBool(4, v); }
+  set jwt($core.bool v) {
+    $_setBool(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasJwt() => $_has(4);
   @$pb.TagNumber(5)
@@ -4279,12 +5356,16 @@ class LNURLAuth extends $pb.GeneratedMessage {
 }
 
 class LNUrlPayImage extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNUrlPayImage', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNUrlPayImage',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'dataUri')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'ext')
-    ..a<$core.List<$core.int>>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'bytes', $pb.PbFieldType.OY)
-    ..hasRequiredFields = false
-  ;
+    ..a<$core.List<$core.int>>(
+        3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'bytes', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
 
   LNUrlPayImage._() : super();
   factory LNUrlPayImage({
@@ -4304,31 +5385,38 @@ class LNUrlPayImage extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory LNUrlPayImage.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory LNUrlPayImage.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory LNUrlPayImage.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LNUrlPayImage.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   LNUrlPayImage clone() => LNUrlPayImage()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  LNUrlPayImage copyWith(void Function(LNUrlPayImage) updates) => super.copyWith((message) => updates(message as LNUrlPayImage)) as LNUrlPayImage; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  LNUrlPayImage copyWith(void Function(LNUrlPayImage) updates) =>
+      super.copyWith((message) => updates(message as LNUrlPayImage))
+          as LNUrlPayImage; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LNUrlPayImage create() => LNUrlPayImage._();
   LNUrlPayImage createEmptyInstance() => create();
   static $pb.PbList<LNUrlPayImage> createRepeated() => $pb.PbList<LNUrlPayImage>();
   @$core.pragma('dart2js:noInline')
-  static LNUrlPayImage getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNUrlPayImage>(create);
+  static LNUrlPayImage getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNUrlPayImage>(create);
   static LNUrlPayImage? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get dataUri => $_getSZ(0);
   @$pb.TagNumber(1)
-  set dataUri($core.String v) { $_setString(0, v); }
+  set dataUri($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasDataUri() => $_has(0);
   @$pb.TagNumber(1)
@@ -4337,7 +5425,10 @@ class LNUrlPayImage extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get ext => $_getSZ(1);
   @$pb.TagNumber(2)
-  set ext($core.String v) { $_setString(1, v); }
+  set ext($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasExt() => $_has(1);
   @$pb.TagNumber(2)
@@ -4346,7 +5437,10 @@ class LNUrlPayImage extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.List<$core.int> get bytes => $_getN(2);
   @$pb.TagNumber(3)
-  set bytes($core.List<$core.int> v) { $_setBytes(2, v); }
+  set bytes($core.List<$core.int> v) {
+    $_setBytes(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasBytes() => $_has(2);
   @$pb.TagNumber(3)
@@ -4354,13 +5448,17 @@ class LNUrlPayImage extends $pb.GeneratedMessage {
 }
 
 class LNUrlPayMetadata extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNUrlPayMetadata', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNUrlPayMetadata',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..pPS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'entry')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'description')
     ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'longDescription')
-    ..aOM<LNUrlPayImage>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'image', subBuilder: LNUrlPayImage.create)
-    ..hasRequiredFields = false
-  ;
+    ..aOM<LNUrlPayImage>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'image',
+        subBuilder: LNUrlPayImage.create)
+    ..hasRequiredFields = false;
 
   LNUrlPayMetadata._() : super();
   factory LNUrlPayMetadata({
@@ -4384,25 +5482,30 @@ class LNUrlPayMetadata extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory LNUrlPayMetadata.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory LNUrlPayMetadata.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory LNUrlPayMetadata.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LNUrlPayMetadata.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   LNUrlPayMetadata clone() => LNUrlPayMetadata()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  LNUrlPayMetadata copyWith(void Function(LNUrlPayMetadata) updates) => super.copyWith((message) => updates(message as LNUrlPayMetadata)) as LNUrlPayMetadata; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  LNUrlPayMetadata copyWith(void Function(LNUrlPayMetadata) updates) =>
+      super.copyWith((message) => updates(message as LNUrlPayMetadata))
+          as LNUrlPayMetadata; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LNUrlPayMetadata create() => LNUrlPayMetadata._();
   LNUrlPayMetadata createEmptyInstance() => create();
   static $pb.PbList<LNUrlPayMetadata> createRepeated() => $pb.PbList<LNUrlPayMetadata>();
   @$core.pragma('dart2js:noInline')
-  static LNUrlPayMetadata getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNUrlPayMetadata>(create);
+  static LNUrlPayMetadata getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNUrlPayMetadata>(create);
   static LNUrlPayMetadata? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -4411,7 +5514,10 @@ class LNUrlPayMetadata extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get description => $_getSZ(1);
   @$pb.TagNumber(2)
-  set description($core.String v) { $_setString(1, v); }
+  set description($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasDescription() => $_has(1);
   @$pb.TagNumber(2)
@@ -4420,7 +5526,10 @@ class LNUrlPayMetadata extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get longDescription => $_getSZ(2);
   @$pb.TagNumber(3)
-  set longDescription($core.String v) { $_setString(2, v); }
+  set longDescription($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasLongDescription() => $_has(2);
   @$pb.TagNumber(3)
@@ -4429,7 +5538,10 @@ class LNUrlPayMetadata extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   LNUrlPayImage get image => $_getN(3);
   @$pb.TagNumber(4)
-  set image(LNUrlPayImage v) { setField(4, v); }
+  set image(LNUrlPayImage v) {
+    setField(4, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasImage() => $_has(3);
   @$pb.TagNumber(4)
@@ -4439,20 +5551,27 @@ class LNUrlPayMetadata extends $pb.GeneratedMessage {
 }
 
 class LNURLPayResponse1 extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNURLPayResponse1', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNURLPayResponse1',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'callback')
     ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'minAmount')
     ..aInt64(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'maxAmount')
-    ..pc<LNUrlPayMetadata>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'metadata', $pb.PbFieldType.PM, subBuilder: LNUrlPayMetadata.create)
+    ..pc<LNUrlPayMetadata>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'metadata',
+        $pb.PbFieldType.PM,
+        subBuilder: LNUrlPayMetadata.create)
     ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'tag')
-    ..a<$fixnum.Int64>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'amount', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(
+        6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'amount', $pb.PbFieldType.OU6,
+        defaultOrMaker: $fixnum.Int64.ZERO)
     ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'fromNodes')
     ..aOS(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'comment')
     ..aOS(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'host')
     ..aInt64(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'commentAllowed')
     ..aOS(11, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lightningAddress')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   LNURLPayResponse1._() : super();
   factory LNURLPayResponse1({
@@ -4504,31 +5623,39 @@ class LNURLPayResponse1 extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory LNURLPayResponse1.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory LNURLPayResponse1.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory LNURLPayResponse1.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LNURLPayResponse1.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   LNURLPayResponse1 clone() => LNURLPayResponse1()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  LNURLPayResponse1 copyWith(void Function(LNURLPayResponse1) updates) => super.copyWith((message) => updates(message as LNURLPayResponse1)) as LNURLPayResponse1; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  LNURLPayResponse1 copyWith(void Function(LNURLPayResponse1) updates) =>
+      super.copyWith((message) => updates(message as LNURLPayResponse1))
+          as LNURLPayResponse1; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LNURLPayResponse1 create() => LNURLPayResponse1._();
   LNURLPayResponse1 createEmptyInstance() => create();
   static $pb.PbList<LNURLPayResponse1> createRepeated() => $pb.PbList<LNURLPayResponse1>();
   @$core.pragma('dart2js:noInline')
-  static LNURLPayResponse1 getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNURLPayResponse1>(create);
+  static LNURLPayResponse1 getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNURLPayResponse1>(create);
   static LNURLPayResponse1? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get callback => $_getSZ(0);
   @$pb.TagNumber(1)
-  set callback($core.String v) { $_setString(0, v); }
+  set callback($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasCallback() => $_has(0);
   @$pb.TagNumber(1)
@@ -4537,7 +5664,10 @@ class LNURLPayResponse1 extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get minAmount => $_getI64(1);
   @$pb.TagNumber(2)
-  set minAmount($fixnum.Int64 v) { $_setInt64(1, v); }
+  set minAmount($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasMinAmount() => $_has(1);
   @$pb.TagNumber(2)
@@ -4546,7 +5676,10 @@ class LNURLPayResponse1 extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get maxAmount => $_getI64(2);
   @$pb.TagNumber(3)
-  set maxAmount($fixnum.Int64 v) { $_setInt64(2, v); }
+  set maxAmount($fixnum.Int64 v) {
+    $_setInt64(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasMaxAmount() => $_has(2);
   @$pb.TagNumber(3)
@@ -4558,7 +5691,10 @@ class LNURLPayResponse1 extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get tag => $_getSZ(4);
   @$pb.TagNumber(5)
-  set tag($core.String v) { $_setString(4, v); }
+  set tag($core.String v) {
+    $_setString(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasTag() => $_has(4);
   @$pb.TagNumber(5)
@@ -4567,7 +5703,10 @@ class LNURLPayResponse1 extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get amount => $_getI64(5);
   @$pb.TagNumber(6)
-  set amount($fixnum.Int64 v) { $_setInt64(5, v); }
+  set amount($fixnum.Int64 v) {
+    $_setInt64(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasAmount() => $_has(5);
   @$pb.TagNumber(6)
@@ -4576,7 +5715,10 @@ class LNURLPayResponse1 extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.String get fromNodes => $_getSZ(6);
   @$pb.TagNumber(7)
-  set fromNodes($core.String v) { $_setString(6, v); }
+  set fromNodes($core.String v) {
+    $_setString(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasFromNodes() => $_has(6);
   @$pb.TagNumber(7)
@@ -4585,7 +5727,10 @@ class LNURLPayResponse1 extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.String get comment => $_getSZ(7);
   @$pb.TagNumber(8)
-  set comment($core.String v) { $_setString(7, v); }
+  set comment($core.String v) {
+    $_setString(7, v);
+  }
+
   @$pb.TagNumber(8)
   $core.bool hasComment() => $_has(7);
   @$pb.TagNumber(8)
@@ -4594,7 +5739,10 @@ class LNURLPayResponse1 extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.String get host => $_getSZ(8);
   @$pb.TagNumber(9)
-  set host($core.String v) { $_setString(8, v); }
+  set host($core.String v) {
+    $_setString(8, v);
+  }
+
   @$pb.TagNumber(9)
   $core.bool hasHost() => $_has(8);
   @$pb.TagNumber(9)
@@ -4603,7 +5751,10 @@ class LNURLPayResponse1 extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $fixnum.Int64 get commentAllowed => $_getI64(9);
   @$pb.TagNumber(10)
-  set commentAllowed($fixnum.Int64 v) { $_setInt64(9, v); }
+  set commentAllowed($fixnum.Int64 v) {
+    $_setInt64(9, v);
+  }
+
   @$pb.TagNumber(10)
   $core.bool hasCommentAllowed() => $_has(9);
   @$pb.TagNumber(10)
@@ -4612,7 +5763,10 @@ class LNURLPayResponse1 extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $core.String get lightningAddress => $_getSZ(10);
   @$pb.TagNumber(11)
-  set lightningAddress($core.String v) { $_setString(10, v); }
+  set lightningAddress($core.String v) {
+    $_setString(10, v);
+  }
+
   @$pb.TagNumber(11)
   $core.bool hasLightningAddress() => $_has(10);
   @$pb.TagNumber(11)
@@ -4620,15 +5774,18 @@ class LNURLPayResponse1 extends $pb.GeneratedMessage {
 }
 
 class SuccessAction extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SuccessAction', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SuccessAction',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'tag')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'description')
     ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'url')
     ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'message')
     ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'ciphertext')
     ..aOS(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'iv')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   SuccessAction._() : super();
   factory SuccessAction({
@@ -4660,31 +5817,38 @@ class SuccessAction extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory SuccessAction.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory SuccessAction.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory SuccessAction.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory SuccessAction.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   SuccessAction clone() => SuccessAction()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  SuccessAction copyWith(void Function(SuccessAction) updates) => super.copyWith((message) => updates(message as SuccessAction)) as SuccessAction; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  SuccessAction copyWith(void Function(SuccessAction) updates) =>
+      super.copyWith((message) => updates(message as SuccessAction))
+          as SuccessAction; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SuccessAction create() => SuccessAction._();
   SuccessAction createEmptyInstance() => create();
   static $pb.PbList<SuccessAction> createRepeated() => $pb.PbList<SuccessAction>();
   @$core.pragma('dart2js:noInline')
-  static SuccessAction getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SuccessAction>(create);
+  static SuccessAction getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SuccessAction>(create);
   static SuccessAction? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get tag => $_getSZ(0);
   @$pb.TagNumber(1)
-  set tag($core.String v) { $_setString(0, v); }
+  set tag($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasTag() => $_has(0);
   @$pb.TagNumber(1)
@@ -4693,7 +5857,10 @@ class SuccessAction extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get description => $_getSZ(1);
   @$pb.TagNumber(2)
-  set description($core.String v) { $_setString(1, v); }
+  set description($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasDescription() => $_has(1);
   @$pb.TagNumber(2)
@@ -4702,7 +5869,10 @@ class SuccessAction extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get url => $_getSZ(2);
   @$pb.TagNumber(3)
-  set url($core.String v) { $_setString(2, v); }
+  set url($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasUrl() => $_has(2);
   @$pb.TagNumber(3)
@@ -4711,7 +5881,10 @@ class SuccessAction extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get message => $_getSZ(3);
   @$pb.TagNumber(4)
-  set message($core.String v) { $_setString(3, v); }
+  set message($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasMessage() => $_has(3);
   @$pb.TagNumber(4)
@@ -4720,7 +5893,10 @@ class SuccessAction extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get ciphertext => $_getSZ(4);
   @$pb.TagNumber(5)
-  set ciphertext($core.String v) { $_setString(4, v); }
+  set ciphertext($core.String v) {
+    $_setString(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasCiphertext() => $_has(4);
   @$pb.TagNumber(5)
@@ -4729,7 +5905,10 @@ class SuccessAction extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.String get iv => $_getSZ(5);
   @$pb.TagNumber(6)
-  set iv($core.String v) { $_setString(5, v); }
+  set iv($core.String v) {
+    $_setString(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasIv() => $_has(5);
   @$pb.TagNumber(6)
@@ -4737,17 +5916,25 @@ class SuccessAction extends $pb.GeneratedMessage {
 }
 
 class LNUrlPayInfo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNUrlPayInfo', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentHash', protoName: 'paymentHash')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNUrlPayInfo',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentHash',
+        protoName: 'paymentHash')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'invoice')
-    ..aOM<SuccessAction>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'successAction', subBuilder: SuccessAction.create)
+    ..aOM<SuccessAction>(
+        3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'successAction',
+        subBuilder: SuccessAction.create)
     ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'comment')
     ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'invoiceDescription')
-    ..pc<LNUrlPayMetadata>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'metadata', $pb.PbFieldType.PM, subBuilder: LNUrlPayMetadata.create)
+    ..pc<LNUrlPayMetadata>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'metadata',
+        $pb.PbFieldType.PM,
+        subBuilder: LNUrlPayMetadata.create)
     ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'host')
     ..aOS(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lightningAddress')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   LNUrlPayInfo._() : super();
   factory LNUrlPayInfo({
@@ -4787,31 +5974,38 @@ class LNUrlPayInfo extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory LNUrlPayInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory LNUrlPayInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory LNUrlPayInfo.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LNUrlPayInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   LNUrlPayInfo clone() => LNUrlPayInfo()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  LNUrlPayInfo copyWith(void Function(LNUrlPayInfo) updates) => super.copyWith((message) => updates(message as LNUrlPayInfo)) as LNUrlPayInfo; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  LNUrlPayInfo copyWith(void Function(LNUrlPayInfo) updates) =>
+      super.copyWith((message) => updates(message as LNUrlPayInfo))
+          as LNUrlPayInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LNUrlPayInfo create() => LNUrlPayInfo._();
   LNUrlPayInfo createEmptyInstance() => create();
   static $pb.PbList<LNUrlPayInfo> createRepeated() => $pb.PbList<LNUrlPayInfo>();
   @$core.pragma('dart2js:noInline')
-  static LNUrlPayInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNUrlPayInfo>(create);
+  static LNUrlPayInfo getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNUrlPayInfo>(create);
   static LNUrlPayInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get paymentHash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set paymentHash($core.String v) { $_setString(0, v); }
+  set paymentHash($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasPaymentHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -4820,7 +6014,10 @@ class LNUrlPayInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get invoice => $_getSZ(1);
   @$pb.TagNumber(2)
-  set invoice($core.String v) { $_setString(1, v); }
+  set invoice($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasInvoice() => $_has(1);
   @$pb.TagNumber(2)
@@ -4829,7 +6026,10 @@ class LNUrlPayInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   SuccessAction get successAction => $_getN(2);
   @$pb.TagNumber(3)
-  set successAction(SuccessAction v) { setField(3, v); }
+  set successAction(SuccessAction v) {
+    setField(3, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasSuccessAction() => $_has(2);
   @$pb.TagNumber(3)
@@ -4840,7 +6040,10 @@ class LNUrlPayInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get comment => $_getSZ(3);
   @$pb.TagNumber(4)
-  set comment($core.String v) { $_setString(3, v); }
+  set comment($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasComment() => $_has(3);
   @$pb.TagNumber(4)
@@ -4849,7 +6052,10 @@ class LNUrlPayInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get invoiceDescription => $_getSZ(4);
   @$pb.TagNumber(5)
-  set invoiceDescription($core.String v) { $_setString(4, v); }
+  set invoiceDescription($core.String v) {
+    $_setString(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasInvoiceDescription() => $_has(4);
   @$pb.TagNumber(5)
@@ -4861,7 +6067,10 @@ class LNUrlPayInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.String get host => $_getSZ(6);
   @$pb.TagNumber(7)
-  set host($core.String v) { $_setString(6, v); }
+  set host($core.String v) {
+    $_setString(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasHost() => $_has(6);
   @$pb.TagNumber(7)
@@ -4870,7 +6079,10 @@ class LNUrlPayInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.String get lightningAddress => $_getSZ(7);
   @$pb.TagNumber(8)
-  set lightningAddress($core.String v) { $_setString(7, v); }
+  set lightningAddress($core.String v) {
+    $_setString(7, v);
+  }
+
   @$pb.TagNumber(8)
   $core.bool hasLightningAddress() => $_has(7);
   @$pb.TagNumber(8)
@@ -4878,10 +6090,15 @@ class LNUrlPayInfo extends $pb.GeneratedMessage {
 }
 
 class LNUrlPayInfoList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNUrlPayInfoList', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..pc<LNUrlPayInfo>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'infoList', $pb.PbFieldType.PM, protoName: 'infoList', subBuilder: LNUrlPayInfo.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LNUrlPayInfoList',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..pc<LNUrlPayInfo>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'infoList',
+        $pb.PbFieldType.PM,
+        protoName: 'infoList', subBuilder: LNUrlPayInfo.create)
+    ..hasRequiredFields = false;
 
   LNUrlPayInfoList._() : super();
   factory LNUrlPayInfoList({
@@ -4893,25 +6110,30 @@ class LNUrlPayInfoList extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory LNUrlPayInfoList.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory LNUrlPayInfoList.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory LNUrlPayInfoList.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LNUrlPayInfoList.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   LNUrlPayInfoList clone() => LNUrlPayInfoList()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  LNUrlPayInfoList copyWith(void Function(LNUrlPayInfoList) updates) => super.copyWith((message) => updates(message as LNUrlPayInfoList)) as LNUrlPayInfoList; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  LNUrlPayInfoList copyWith(void Function(LNUrlPayInfoList) updates) =>
+      super.copyWith((message) => updates(message as LNUrlPayInfoList))
+          as LNUrlPayInfoList; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LNUrlPayInfoList create() => LNUrlPayInfoList._();
   LNUrlPayInfoList createEmptyInstance() => create();
   static $pb.PbList<LNUrlPayInfoList> createRepeated() => $pb.PbList<LNUrlPayInfoList>();
   @$core.pragma('dart2js:noInline')
-  static LNUrlPayInfoList getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNUrlPayInfoList>(create);
+  static LNUrlPayInfoList getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LNUrlPayInfoList>(create);
   static LNUrlPayInfoList? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -4919,12 +6141,15 @@ class LNUrlPayInfoList extends $pb.GeneratedMessage {
 }
 
 class ReverseSwapRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReverseSwapRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReverseSwapRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'address')
     ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'amount')
     ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'feesHash')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   ReverseSwapRequest._() : super();
   factory ReverseSwapRequest({
@@ -4944,31 +6169,39 @@ class ReverseSwapRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ReverseSwapRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ReverseSwapRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ReverseSwapRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ReverseSwapRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ReverseSwapRequest clone() => ReverseSwapRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ReverseSwapRequest copyWith(void Function(ReverseSwapRequest) updates) => super.copyWith((message) => updates(message as ReverseSwapRequest)) as ReverseSwapRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ReverseSwapRequest copyWith(void Function(ReverseSwapRequest) updates) =>
+      super.copyWith((message) => updates(message as ReverseSwapRequest))
+          as ReverseSwapRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReverseSwapRequest create() => ReverseSwapRequest._();
   ReverseSwapRequest createEmptyInstance() => create();
   static $pb.PbList<ReverseSwapRequest> createRepeated() => $pb.PbList<ReverseSwapRequest>();
   @$core.pragma('dart2js:noInline')
-  static ReverseSwapRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapRequest>(create);
+  static ReverseSwapRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapRequest>(create);
   static ReverseSwapRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) { $_setString(0, v); }
+  set address($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -4977,7 +6210,10 @@ class ReverseSwapRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get amount => $_getI64(1);
   @$pb.TagNumber(2)
-  set amount($fixnum.Int64 v) { $_setInt64(1, v); }
+  set amount($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasAmount() => $_has(1);
   @$pb.TagNumber(2)
@@ -4986,7 +6222,10 @@ class ReverseSwapRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get feesHash => $_getSZ(2);
   @$pb.TagNumber(3)
-  set feesHash($core.String v) { $_setString(2, v); }
+  set feesHash($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasFeesHash() => $_has(2);
   @$pb.TagNumber(3)
@@ -4994,7 +6233,11 @@ class ReverseSwapRequest extends $pb.GeneratedMessage {
 }
 
 class ReverseSwap extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReverseSwap', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReverseSwap',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'id')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'invoice')
     ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'script')
@@ -5008,8 +6251,7 @@ class ReverseSwap extends $pb.GeneratedMessage {
     ..aInt64(11, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'startBlockHeight')
     ..aInt64(12, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'claimFee')
     ..aOS(13, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'claimTxid')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   ReverseSwap._() : super();
   factory ReverseSwap({
@@ -5069,31 +6311,38 @@ class ReverseSwap extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ReverseSwap.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ReverseSwap.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ReverseSwap.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ReverseSwap.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ReverseSwap clone() => ReverseSwap()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ReverseSwap copyWith(void Function(ReverseSwap) updates) => super.copyWith((message) => updates(message as ReverseSwap)) as ReverseSwap; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ReverseSwap copyWith(void Function(ReverseSwap) updates) =>
+      super.copyWith((message) => updates(message as ReverseSwap))
+          as ReverseSwap; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReverseSwap create() => ReverseSwap._();
   ReverseSwap createEmptyInstance() => create();
   static $pb.PbList<ReverseSwap> createRepeated() => $pb.PbList<ReverseSwap>();
   @$core.pragma('dart2js:noInline')
-  static ReverseSwap getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwap>(create);
+  static ReverseSwap getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwap>(create);
   static ReverseSwap? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) { $_setString(0, v); }
+  set id($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
@@ -5102,7 +6351,10 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get invoice => $_getSZ(1);
   @$pb.TagNumber(2)
-  set invoice($core.String v) { $_setString(1, v); }
+  set invoice($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasInvoice() => $_has(1);
   @$pb.TagNumber(2)
@@ -5111,7 +6363,10 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get script => $_getSZ(2);
   @$pb.TagNumber(3)
-  set script($core.String v) { $_setString(2, v); }
+  set script($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasScript() => $_has(2);
   @$pb.TagNumber(3)
@@ -5120,7 +6375,10 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get lockupAddress => $_getSZ(3);
   @$pb.TagNumber(4)
-  set lockupAddress($core.String v) { $_setString(3, v); }
+  set lockupAddress($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasLockupAddress() => $_has(3);
   @$pb.TagNumber(4)
@@ -5129,7 +6387,10 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get preimage => $_getSZ(4);
   @$pb.TagNumber(5)
-  set preimage($core.String v) { $_setString(4, v); }
+  set preimage($core.String v) {
+    $_setString(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasPreimage() => $_has(4);
   @$pb.TagNumber(5)
@@ -5138,7 +6399,10 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.String get key => $_getSZ(5);
   @$pb.TagNumber(6)
-  set key($core.String v) { $_setString(5, v); }
+  set key($core.String v) {
+    $_setString(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasKey() => $_has(5);
   @$pb.TagNumber(6)
@@ -5147,7 +6411,10 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.String get claimAddress => $_getSZ(6);
   @$pb.TagNumber(7)
-  set claimAddress($core.String v) { $_setString(6, v); }
+  set claimAddress($core.String v) {
+    $_setString(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasClaimAddress() => $_has(6);
   @$pb.TagNumber(7)
@@ -5156,7 +6423,10 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $fixnum.Int64 get lnAmount => $_getI64(7);
   @$pb.TagNumber(8)
-  set lnAmount($fixnum.Int64 v) { $_setInt64(7, v); }
+  set lnAmount($fixnum.Int64 v) {
+    $_setInt64(7, v);
+  }
+
   @$pb.TagNumber(8)
   $core.bool hasLnAmount() => $_has(7);
   @$pb.TagNumber(8)
@@ -5165,7 +6435,10 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $fixnum.Int64 get onchainAmount => $_getI64(8);
   @$pb.TagNumber(9)
-  set onchainAmount($fixnum.Int64 v) { $_setInt64(8, v); }
+  set onchainAmount($fixnum.Int64 v) {
+    $_setInt64(8, v);
+  }
+
   @$pb.TagNumber(9)
   $core.bool hasOnchainAmount() => $_has(8);
   @$pb.TagNumber(9)
@@ -5174,7 +6447,10 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $fixnum.Int64 get timeoutBlockHeight => $_getI64(9);
   @$pb.TagNumber(10)
-  set timeoutBlockHeight($fixnum.Int64 v) { $_setInt64(9, v); }
+  set timeoutBlockHeight($fixnum.Int64 v) {
+    $_setInt64(9, v);
+  }
+
   @$pb.TagNumber(10)
   $core.bool hasTimeoutBlockHeight() => $_has(9);
   @$pb.TagNumber(10)
@@ -5183,7 +6459,10 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $fixnum.Int64 get startBlockHeight => $_getI64(10);
   @$pb.TagNumber(11)
-  set startBlockHeight($fixnum.Int64 v) { $_setInt64(10, v); }
+  set startBlockHeight($fixnum.Int64 v) {
+    $_setInt64(10, v);
+  }
+
   @$pb.TagNumber(11)
   $core.bool hasStartBlockHeight() => $_has(10);
   @$pb.TagNumber(11)
@@ -5192,7 +6471,10 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(12)
   $fixnum.Int64 get claimFee => $_getI64(11);
   @$pb.TagNumber(12)
-  set claimFee($fixnum.Int64 v) { $_setInt64(11, v); }
+  set claimFee($fixnum.Int64 v) {
+    $_setInt64(11, v);
+  }
+
   @$pb.TagNumber(12)
   $core.bool hasClaimFee() => $_has(11);
   @$pb.TagNumber(12)
@@ -5201,7 +6483,10 @@ class ReverseSwap extends $pb.GeneratedMessage {
   @$pb.TagNumber(13)
   $core.String get claimTxid => $_getSZ(12);
   @$pb.TagNumber(13)
-  set claimTxid($core.String v) { $_setString(12, v); }
+  set claimTxid($core.String v) {
+    $_setString(12, v);
+  }
+
   @$pb.TagNumber(13)
   $core.bool hasClaimTxid() => $_has(12);
   @$pb.TagNumber(13)
@@ -5209,12 +6494,16 @@ class ReverseSwap extends $pb.GeneratedMessage {
 }
 
 class ReverseSwapFees extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReverseSwapFees', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..a<$core.double>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'percentage', $pb.PbFieldType.OD)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReverseSwapFees',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..a<$core.double>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'percentage',
+        $pb.PbFieldType.OD)
     ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lockup')
     ..aInt64(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'claim')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   ReverseSwapFees._() : super();
   factory ReverseSwapFees({
@@ -5234,31 +6523,38 @@ class ReverseSwapFees extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ReverseSwapFees.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ReverseSwapFees.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ReverseSwapFees.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ReverseSwapFees.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ReverseSwapFees clone() => ReverseSwapFees()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ReverseSwapFees copyWith(void Function(ReverseSwapFees) updates) => super.copyWith((message) => updates(message as ReverseSwapFees)) as ReverseSwapFees; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ReverseSwapFees copyWith(void Function(ReverseSwapFees) updates) =>
+      super.copyWith((message) => updates(message as ReverseSwapFees))
+          as ReverseSwapFees; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReverseSwapFees create() => ReverseSwapFees._();
   ReverseSwapFees createEmptyInstance() => create();
   static $pb.PbList<ReverseSwapFees> createRepeated() => $pb.PbList<ReverseSwapFees>();
   @$core.pragma('dart2js:noInline')
-  static ReverseSwapFees getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapFees>(create);
+  static ReverseSwapFees getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapFees>(create);
   static ReverseSwapFees? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.double get percentage => $_getN(0);
   @$pb.TagNumber(1)
-  set percentage($core.double v) { $_setDouble(0, v); }
+  set percentage($core.double v) {
+    $_setDouble(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasPercentage() => $_has(0);
   @$pb.TagNumber(1)
@@ -5267,7 +6563,10 @@ class ReverseSwapFees extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get lockup => $_getI64(1);
   @$pb.TagNumber(2)
-  set lockup($fixnum.Int64 v) { $_setInt64(1, v); }
+  set lockup($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasLockup() => $_has(1);
   @$pb.TagNumber(2)
@@ -5276,7 +6575,10 @@ class ReverseSwapFees extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get claim => $_getI64(2);
   @$pb.TagNumber(3)
-  set claim($fixnum.Int64 v) { $_setInt64(2, v); }
+  set claim($fixnum.Int64 v) {
+    $_setInt64(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasClaim() => $_has(2);
   @$pb.TagNumber(3)
@@ -5284,13 +6586,17 @@ class ReverseSwapFees extends $pb.GeneratedMessage {
 }
 
 class ReverseSwapInfo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReverseSwapInfo', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReverseSwapInfo',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aInt64(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'min')
     ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'max')
-    ..aOM<ReverseSwapFees>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'fees', subBuilder: ReverseSwapFees.create)
+    ..aOM<ReverseSwapFees>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'fees',
+        subBuilder: ReverseSwapFees.create)
     ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'feesHash')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   ReverseSwapInfo._() : super();
   factory ReverseSwapInfo({
@@ -5314,31 +6620,38 @@ class ReverseSwapInfo extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ReverseSwapInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ReverseSwapInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ReverseSwapInfo.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ReverseSwapInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ReverseSwapInfo clone() => ReverseSwapInfo()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ReverseSwapInfo copyWith(void Function(ReverseSwapInfo) updates) => super.copyWith((message) => updates(message as ReverseSwapInfo)) as ReverseSwapInfo; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ReverseSwapInfo copyWith(void Function(ReverseSwapInfo) updates) =>
+      super.copyWith((message) => updates(message as ReverseSwapInfo))
+          as ReverseSwapInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReverseSwapInfo create() => ReverseSwapInfo._();
   ReverseSwapInfo createEmptyInstance() => create();
   static $pb.PbList<ReverseSwapInfo> createRepeated() => $pb.PbList<ReverseSwapInfo>();
   @$core.pragma('dart2js:noInline')
-  static ReverseSwapInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapInfo>(create);
+  static ReverseSwapInfo getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapInfo>(create);
   static ReverseSwapInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get min => $_getI64(0);
   @$pb.TagNumber(1)
-  set min($fixnum.Int64 v) { $_setInt64(0, v); }
+  set min($fixnum.Int64 v) {
+    $_setInt64(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasMin() => $_has(0);
   @$pb.TagNumber(1)
@@ -5347,7 +6660,10 @@ class ReverseSwapInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get max => $_getI64(1);
   @$pb.TagNumber(2)
-  set max($fixnum.Int64 v) { $_setInt64(1, v); }
+  set max($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasMax() => $_has(1);
   @$pb.TagNumber(2)
@@ -5356,7 +6672,10 @@ class ReverseSwapInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   ReverseSwapFees get fees => $_getN(2);
   @$pb.TagNumber(3)
-  set fees(ReverseSwapFees v) { setField(3, v); }
+  set fees(ReverseSwapFees v) {
+    setField(3, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasFees() => $_has(2);
   @$pb.TagNumber(3)
@@ -5367,7 +6686,10 @@ class ReverseSwapInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get feesHash => $_getSZ(3);
   @$pb.TagNumber(4)
-  set feesHash($core.String v) { $_setString(3, v); }
+  set feesHash($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasFeesHash() => $_has(3);
   @$pb.TagNumber(4)
@@ -5375,12 +6697,17 @@ class ReverseSwapInfo extends $pb.GeneratedMessage {
 }
 
 class ReverseSwapPaymentRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReverseSwapPaymentRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReverseSwapPaymentRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'hash')
-    ..aOM<PushNotificationDetails>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pushNotificationDetails', subBuilder: PushNotificationDetails.create)
+    ..aOM<PushNotificationDetails>(
+        2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pushNotificationDetails',
+        subBuilder: PushNotificationDetails.create)
     ..aInt64(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'fee')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   ReverseSwapPaymentRequest._() : super();
   factory ReverseSwapPaymentRequest({
@@ -5400,31 +6727,39 @@ class ReverseSwapPaymentRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ReverseSwapPaymentRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ReverseSwapPaymentRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ReverseSwapPaymentRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ReverseSwapPaymentRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ReverseSwapPaymentRequest clone() => ReverseSwapPaymentRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ReverseSwapPaymentRequest copyWith(void Function(ReverseSwapPaymentRequest) updates) => super.copyWith((message) => updates(message as ReverseSwapPaymentRequest)) as ReverseSwapPaymentRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ReverseSwapPaymentRequest copyWith(void Function(ReverseSwapPaymentRequest) updates) =>
+      super.copyWith((message) => updates(message as ReverseSwapPaymentRequest))
+          as ReverseSwapPaymentRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReverseSwapPaymentRequest create() => ReverseSwapPaymentRequest._();
   ReverseSwapPaymentRequest createEmptyInstance() => create();
   static $pb.PbList<ReverseSwapPaymentRequest> createRepeated() => $pb.PbList<ReverseSwapPaymentRequest>();
   @$core.pragma('dart2js:noInline')
-  static ReverseSwapPaymentRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapPaymentRequest>(create);
+  static ReverseSwapPaymentRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapPaymentRequest>(create);
   static ReverseSwapPaymentRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) { $_setString(0, v); }
+  set hash($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -5433,7 +6768,10 @@ class ReverseSwapPaymentRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   PushNotificationDetails get pushNotificationDetails => $_getN(1);
   @$pb.TagNumber(2)
-  set pushNotificationDetails(PushNotificationDetails v) { setField(2, v); }
+  set pushNotificationDetails(PushNotificationDetails v) {
+    setField(2, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasPushNotificationDetails() => $_has(1);
   @$pb.TagNumber(2)
@@ -5444,7 +6782,10 @@ class ReverseSwapPaymentRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get fee => $_getI64(2);
   @$pb.TagNumber(3)
-  set fee($fixnum.Int64 v) { $_setInt64(2, v); }
+  set fee($fixnum.Int64 v) {
+    $_setInt64(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasFee() => $_has(2);
   @$pb.TagNumber(3)
@@ -5452,12 +6793,15 @@ class ReverseSwapPaymentRequest extends $pb.GeneratedMessage {
 }
 
 class PushNotificationDetails extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PushNotificationDetails', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PushNotificationDetails',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deviceId')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'title')
     ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'body')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   PushNotificationDetails._() : super();
   factory PushNotificationDetails({
@@ -5477,31 +6821,39 @@ class PushNotificationDetails extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory PushNotificationDetails.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PushNotificationDetails.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory PushNotificationDetails.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory PushNotificationDetails.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   PushNotificationDetails clone() => PushNotificationDetails()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  PushNotificationDetails copyWith(void Function(PushNotificationDetails) updates) => super.copyWith((message) => updates(message as PushNotificationDetails)) as PushNotificationDetails; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  PushNotificationDetails copyWith(void Function(PushNotificationDetails) updates) =>
+      super.copyWith((message) => updates(message as PushNotificationDetails))
+          as PushNotificationDetails; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PushNotificationDetails create() => PushNotificationDetails._();
   PushNotificationDetails createEmptyInstance() => create();
   static $pb.PbList<PushNotificationDetails> createRepeated() => $pb.PbList<PushNotificationDetails>();
   @$core.pragma('dart2js:noInline')
-  static PushNotificationDetails getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PushNotificationDetails>(create);
+  static PushNotificationDetails getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PushNotificationDetails>(create);
   static PushNotificationDetails? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get deviceId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set deviceId($core.String v) { $_setString(0, v); }
+  set deviceId($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasDeviceId() => $_has(0);
   @$pb.TagNumber(1)
@@ -5510,7 +6862,10 @@ class PushNotificationDetails extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get title => $_getSZ(1);
   @$pb.TagNumber(2)
-  set title($core.String v) { $_setString(1, v); }
+  set title($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasTitle() => $_has(1);
   @$pb.TagNumber(2)
@@ -5519,7 +6874,10 @@ class PushNotificationDetails extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get body => $_getSZ(2);
   @$pb.TagNumber(3)
-  set body($core.String v) { $_setString(2, v); }
+  set body($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasBody() => $_has(2);
   @$pb.TagNumber(3)
@@ -5527,12 +6885,16 @@ class PushNotificationDetails extends $pb.GeneratedMessage {
 }
 
 class ReverseSwapPaymentStatus extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReverseSwapPaymentStatus', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReverseSwapPaymentStatus',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'hash')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'txID', protoName: 'txID')
-    ..a<$core.int>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'eta', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false
-  ;
+    ..a<$core.int>(
+        3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'eta', $pb.PbFieldType.O3)
+    ..hasRequiredFields = false;
 
   ReverseSwapPaymentStatus._() : super();
   factory ReverseSwapPaymentStatus({
@@ -5552,31 +6914,39 @@ class ReverseSwapPaymentStatus extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ReverseSwapPaymentStatus.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ReverseSwapPaymentStatus.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ReverseSwapPaymentStatus.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ReverseSwapPaymentStatus.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ReverseSwapPaymentStatus clone() => ReverseSwapPaymentStatus()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ReverseSwapPaymentStatus copyWith(void Function(ReverseSwapPaymentStatus) updates) => super.copyWith((message) => updates(message as ReverseSwapPaymentStatus)) as ReverseSwapPaymentStatus; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ReverseSwapPaymentStatus copyWith(void Function(ReverseSwapPaymentStatus) updates) =>
+      super.copyWith((message) => updates(message as ReverseSwapPaymentStatus))
+          as ReverseSwapPaymentStatus; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReverseSwapPaymentStatus create() => ReverseSwapPaymentStatus._();
   ReverseSwapPaymentStatus createEmptyInstance() => create();
   static $pb.PbList<ReverseSwapPaymentStatus> createRepeated() => $pb.PbList<ReverseSwapPaymentStatus>();
   @$core.pragma('dart2js:noInline')
-  static ReverseSwapPaymentStatus getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapPaymentStatus>(create);
+  static ReverseSwapPaymentStatus getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapPaymentStatus>(create);
   static ReverseSwapPaymentStatus? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) { $_setString(0, v); }
+  set hash($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -5585,7 +6955,10 @@ class ReverseSwapPaymentStatus extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get txID => $_getSZ(1);
   @$pb.TagNumber(2)
-  set txID($core.String v) { $_setString(1, v); }
+  set txID($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasTxID() => $_has(1);
   @$pb.TagNumber(2)
@@ -5594,7 +6967,10 @@ class ReverseSwapPaymentStatus extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.int get eta => $_getIZ(2);
   @$pb.TagNumber(3)
-  set eta($core.int v) { $_setSignedInt32(2, v); }
+  set eta($core.int v) {
+    $_setSignedInt32(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasEta() => $_has(2);
   @$pb.TagNumber(3)
@@ -5602,10 +6978,17 @@ class ReverseSwapPaymentStatus extends $pb.GeneratedMessage {
 }
 
 class ReverseSwapPaymentStatuses extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReverseSwapPaymentStatuses', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..pc<ReverseSwapPaymentStatus>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentsStatus', $pb.PbFieldType.PM, subBuilder: ReverseSwapPaymentStatus.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReverseSwapPaymentStatuses',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..pc<ReverseSwapPaymentStatus>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'paymentsStatus',
+        $pb.PbFieldType.PM,
+        subBuilder: ReverseSwapPaymentStatus.create)
+    ..hasRequiredFields = false;
 
   ReverseSwapPaymentStatuses._() : super();
   factory ReverseSwapPaymentStatuses({
@@ -5617,25 +7000,30 @@ class ReverseSwapPaymentStatuses extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ReverseSwapPaymentStatuses.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ReverseSwapPaymentStatuses.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ReverseSwapPaymentStatuses.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ReverseSwapPaymentStatuses.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ReverseSwapPaymentStatuses clone() => ReverseSwapPaymentStatuses()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ReverseSwapPaymentStatuses copyWith(void Function(ReverseSwapPaymentStatuses) updates) => super.copyWith((message) => updates(message as ReverseSwapPaymentStatuses)) as ReverseSwapPaymentStatuses; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ReverseSwapPaymentStatuses copyWith(void Function(ReverseSwapPaymentStatuses) updates) =>
+      super.copyWith((message) => updates(message as ReverseSwapPaymentStatuses))
+          as ReverseSwapPaymentStatuses; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReverseSwapPaymentStatuses create() => ReverseSwapPaymentStatuses._();
   ReverseSwapPaymentStatuses createEmptyInstance() => create();
   static $pb.PbList<ReverseSwapPaymentStatuses> createRepeated() => $pb.PbList<ReverseSwapPaymentStatuses>();
   @$core.pragma('dart2js:noInline')
-  static ReverseSwapPaymentStatuses getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapPaymentStatuses>(create);
+  static ReverseSwapPaymentStatuses getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapPaymentStatuses>(create);
   static ReverseSwapPaymentStatuses? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -5643,11 +7031,14 @@ class ReverseSwapPaymentStatuses extends $pb.GeneratedMessage {
 }
 
 class ReverseSwapClaimFee extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReverseSwapClaimFee', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReverseSwapClaimFee',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'hash')
     ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'fee')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   ReverseSwapClaimFee._() : super();
   factory ReverseSwapClaimFee({
@@ -5663,31 +7054,39 @@ class ReverseSwapClaimFee extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ReverseSwapClaimFee.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ReverseSwapClaimFee.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ReverseSwapClaimFee.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ReverseSwapClaimFee.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ReverseSwapClaimFee clone() => ReverseSwapClaimFee()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ReverseSwapClaimFee copyWith(void Function(ReverseSwapClaimFee) updates) => super.copyWith((message) => updates(message as ReverseSwapClaimFee)) as ReverseSwapClaimFee; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ReverseSwapClaimFee copyWith(void Function(ReverseSwapClaimFee) updates) =>
+      super.copyWith((message) => updates(message as ReverseSwapClaimFee))
+          as ReverseSwapClaimFee; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReverseSwapClaimFee create() => ReverseSwapClaimFee._();
   ReverseSwapClaimFee createEmptyInstance() => create();
   static $pb.PbList<ReverseSwapClaimFee> createRepeated() => $pb.PbList<ReverseSwapClaimFee>();
   @$core.pragma('dart2js:noInline')
-  static ReverseSwapClaimFee getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapClaimFee>(create);
+  static ReverseSwapClaimFee getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReverseSwapClaimFee>(create);
   static ReverseSwapClaimFee? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get hash => $_getSZ(0);
   @$pb.TagNumber(1)
-  set hash($core.String v) { $_setString(0, v); }
+  set hash($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasHash() => $_has(0);
   @$pb.TagNumber(1)
@@ -5696,7 +7095,10 @@ class ReverseSwapClaimFee extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get fee => $_getI64(1);
   @$pb.TagNumber(2)
-  set fee($fixnum.Int64 v) { $_setInt64(1, v); }
+  set fee($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasFee() => $_has(1);
   @$pb.TagNumber(2)
@@ -5704,10 +7106,18 @@ class ReverseSwapClaimFee extends $pb.GeneratedMessage {
 }
 
 class ClaimFeeEstimates extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ClaimFeeEstimates', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..m<$core.int, $fixnum.Int64>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'fees', entryClassName: 'ClaimFeeEstimates.FeesEntry', keyFieldType: $pb.PbFieldType.O3, valueFieldType: $pb.PbFieldType.O6, packageName: const $pb.PackageName('data'))
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ClaimFeeEstimates',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..m<$core.int, $fixnum.Int64>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'fees',
+        entryClassName: 'ClaimFeeEstimates.FeesEntry',
+        keyFieldType: $pb.PbFieldType.O3,
+        valueFieldType: $pb.PbFieldType.O6,
+        packageName: const $pb.PackageName('data'))
+    ..hasRequiredFields = false;
 
   ClaimFeeEstimates._() : super();
   factory ClaimFeeEstimates({
@@ -5719,25 +7129,30 @@ class ClaimFeeEstimates extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ClaimFeeEstimates.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ClaimFeeEstimates.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ClaimFeeEstimates.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ClaimFeeEstimates.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ClaimFeeEstimates clone() => ClaimFeeEstimates()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ClaimFeeEstimates copyWith(void Function(ClaimFeeEstimates) updates) => super.copyWith((message) => updates(message as ClaimFeeEstimates)) as ClaimFeeEstimates; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ClaimFeeEstimates copyWith(void Function(ClaimFeeEstimates) updates) =>
+      super.copyWith((message) => updates(message as ClaimFeeEstimates))
+          as ClaimFeeEstimates; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ClaimFeeEstimates create() => ClaimFeeEstimates._();
   ClaimFeeEstimates createEmptyInstance() => create();
   static $pb.PbList<ClaimFeeEstimates> createRepeated() => $pb.PbList<ClaimFeeEstimates>();
   @$core.pragma('dart2js:noInline')
-  static ClaimFeeEstimates getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ClaimFeeEstimates>(create);
+  static ClaimFeeEstimates getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ClaimFeeEstimates>(create);
   static ClaimFeeEstimates? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -5745,12 +7160,22 @@ class ClaimFeeEstimates extends $pb.GeneratedMessage {
 }
 
 class UnspendLockupInformation extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'UnspendLockupInformation', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..a<$core.int>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'heightHint', $pb.PbFieldType.OU3)
-    ..a<$core.List<$core.int>>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lockupScript', $pb.PbFieldType.OY)
-    ..a<$core.List<$core.int>>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'claimTxHash', $pb.PbFieldType.OY)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'UnspendLockupInformation',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..a<$core.int>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'heightHint',
+        $pb.PbFieldType.OU3)
+    ..a<$core.List<$core.int>>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lockupScript',
+        $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(
+        3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'claimTxHash',
+        $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
 
   UnspendLockupInformation._() : super();
   factory UnspendLockupInformation({
@@ -5770,31 +7195,39 @@ class UnspendLockupInformation extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory UnspendLockupInformation.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory UnspendLockupInformation.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory UnspendLockupInformation.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory UnspendLockupInformation.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   UnspendLockupInformation clone() => UnspendLockupInformation()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  UnspendLockupInformation copyWith(void Function(UnspendLockupInformation) updates) => super.copyWith((message) => updates(message as UnspendLockupInformation)) as UnspendLockupInformation; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  UnspendLockupInformation copyWith(void Function(UnspendLockupInformation) updates) =>
+      super.copyWith((message) => updates(message as UnspendLockupInformation))
+          as UnspendLockupInformation; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static UnspendLockupInformation create() => UnspendLockupInformation._();
   UnspendLockupInformation createEmptyInstance() => create();
   static $pb.PbList<UnspendLockupInformation> createRepeated() => $pb.PbList<UnspendLockupInformation>();
   @$core.pragma('dart2js:noInline')
-  static UnspendLockupInformation getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UnspendLockupInformation>(create);
+  static UnspendLockupInformation getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UnspendLockupInformation>(create);
   static UnspendLockupInformation? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get heightHint => $_getIZ(0);
   @$pb.TagNumber(1)
-  set heightHint($core.int v) { $_setUnsignedInt32(0, v); }
+  set heightHint($core.int v) {
+    $_setUnsignedInt32(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasHeightHint() => $_has(0);
   @$pb.TagNumber(1)
@@ -5803,7 +7236,10 @@ class UnspendLockupInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.List<$core.int> get lockupScript => $_getN(1);
   @$pb.TagNumber(2)
-  set lockupScript($core.List<$core.int> v) { $_setBytes(1, v); }
+  set lockupScript($core.List<$core.int> v) {
+    $_setBytes(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasLockupScript() => $_has(1);
   @$pb.TagNumber(2)
@@ -5812,7 +7248,10 @@ class UnspendLockupInformation extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.List<$core.int> get claimTxHash => $_getN(2);
   @$pb.TagNumber(3)
-  set claimTxHash($core.List<$core.int> v) { $_setBytes(2, v); }
+  set claimTxHash($core.List<$core.int> v) {
+    $_setBytes(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasClaimTxHash() => $_has(2);
   @$pb.TagNumber(3)
@@ -5820,12 +7259,16 @@ class UnspendLockupInformation extends $pb.GeneratedMessage {
 }
 
 class TransactionDetails extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'TransactionDetails', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..a<$core.List<$core.int>>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'tx', $pb.PbFieldType.OY)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'TransactionDetails',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'tx', $pb.PbFieldType.OY)
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'txHash')
     ..aInt64(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'fees')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   TransactionDetails._() : super();
   factory TransactionDetails({
@@ -5845,31 +7288,39 @@ class TransactionDetails extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory TransactionDetails.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory TransactionDetails.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory TransactionDetails.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory TransactionDetails.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   TransactionDetails clone() => TransactionDetails()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  TransactionDetails copyWith(void Function(TransactionDetails) updates) => super.copyWith((message) => updates(message as TransactionDetails)) as TransactionDetails; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  TransactionDetails copyWith(void Function(TransactionDetails) updates) =>
+      super.copyWith((message) => updates(message as TransactionDetails))
+          as TransactionDetails; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static TransactionDetails create() => TransactionDetails._();
   TransactionDetails createEmptyInstance() => create();
   static $pb.PbList<TransactionDetails> createRepeated() => $pb.PbList<TransactionDetails>();
   @$core.pragma('dart2js:noInline')
-  static TransactionDetails getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransactionDetails>(create);
+  static TransactionDetails getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TransactionDetails>(create);
   static TransactionDetails? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get tx => $_getN(0);
   @$pb.TagNumber(1)
-  set tx($core.List<$core.int> v) { $_setBytes(0, v); }
+  set tx($core.List<$core.int> v) {
+    $_setBytes(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasTx() => $_has(0);
   @$pb.TagNumber(1)
@@ -5878,7 +7329,10 @@ class TransactionDetails extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get txHash => $_getSZ(1);
   @$pb.TagNumber(2)
-  set txHash($core.String v) { $_setString(1, v); }
+  set txHash($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasTxHash() => $_has(1);
   @$pb.TagNumber(2)
@@ -5887,7 +7341,10 @@ class TransactionDetails extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get fees => $_getI64(2);
   @$pb.TagNumber(3)
-  set fees($fixnum.Int64 v) { $_setInt64(2, v); }
+  set fees($fixnum.Int64 v) {
+    $_setInt64(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasFees() => $_has(2);
   @$pb.TagNumber(3)
@@ -5895,11 +7352,20 @@ class TransactionDetails extends $pb.GeneratedMessage {
 }
 
 class SweepAllCoinsTransactions extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SweepAllCoinsTransactions', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SweepAllCoinsTransactions',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aInt64(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'amt')
-    ..m<$core.int, TransactionDetails>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'transactions', entryClassName: 'SweepAllCoinsTransactions.TransactionsEntry', keyFieldType: $pb.PbFieldType.O3, valueFieldType: $pb.PbFieldType.OM, valueCreator: TransactionDetails.create, packageName: const $pb.PackageName('data'))
-    ..hasRequiredFields = false
-  ;
+    ..m<$core.int, TransactionDetails>(
+        2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'transactions',
+        entryClassName: 'SweepAllCoinsTransactions.TransactionsEntry',
+        keyFieldType: $pb.PbFieldType.O3,
+        valueFieldType: $pb.PbFieldType.OM,
+        valueCreator: TransactionDetails.create,
+        packageName: const $pb.PackageName('data'))
+    ..hasRequiredFields = false;
 
   SweepAllCoinsTransactions._() : super();
   factory SweepAllCoinsTransactions({
@@ -5915,31 +7381,39 @@ class SweepAllCoinsTransactions extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory SweepAllCoinsTransactions.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory SweepAllCoinsTransactions.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory SweepAllCoinsTransactions.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory SweepAllCoinsTransactions.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   SweepAllCoinsTransactions clone() => SweepAllCoinsTransactions()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  SweepAllCoinsTransactions copyWith(void Function(SweepAllCoinsTransactions) updates) => super.copyWith((message) => updates(message as SweepAllCoinsTransactions)) as SweepAllCoinsTransactions; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  SweepAllCoinsTransactions copyWith(void Function(SweepAllCoinsTransactions) updates) =>
+      super.copyWith((message) => updates(message as SweepAllCoinsTransactions))
+          as SweepAllCoinsTransactions; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SweepAllCoinsTransactions create() => SweepAllCoinsTransactions._();
   SweepAllCoinsTransactions createEmptyInstance() => create();
   static $pb.PbList<SweepAllCoinsTransactions> createRepeated() => $pb.PbList<SweepAllCoinsTransactions>();
   @$core.pragma('dart2js:noInline')
-  static SweepAllCoinsTransactions getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SweepAllCoinsTransactions>(create);
+  static SweepAllCoinsTransactions getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SweepAllCoinsTransactions>(create);
   static SweepAllCoinsTransactions? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get amt => $_getI64(0);
   @$pb.TagNumber(1)
-  set amt($fixnum.Int64 v) { $_setInt64(0, v); }
+  set amt($fixnum.Int64 v) {
+    $_setInt64(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasAmt() => $_has(0);
   @$pb.TagNumber(1)
@@ -5950,10 +7424,13 @@ class SweepAllCoinsTransactions extends $pb.GeneratedMessage {
 }
 
 class DownloadBackupResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'DownloadBackupResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'DownloadBackupResponse',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..pPS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'files')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   DownloadBackupResponse._() : super();
   factory DownloadBackupResponse({
@@ -5965,25 +7442,30 @@ class DownloadBackupResponse extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory DownloadBackupResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory DownloadBackupResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory DownloadBackupResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory DownloadBackupResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   DownloadBackupResponse clone() => DownloadBackupResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  DownloadBackupResponse copyWith(void Function(DownloadBackupResponse) updates) => super.copyWith((message) => updates(message as DownloadBackupResponse)) as DownloadBackupResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  DownloadBackupResponse copyWith(void Function(DownloadBackupResponse) updates) =>
+      super.copyWith((message) => updates(message as DownloadBackupResponse))
+          as DownloadBackupResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static DownloadBackupResponse create() => DownloadBackupResponse._();
   DownloadBackupResponse createEmptyInstance() => create();
   static $pb.PbList<DownloadBackupResponse> createRepeated() => $pb.PbList<DownloadBackupResponse>();
   @$core.pragma('dart2js:noInline')
-  static DownloadBackupResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DownloadBackupResponse>(create);
+  static DownloadBackupResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DownloadBackupResponse>(create);
   static DownloadBackupResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -5991,12 +7473,15 @@ class DownloadBackupResponse extends $pb.GeneratedMessage {
 }
 
 class TorConfig extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'TorConfig', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'TorConfig',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'control')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'http')
     ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'socks')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   TorConfig._() : super();
   factory TorConfig({
@@ -6016,18 +7501,21 @@ class TorConfig extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory TorConfig.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory TorConfig.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory TorConfig.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory TorConfig.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   TorConfig clone() => TorConfig()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  TorConfig copyWith(void Function(TorConfig) updates) => super.copyWith((message) => updates(message as TorConfig)) as TorConfig; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  TorConfig copyWith(void Function(TorConfig) updates) =>
+      super.copyWith((message) => updates(message as TorConfig))
+          as TorConfig; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static TorConfig create() => TorConfig._();
@@ -6040,7 +7528,10 @@ class TorConfig extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get control => $_getSZ(0);
   @$pb.TagNumber(1)
-  set control($core.String v) { $_setString(0, v); }
+  set control($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasControl() => $_has(0);
   @$pb.TagNumber(1)
@@ -6049,7 +7540,10 @@ class TorConfig extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get http => $_getSZ(1);
   @$pb.TagNumber(2)
-  set http($core.String v) { $_setString(1, v); }
+  set http($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasHttp() => $_has(1);
   @$pb.TagNumber(2)
@@ -6058,7 +7552,10 @@ class TorConfig extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get socks => $_getSZ(2);
   @$pb.TagNumber(3)
-  set socks($core.String v) { $_setString(2, v); }
+  set socks($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasSocks() => $_has(2);
   @$pb.TagNumber(3)
@@ -6066,10 +7563,13 @@ class TorConfig extends $pb.GeneratedMessage {
 }
 
 class CloseChannelsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CloseChannelsRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CloseChannelsRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'address')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   CloseChannelsRequest._() : super();
   factory CloseChannelsRequest({
@@ -6081,31 +7581,39 @@ class CloseChannelsRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory CloseChannelsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory CloseChannelsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory CloseChannelsRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory CloseChannelsRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   CloseChannelsRequest clone() => CloseChannelsRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  CloseChannelsRequest copyWith(void Function(CloseChannelsRequest) updates) => super.copyWith((message) => updates(message as CloseChannelsRequest)) as CloseChannelsRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  CloseChannelsRequest copyWith(void Function(CloseChannelsRequest) updates) =>
+      super.copyWith((message) => updates(message as CloseChannelsRequest))
+          as CloseChannelsRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CloseChannelsRequest create() => CloseChannelsRequest._();
   CloseChannelsRequest createEmptyInstance() => create();
   static $pb.PbList<CloseChannelsRequest> createRepeated() => $pb.PbList<CloseChannelsRequest>();
   @$core.pragma('dart2js:noInline')
-  static CloseChannelsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CloseChannelsRequest>(create);
+  static CloseChannelsRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CloseChannelsRequest>(create);
   static CloseChannelsRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get address => $_getSZ(0);
   @$pb.TagNumber(1)
-  set address($core.String v) { $_setString(0, v); }
+  set address($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasAddress() => $_has(0);
   @$pb.TagNumber(1)
@@ -6113,10 +7621,15 @@ class CloseChannelsRequest extends $pb.GeneratedMessage {
 }
 
 class CloseChannelsReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CloseChannelsReply', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
-    ..pc<CloseChannelResult>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'channels', $pb.PbFieldType.PM, subBuilder: CloseChannelResult.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CloseChannelsReply',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
+    ..pc<CloseChannelResult>(1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'channels', $pb.PbFieldType.PM,
+        subBuilder: CloseChannelResult.create)
+    ..hasRequiredFields = false;
 
   CloseChannelsReply._() : super();
   factory CloseChannelsReply({
@@ -6128,25 +7641,30 @@ class CloseChannelsReply extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory CloseChannelsReply.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory CloseChannelsReply.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory CloseChannelsReply.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory CloseChannelsReply.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   CloseChannelsReply clone() => CloseChannelsReply()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  CloseChannelsReply copyWith(void Function(CloseChannelsReply) updates) => super.copyWith((message) => updates(message as CloseChannelsReply)) as CloseChannelsReply; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  CloseChannelsReply copyWith(void Function(CloseChannelsReply) updates) =>
+      super.copyWith((message) => updates(message as CloseChannelsReply))
+          as CloseChannelsReply; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CloseChannelsReply create() => CloseChannelsReply._();
   CloseChannelsReply createEmptyInstance() => create();
   static $pb.PbList<CloseChannelsReply> createRepeated() => $pb.PbList<CloseChannelsReply>();
   @$core.pragma('dart2js:noInline')
-  static CloseChannelsReply getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CloseChannelsReply>(create);
+  static CloseChannelsReply getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CloseChannelsReply>(create);
   static CloseChannelsReply? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -6154,14 +7672,17 @@ class CloseChannelsReply extends $pb.GeneratedMessage {
 }
 
 class CloseChannelResult extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CloseChannelResult', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CloseChannelResult',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'data'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'remotePubkey')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'channelPoint')
     ..aOB(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'isSkipped')
     ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'closingTxid')
     ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'failErr')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   CloseChannelResult._() : super();
   factory CloseChannelResult({
@@ -6189,31 +7710,39 @@ class CloseChannelResult extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory CloseChannelResult.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory CloseChannelResult.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory CloseChannelResult.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory CloseChannelResult.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   CloseChannelResult clone() => CloseChannelResult()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  CloseChannelResult copyWith(void Function(CloseChannelResult) updates) => super.copyWith((message) => updates(message as CloseChannelResult)) as CloseChannelResult; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  CloseChannelResult copyWith(void Function(CloseChannelResult) updates) =>
+      super.copyWith((message) => updates(message as CloseChannelResult))
+          as CloseChannelResult; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CloseChannelResult create() => CloseChannelResult._();
   CloseChannelResult createEmptyInstance() => create();
   static $pb.PbList<CloseChannelResult> createRepeated() => $pb.PbList<CloseChannelResult>();
   @$core.pragma('dart2js:noInline')
-  static CloseChannelResult getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CloseChannelResult>(create);
+  static CloseChannelResult getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CloseChannelResult>(create);
   static CloseChannelResult? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get remotePubkey => $_getSZ(0);
   @$pb.TagNumber(1)
-  set remotePubkey($core.String v) { $_setString(0, v); }
+  set remotePubkey($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasRemotePubkey() => $_has(0);
   @$pb.TagNumber(1)
@@ -6222,7 +7751,10 @@ class CloseChannelResult extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get channelPoint => $_getSZ(1);
   @$pb.TagNumber(2)
-  set channelPoint($core.String v) { $_setString(1, v); }
+  set channelPoint($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasChannelPoint() => $_has(1);
   @$pb.TagNumber(2)
@@ -6231,7 +7763,10 @@ class CloseChannelResult extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get isSkipped => $_getBF(2);
   @$pb.TagNumber(3)
-  set isSkipped($core.bool v) { $_setBool(2, v); }
+  set isSkipped($core.bool v) {
+    $_setBool(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasIsSkipped() => $_has(2);
   @$pb.TagNumber(3)
@@ -6240,7 +7775,10 @@ class CloseChannelResult extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get closingTxid => $_getSZ(3);
   @$pb.TagNumber(4)
-  set closingTxid($core.String v) { $_setString(3, v); }
+  set closingTxid($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasClosingTxid() => $_has(3);
   @$pb.TagNumber(4)
@@ -6249,10 +7787,12 @@ class CloseChannelResult extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get failErr => $_getSZ(4);
   @$pb.TagNumber(5)
-  set failErr($core.String v) { $_setString(4, v); }
+  set failErr($core.String v) {
+    $_setString(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasFailErr() => $_has(4);
   @$pb.TagNumber(5)
   void clearFailErr() => clearField(5);
 }
-

--- a/lib/services/breezlib/data/messages.pbenum.dart
+++ b/lib/services/breezlib/data/messages.pbenum.dart
@@ -10,13 +10,18 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class SwapError extends $pb.ProtobufEnum {
-  static const SwapError NO_ERROR = SwapError._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'NO_ERROR');
-  static const SwapError FUNDS_EXCEED_LIMIT = SwapError._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'FUNDS_EXCEED_LIMIT');
-  static const SwapError TX_TOO_SMALL = SwapError._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'TX_TOO_SMALL');
-  static const SwapError INVOICE_AMOUNT_MISMATCH = SwapError._(3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'INVOICE_AMOUNT_MISMATCH');
-  static const SwapError SWAP_EXPIRED = SwapError._(4, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'SWAP_EXPIRED');
+  static const SwapError NO_ERROR =
+      SwapError._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'NO_ERROR');
+  static const SwapError FUNDS_EXCEED_LIMIT = SwapError._(
+      1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'FUNDS_EXCEED_LIMIT');
+  static const SwapError TX_TOO_SMALL =
+      SwapError._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'TX_TOO_SMALL');
+  static const SwapError INVOICE_AMOUNT_MISMATCH = SwapError._(
+      3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'INVOICE_AMOUNT_MISMATCH');
+  static const SwapError SWAP_EXPIRED =
+      SwapError._(4, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'SWAP_EXPIRED');
 
-  static const $core.List<SwapError> values = <SwapError> [
+  static const $core.List<SwapError> values = <SwapError>[
     NO_ERROR,
     FUNDS_EXCEED_LIMIT,
     TX_TOO_SMALL,
@@ -31,12 +36,16 @@ class SwapError extends $pb.ProtobufEnum {
 }
 
 class Account_AccountStatus extends $pb.ProtobufEnum {
-  static const Account_AccountStatus DISCONNECTED = Account_AccountStatus._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DISCONNECTED');
-  static const Account_AccountStatus PROCESSING_CONNECTION = Account_AccountStatus._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PROCESSING_CONNECTION');
-  static const Account_AccountStatus CLOSING_CONNECTION = Account_AccountStatus._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'CLOSING_CONNECTION');
-  static const Account_AccountStatus CONNECTED = Account_AccountStatus._(3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'CONNECTED');
+  static const Account_AccountStatus DISCONNECTED = Account_AccountStatus._(
+      0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DISCONNECTED');
+  static const Account_AccountStatus PROCESSING_CONNECTION = Account_AccountStatus._(
+      1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PROCESSING_CONNECTION');
+  static const Account_AccountStatus CLOSING_CONNECTION = Account_AccountStatus._(
+      2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'CLOSING_CONNECTION');
+  static const Account_AccountStatus CONNECTED = Account_AccountStatus._(
+      3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'CONNECTED');
 
-  static const $core.List<Account_AccountStatus> values = <Account_AccountStatus> [
+  static const $core.List<Account_AccountStatus> values = <Account_AccountStatus>[
     DISCONNECTED,
     PROCESSING_CONNECTION,
     CLOSING_CONNECTION,
@@ -50,13 +59,18 @@ class Account_AccountStatus extends $pb.ProtobufEnum {
 }
 
 class Payment_PaymentType extends $pb.ProtobufEnum {
-  static const Payment_PaymentType DEPOSIT = Payment_PaymentType._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DEPOSIT');
-  static const Payment_PaymentType WITHDRAWAL = Payment_PaymentType._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'WITHDRAWAL');
-  static const Payment_PaymentType SENT = Payment_PaymentType._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'SENT');
-  static const Payment_PaymentType RECEIVED = Payment_PaymentType._(3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'RECEIVED');
-  static const Payment_PaymentType CLOSED_CHANNEL = Payment_PaymentType._(4, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'CLOSED_CHANNEL');
+  static const Payment_PaymentType DEPOSIT =
+      Payment_PaymentType._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DEPOSIT');
+  static const Payment_PaymentType WITHDRAWAL = Payment_PaymentType._(
+      1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'WITHDRAWAL');
+  static const Payment_PaymentType SENT =
+      Payment_PaymentType._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'SENT');
+  static const Payment_PaymentType RECEIVED = Payment_PaymentType._(
+      3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'RECEIVED');
+  static const Payment_PaymentType CLOSED_CHANNEL = Payment_PaymentType._(
+      4, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'CLOSED_CHANNEL');
 
-  static const $core.List<Payment_PaymentType> values = <Payment_PaymentType> [
+  static const $core.List<Payment_PaymentType> values = <Payment_PaymentType>[
     DEPOSIT,
     WITHDRAWAL,
     SENT,
@@ -71,29 +85,58 @@ class Payment_PaymentType extends $pb.ProtobufEnum {
 }
 
 class NotificationEvent_NotificationType extends $pb.ProtobufEnum {
-  static const NotificationEvent_NotificationType READY = NotificationEvent_NotificationType._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'READY');
-  static const NotificationEvent_NotificationType INITIALIZATION_FAILED = NotificationEvent_NotificationType._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'INITIALIZATION_FAILED');
-  static const NotificationEvent_NotificationType ACCOUNT_CHANGED = NotificationEvent_NotificationType._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'ACCOUNT_CHANGED');
-  static const NotificationEvent_NotificationType PAYMENT_SENT = NotificationEvent_NotificationType._(3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PAYMENT_SENT');
-  static const NotificationEvent_NotificationType INVOICE_PAID = NotificationEvent_NotificationType._(4, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'INVOICE_PAID');
-  static const NotificationEvent_NotificationType LIGHTNING_SERVICE_DOWN = NotificationEvent_NotificationType._(5, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'LIGHTNING_SERVICE_DOWN');
-  static const NotificationEvent_NotificationType FUND_ADDRESS_CREATED = NotificationEvent_NotificationType._(6, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'FUND_ADDRESS_CREATED');
-  static const NotificationEvent_NotificationType FUND_ADDRESS_UNSPENT_CHANGED = NotificationEvent_NotificationType._(7, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'FUND_ADDRESS_UNSPENT_CHANGED');
-  static const NotificationEvent_NotificationType BACKUP_SUCCESS = NotificationEvent_NotificationType._(8, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'BACKUP_SUCCESS');
-  static const NotificationEvent_NotificationType BACKUP_FAILED = NotificationEvent_NotificationType._(9, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'BACKUP_FAILED');
-  static const NotificationEvent_NotificationType BACKUP_AUTH_FAILED = NotificationEvent_NotificationType._(10, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'BACKUP_AUTH_FAILED');
-  static const NotificationEvent_NotificationType BACKUP_NODE_CONFLICT = NotificationEvent_NotificationType._(11, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'BACKUP_NODE_CONFLICT');
-  static const NotificationEvent_NotificationType BACKUP_REQUEST = NotificationEvent_NotificationType._(12, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'BACKUP_REQUEST');
-  static const NotificationEvent_NotificationType PAYMENT_FAILED = NotificationEvent_NotificationType._(13, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PAYMENT_FAILED');
-  static const NotificationEvent_NotificationType PAYMENT_SUCCEEDED = NotificationEvent_NotificationType._(14, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PAYMENT_SUCCEEDED');
-  static const NotificationEvent_NotificationType REVERSE_SWAP_CLAIM_STARTED = NotificationEvent_NotificationType._(15, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'REVERSE_SWAP_CLAIM_STARTED');
-  static const NotificationEvent_NotificationType REVERSE_SWAP_CLAIM_SUCCEEDED = NotificationEvent_NotificationType._(16, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'REVERSE_SWAP_CLAIM_SUCCEEDED');
-  static const NotificationEvent_NotificationType REVERSE_SWAP_CLAIM_FAILED = NotificationEvent_NotificationType._(17, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'REVERSE_SWAP_CLAIM_FAILED');
-  static const NotificationEvent_NotificationType REVERSE_SWAP_CLAIM_CONFIRMED = NotificationEvent_NotificationType._(18, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'REVERSE_SWAP_CLAIM_CONFIRMED');
-  static const NotificationEvent_NotificationType LSP_CHANNEL_OPENED = NotificationEvent_NotificationType._(19, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'LSP_CHANNEL_OPENED');
-  static const NotificationEvent_NotificationType BACKUP_NOT_LATEST_CONFLICT = NotificationEvent_NotificationType._(20, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'BACKUP_NOT_LATEST_CONFLICT');
+  static const NotificationEvent_NotificationType READY = NotificationEvent_NotificationType._(
+      0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'READY');
+  static const NotificationEvent_NotificationType INITIALIZATION_FAILED =
+      NotificationEvent_NotificationType._(
+          1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'INITIALIZATION_FAILED');
+  static const NotificationEvent_NotificationType ACCOUNT_CHANGED = NotificationEvent_NotificationType._(
+      2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'ACCOUNT_CHANGED');
+  static const NotificationEvent_NotificationType PAYMENT_SENT = NotificationEvent_NotificationType._(
+      3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PAYMENT_SENT');
+  static const NotificationEvent_NotificationType INVOICE_PAID = NotificationEvent_NotificationType._(
+      4, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'INVOICE_PAID');
+  static const NotificationEvent_NotificationType LIGHTNING_SERVICE_DOWN =
+      NotificationEvent_NotificationType._(
+          5, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'LIGHTNING_SERVICE_DOWN');
+  static const NotificationEvent_NotificationType FUND_ADDRESS_CREATED = NotificationEvent_NotificationType._(
+      6, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'FUND_ADDRESS_CREATED');
+  static const NotificationEvent_NotificationType FUND_ADDRESS_UNSPENT_CHANGED =
+      NotificationEvent_NotificationType._(7,
+          const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'FUND_ADDRESS_UNSPENT_CHANGED');
+  static const NotificationEvent_NotificationType BACKUP_SUCCESS = NotificationEvent_NotificationType._(
+      8, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'BACKUP_SUCCESS');
+  static const NotificationEvent_NotificationType BACKUP_FAILED = NotificationEvent_NotificationType._(
+      9, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'BACKUP_FAILED');
+  static const NotificationEvent_NotificationType BACKUP_AUTH_FAILED = NotificationEvent_NotificationType._(
+      10, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'BACKUP_AUTH_FAILED');
+  static const NotificationEvent_NotificationType BACKUP_NODE_CONFLICT = NotificationEvent_NotificationType._(
+      11, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'BACKUP_NODE_CONFLICT');
+  static const NotificationEvent_NotificationType BACKUP_REQUEST = NotificationEvent_NotificationType._(
+      12, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'BACKUP_REQUEST');
+  static const NotificationEvent_NotificationType PAYMENT_FAILED = NotificationEvent_NotificationType._(
+      13, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PAYMENT_FAILED');
+  static const NotificationEvent_NotificationType PAYMENT_SUCCEEDED = NotificationEvent_NotificationType._(
+      14, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PAYMENT_SUCCEEDED');
+  static const NotificationEvent_NotificationType REVERSE_SWAP_CLAIM_STARTED =
+      NotificationEvent_NotificationType._(15,
+          const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'REVERSE_SWAP_CLAIM_STARTED');
+  static const NotificationEvent_NotificationType REVERSE_SWAP_CLAIM_SUCCEEDED =
+      NotificationEvent_NotificationType._(16,
+          const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'REVERSE_SWAP_CLAIM_SUCCEEDED');
+  static const NotificationEvent_NotificationType REVERSE_SWAP_CLAIM_FAILED =
+      NotificationEvent_NotificationType._(17,
+          const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'REVERSE_SWAP_CLAIM_FAILED');
+  static const NotificationEvent_NotificationType REVERSE_SWAP_CLAIM_CONFIRMED =
+      NotificationEvent_NotificationType._(18,
+          const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'REVERSE_SWAP_CLAIM_CONFIRMED');
+  static const NotificationEvent_NotificationType LSP_CHANNEL_OPENED = NotificationEvent_NotificationType._(
+      19, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'LSP_CHANNEL_OPENED');
+  static const NotificationEvent_NotificationType BACKUP_NOT_LATEST_CONFLICT =
+      NotificationEvent_NotificationType._(20,
+          const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'BACKUP_NOT_LATEST_CONFLICT');
 
-  static const $core.List<NotificationEvent_NotificationType> values = <NotificationEvent_NotificationType> [
+  static const $core.List<NotificationEvent_NotificationType> values = <NotificationEvent_NotificationType>[
     READY,
     INITIALIZATION_FAILED,
     ACCOUNT_CHANGED,
@@ -117,9 +160,9 @@ class NotificationEvent_NotificationType extends $pb.ProtobufEnum {
     BACKUP_NOT_LATEST_CONFLICT,
   ];
 
-  static final $core.Map<$core.int, NotificationEvent_NotificationType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static final $core.Map<$core.int, NotificationEvent_NotificationType> _byValue =
+      $pb.ProtobufEnum.initByValue(values);
   static NotificationEvent_NotificationType? valueOf($core.int value) => _byValue[value];
 
   const NotificationEvent_NotificationType._($core.int v, $core.String n) : super(v, n);
 }
-

--- a/lib/services/breezlib/data/messages.pbgrpc.dart
+++ b/lib/services/breezlib/data/messages.pbgrpc.dart
@@ -18,108 +18,83 @@ class BreezAPIClient extends $grpc.Client {
       '/data.BreezAPI/GetLSPList',
       ($0.LSPListRequest value) => value.writeToBuffer(),
       ($core.List<$core.int> value) => $0.LSPList.fromBuffer(value));
-  static final _$connectToLSP =
-      $grpc.ClientMethod<$0.ConnectLSPRequest, $0.ConnectLSPReply>(
-          '/data.BreezAPI/ConnectToLSP',
-          ($0.ConnectLSPRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.ConnectLSPReply.fromBuffer(value));
-  static final _$addFundInit =
-      $grpc.ClientMethod<$0.AddFundInitRequest, $0.AddFundInitReply>(
-          '/data.BreezAPI/AddFundInit',
-          ($0.AddFundInitRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.AddFundInitReply.fromBuffer(value));
-  static final _$getFundStatus =
-      $grpc.ClientMethod<$0.FundStatusRequest, $0.FundStatusReply>(
-          '/data.BreezAPI/GetFundStatus',
-          ($0.FundStatusRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.FundStatusReply.fromBuffer(value));
-  static final _$addInvoice =
-      $grpc.ClientMethod<$0.AddInvoiceRequest, $0.AddInvoiceReply>(
-          '/data.BreezAPI/AddInvoice',
-          ($0.AddInvoiceRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.AddInvoiceReply.fromBuffer(value));
-  static final _$payInvoice =
-      $grpc.ClientMethod<$0.PayInvoiceRequest, $0.PaymentResponse>(
-          '/data.BreezAPI/PayInvoice',
-          ($0.PayInvoiceRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.PaymentResponse.fromBuffer(value));
-  static final _$restartDaemon =
-      $grpc.ClientMethod<$0.RestartDaemonRequest, $0.RestartDaemonReply>(
-          '/data.BreezAPI/RestartDaemon',
-          ($0.RestartDaemonRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.RestartDaemonReply.fromBuffer(value));
-  static final _$listPayments =
-      $grpc.ClientMethod<$0.ListPaymentsRequest, $0.PaymentsList>(
-          '/data.BreezAPI/ListPayments',
-          ($0.ListPaymentsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.PaymentsList.fromBuffer(value));
-  static final _$closeChannels =
-      $grpc.ClientMethod<$0.CloseChannelsRequest, $0.CloseChannelsReply>(
-          '/data.BreezAPI/CloseChannels',
-          ($0.CloseChannelsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.CloseChannelsReply.fromBuffer(value));
+  static final _$connectToLSP = $grpc.ClientMethod<$0.ConnectLSPRequest, $0.ConnectLSPReply>(
+      '/data.BreezAPI/ConnectToLSP',
+      ($0.ConnectLSPRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.ConnectLSPReply.fromBuffer(value));
+  static final _$addFundInit = $grpc.ClientMethod<$0.AddFundInitRequest, $0.AddFundInitReply>(
+      '/data.BreezAPI/AddFundInit',
+      ($0.AddFundInitRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.AddFundInitReply.fromBuffer(value));
+  static final _$getFundStatus = $grpc.ClientMethod<$0.FundStatusRequest, $0.FundStatusReply>(
+      '/data.BreezAPI/GetFundStatus',
+      ($0.FundStatusRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.FundStatusReply.fromBuffer(value));
+  static final _$addInvoice = $grpc.ClientMethod<$0.AddInvoiceRequest, $0.AddInvoiceReply>(
+      '/data.BreezAPI/AddInvoice',
+      ($0.AddInvoiceRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.AddInvoiceReply.fromBuffer(value));
+  static final _$payInvoice = $grpc.ClientMethod<$0.PayInvoiceRequest, $0.PaymentResponse>(
+      '/data.BreezAPI/PayInvoice',
+      ($0.PayInvoiceRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.PaymentResponse.fromBuffer(value));
+  static final _$restartDaemon = $grpc.ClientMethod<$0.RestartDaemonRequest, $0.RestartDaemonReply>(
+      '/data.BreezAPI/RestartDaemon',
+      ($0.RestartDaemonRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.RestartDaemonReply.fromBuffer(value));
+  static final _$listPayments = $grpc.ClientMethod<$0.ListPaymentsRequest, $0.PaymentsList>(
+      '/data.BreezAPI/ListPayments',
+      ($0.ListPaymentsRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.PaymentsList.fromBuffer(value));
+  static final _$closeChannels = $grpc.ClientMethod<$0.CloseChannelsRequest, $0.CloseChannelsReply>(
+      '/data.BreezAPI/CloseChannels',
+      ($0.CloseChannelsRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.CloseChannelsReply.fromBuffer(value));
 
   BreezAPIClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions? options,
-      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
+      {$grpc.CallOptions? options, $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
-  $grpc.ResponseFuture<$0.LSPList> getLSPList($0.LSPListRequest request,
-      {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.LSPList> getLSPList($0.LSPListRequest request, {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$getLSPList, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.ConnectLSPReply> connectToLSP(
-      $0.ConnectLSPRequest request,
+  $grpc.ResponseFuture<$0.ConnectLSPReply> connectToLSP($0.ConnectLSPRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$connectToLSP, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.AddFundInitReply> addFundInit(
-      $0.AddFundInitRequest request,
+  $grpc.ResponseFuture<$0.AddFundInitReply> addFundInit($0.AddFundInitRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$addFundInit, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.FundStatusReply> getFundStatus(
-      $0.FundStatusRequest request,
+  $grpc.ResponseFuture<$0.FundStatusReply> getFundStatus($0.FundStatusRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$getFundStatus, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.AddInvoiceReply> addInvoice(
-      $0.AddInvoiceRequest request,
+  $grpc.ResponseFuture<$0.AddInvoiceReply> addInvoice($0.AddInvoiceRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$addInvoice, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.PaymentResponse> payInvoice(
-      $0.PayInvoiceRequest request,
+  $grpc.ResponseFuture<$0.PaymentResponse> payInvoice($0.PayInvoiceRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$payInvoice, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.RestartDaemonReply> restartDaemon(
-      $0.RestartDaemonRequest request,
+  $grpc.ResponseFuture<$0.RestartDaemonReply> restartDaemon($0.RestartDaemonRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$restartDaemon, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.PaymentsList> listPayments(
-      $0.ListPaymentsRequest request,
+  $grpc.ResponseFuture<$0.PaymentsList> listPayments($0.ListPaymentsRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$listPayments, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.CloseChannelsReply> closeChannels(
-      $0.CloseChannelsRequest request,
+  $grpc.ResponseFuture<$0.CloseChannelsReply> closeChannels($0.CloseChannelsRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$closeChannels, request, options: options);
   }
@@ -148,8 +123,7 @@ abstract class BreezAPIServiceBase extends $grpc.Service {
         addFundInit_Pre,
         false,
         false,
-        ($core.List<$core.int> value) =>
-            $0.AddFundInitRequest.fromBuffer(value),
+        ($core.List<$core.int> value) => $0.AddFundInitRequest.fromBuffer(value),
         ($0.AddFundInitReply value) => value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$0.FundStatusRequest, $0.FundStatusReply>(
         'GetFundStatus',
@@ -172,32 +146,27 @@ abstract class BreezAPIServiceBase extends $grpc.Service {
         false,
         ($core.List<$core.int> value) => $0.PayInvoiceRequest.fromBuffer(value),
         ($0.PaymentResponse value) => value.writeToBuffer()));
-    $addMethod(
-        $grpc.ServiceMethod<$0.RestartDaemonRequest, $0.RestartDaemonReply>(
-            'RestartDaemon',
-            restartDaemon_Pre,
-            false,
-            false,
-            ($core.List<$core.int> value) =>
-                $0.RestartDaemonRequest.fromBuffer(value),
-            ($0.RestartDaemonReply value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.RestartDaemonRequest, $0.RestartDaemonReply>(
+        'RestartDaemon',
+        restartDaemon_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.RestartDaemonRequest.fromBuffer(value),
+        ($0.RestartDaemonReply value) => value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$0.ListPaymentsRequest, $0.PaymentsList>(
         'ListPayments',
         listPayments_Pre,
         false,
         false,
-        ($core.List<$core.int> value) =>
-            $0.ListPaymentsRequest.fromBuffer(value),
+        ($core.List<$core.int> value) => $0.ListPaymentsRequest.fromBuffer(value),
         ($0.PaymentsList value) => value.writeToBuffer()));
-    $addMethod(
-        $grpc.ServiceMethod<$0.CloseChannelsRequest, $0.CloseChannelsReply>(
-            'CloseChannels',
-            closeChannels_Pre,
-            false,
-            false,
-            ($core.List<$core.int> value) =>
-                $0.CloseChannelsRequest.fromBuffer(value),
-            ($0.CloseChannelsReply value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.CloseChannelsRequest, $0.CloseChannelsReply>(
+        'CloseChannels',
+        closeChannels_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.CloseChannelsRequest.fromBuffer(value),
+        ($0.CloseChannelsReply value) => value.writeToBuffer()));
   }
 
   $async.Future<$0.LSPList> getLSPList_Pre(
@@ -205,62 +174,53 @@ abstract class BreezAPIServiceBase extends $grpc.Service {
     return getLSPList(call, await request);
   }
 
-  $async.Future<$0.ConnectLSPReply> connectToLSP_Pre($grpc.ServiceCall call,
-      $async.Future<$0.ConnectLSPRequest> request) async {
+  $async.Future<$0.ConnectLSPReply> connectToLSP_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.ConnectLSPRequest> request) async {
     return connectToLSP(call, await request);
   }
 
-  $async.Future<$0.AddFundInitReply> addFundInit_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AddFundInitRequest> request) async {
+  $async.Future<$0.AddFundInitReply> addFundInit_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.AddFundInitRequest> request) async {
     return addFundInit(call, await request);
   }
 
-  $async.Future<$0.FundStatusReply> getFundStatus_Pre($grpc.ServiceCall call,
-      $async.Future<$0.FundStatusRequest> request) async {
+  $async.Future<$0.FundStatusReply> getFundStatus_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.FundStatusRequest> request) async {
     return getFundStatus(call, await request);
   }
 
-  $async.Future<$0.AddInvoiceReply> addInvoice_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AddInvoiceRequest> request) async {
+  $async.Future<$0.AddInvoiceReply> addInvoice_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.AddInvoiceRequest> request) async {
     return addInvoice(call, await request);
   }
 
-  $async.Future<$0.PaymentResponse> payInvoice_Pre($grpc.ServiceCall call,
-      $async.Future<$0.PayInvoiceRequest> request) async {
+  $async.Future<$0.PaymentResponse> payInvoice_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.PayInvoiceRequest> request) async {
     return payInvoice(call, await request);
   }
 
-  $async.Future<$0.RestartDaemonReply> restartDaemon_Pre($grpc.ServiceCall call,
-      $async.Future<$0.RestartDaemonRequest> request) async {
+  $async.Future<$0.RestartDaemonReply> restartDaemon_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.RestartDaemonRequest> request) async {
     return restartDaemon(call, await request);
   }
 
-  $async.Future<$0.PaymentsList> listPayments_Pre($grpc.ServiceCall call,
-      $async.Future<$0.ListPaymentsRequest> request) async {
+  $async.Future<$0.PaymentsList> listPayments_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.ListPaymentsRequest> request) async {
     return listPayments(call, await request);
   }
 
-  $async.Future<$0.CloseChannelsReply> closeChannels_Pre($grpc.ServiceCall call,
-      $async.Future<$0.CloseChannelsRequest> request) async {
+  $async.Future<$0.CloseChannelsReply> closeChannels_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.CloseChannelsRequest> request) async {
     return closeChannels(call, await request);
   }
 
-  $async.Future<$0.LSPList> getLSPList(
-      $grpc.ServiceCall call, $0.LSPListRequest request);
-  $async.Future<$0.ConnectLSPReply> connectToLSP(
-      $grpc.ServiceCall call, $0.ConnectLSPRequest request);
-  $async.Future<$0.AddFundInitReply> addFundInit(
-      $grpc.ServiceCall call, $0.AddFundInitRequest request);
-  $async.Future<$0.FundStatusReply> getFundStatus(
-      $grpc.ServiceCall call, $0.FundStatusRequest request);
-  $async.Future<$0.AddInvoiceReply> addInvoice(
-      $grpc.ServiceCall call, $0.AddInvoiceRequest request);
-  $async.Future<$0.PaymentResponse> payInvoice(
-      $grpc.ServiceCall call, $0.PayInvoiceRequest request);
-  $async.Future<$0.RestartDaemonReply> restartDaemon(
-      $grpc.ServiceCall call, $0.RestartDaemonRequest request);
-  $async.Future<$0.PaymentsList> listPayments(
-      $grpc.ServiceCall call, $0.ListPaymentsRequest request);
-  $async.Future<$0.CloseChannelsReply> closeChannels(
-      $grpc.ServiceCall call, $0.CloseChannelsRequest request);
+  $async.Future<$0.LSPList> getLSPList($grpc.ServiceCall call, $0.LSPListRequest request);
+  $async.Future<$0.ConnectLSPReply> connectToLSP($grpc.ServiceCall call, $0.ConnectLSPRequest request);
+  $async.Future<$0.AddFundInitReply> addFundInit($grpc.ServiceCall call, $0.AddFundInitRequest request);
+  $async.Future<$0.FundStatusReply> getFundStatus($grpc.ServiceCall call, $0.FundStatusRequest request);
+  $async.Future<$0.AddInvoiceReply> addInvoice($grpc.ServiceCall call, $0.AddInvoiceRequest request);
+  $async.Future<$0.PaymentResponse> payInvoice($grpc.ServiceCall call, $0.PayInvoiceRequest request);
+  $async.Future<$0.RestartDaemonReply> restartDaemon($grpc.ServiceCall call, $0.RestartDaemonRequest request);
+  $async.Future<$0.PaymentsList> listPayments($grpc.ServiceCall call, $0.ListPaymentsRequest request);
+  $async.Future<$0.CloseChannelsReply> closeChannels($grpc.ServiceCall call, $0.CloseChannelsRequest request);
 }

--- a/lib/services/breezlib/data/messages.pbjson.dart
+++ b/lib/services/breezlib/data/messages.pbjson.dart
@@ -8,6 +8,7 @@
 import 'dart:core' as $core;
 import 'dart:convert' as $convert;
 import 'dart:typed_data' as $typed_data;
+
 @$core.Deprecated('Use swapErrorDescriptor instead')
 const SwapError$json = const {
   '1': 'SwapError',
@@ -21,40 +22,52 @@ const SwapError$json = const {
 };
 
 /// Descriptor for `SwapError`. Decode as a `google.protobuf.EnumDescriptorProto`.
-final $typed_data.Uint8List swapErrorDescriptor = $convert.base64Decode('CglTd2FwRXJyb3ISDAoITk9fRVJST1IQABIWChJGVU5EU19FWENFRURfTElNSVQQARIQCgxUWF9UT09fU01BTEwQAhIbChdJTlZPSUNFX0FNT1VOVF9NSVNNQVRDSBADEhAKDFNXQVBfRVhQSVJFRBAE');
+final $typed_data.Uint8List swapErrorDescriptor = $convert.base64Decode(
+    'CglTd2FwRXJyb3ISDAoITk9fRVJST1IQABIWChJGVU5EU19FWENFRURfTElNSVQQARIQCgxUWF9UT09fU01BTEwQAhIbChdJTlZPSUNFX0FNT1VOVF9NSVNNQVRDSBADEhAKDFNXQVBfRVhQSVJFRBAE');
 @$core.Deprecated('Use listPaymentsRequestDescriptor instead')
 const ListPaymentsRequest$json = const {
   '1': 'ListPaymentsRequest',
 };
 
 /// Descriptor for `ListPaymentsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listPaymentsRequestDescriptor = $convert.base64Decode('ChNMaXN0UGF5bWVudHNSZXF1ZXN0');
+final $typed_data.Uint8List listPaymentsRequestDescriptor =
+    $convert.base64Decode('ChNMaXN0UGF5bWVudHNSZXF1ZXN0');
 @$core.Deprecated('Use restartDaemonRequestDescriptor instead')
 const RestartDaemonRequest$json = const {
   '1': 'RestartDaemonRequest',
 };
 
 /// Descriptor for `RestartDaemonRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List restartDaemonRequestDescriptor = $convert.base64Decode('ChRSZXN0YXJ0RGFlbW9uUmVxdWVzdA==');
+final $typed_data.Uint8List restartDaemonRequestDescriptor =
+    $convert.base64Decode('ChRSZXN0YXJ0RGFlbW9uUmVxdWVzdA==');
 @$core.Deprecated('Use restartDaemonReplyDescriptor instead')
 const RestartDaemonReply$json = const {
   '1': 'RestartDaemonReply',
 };
 
 /// Descriptor for `RestartDaemonReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List restartDaemonReplyDescriptor = $convert.base64Decode('ChJSZXN0YXJ0RGFlbW9uUmVwbHk=');
+final $typed_data.Uint8List restartDaemonReplyDescriptor =
+    $convert.base64Decode('ChJSZXN0YXJ0RGFlbW9uUmVwbHk=');
 @$core.Deprecated('Use addFundInitRequestDescriptor instead')
 const AddFundInitRequest$json = const {
   '1': 'AddFundInitRequest',
   '2': const [
     const {'1': 'notificationToken', '3': 1, '4': 1, '5': 9, '10': 'notificationToken'},
     const {'1': 'lspID', '3': 2, '4': 1, '5': 9, '10': 'lspID'},
-    const {'1': 'opening_fee_params', '3': 3, '4': 1, '5': 11, '6': '.data.OpeningFeeParams', '10': 'openingFeeParams'},
+    const {
+      '1': 'opening_fee_params',
+      '3': 3,
+      '4': 1,
+      '5': 11,
+      '6': '.data.OpeningFeeParams',
+      '10': 'openingFeeParams'
+    },
   ],
 };
 
 /// Descriptor for `AddFundInitRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List addFundInitRequestDescriptor = $convert.base64Decode('ChJBZGRGdW5kSW5pdFJlcXVlc3QSLAoRbm90aWZpY2F0aW9uVG9rZW4YASABKAlSEW5vdGlmaWNhdGlvblRva2VuEhQKBWxzcElEGAIgASgJUgVsc3BJRBJEChJvcGVuaW5nX2ZlZV9wYXJhbXMYAyABKAsyFi5kYXRhLk9wZW5pbmdGZWVQYXJhbXNSEG9wZW5pbmdGZWVQYXJhbXM=');
+final $typed_data.Uint8List addFundInitRequestDescriptor = $convert.base64Decode(
+    'ChJBZGRGdW5kSW5pdFJlcXVlc3QSLAoRbm90aWZpY2F0aW9uVG9rZW4YASABKAlSEW5vdGlmaWNhdGlvblRva2VuEhQKBWxzcElEGAIgASgJUgVsc3BJRBJEChJvcGVuaW5nX2ZlZV9wYXJhbXMYAyABKAsyFi5kYXRhLk9wZW5pbmdGZWVQYXJhbXNSEG9wZW5pbmdGZWVQYXJhbXM=');
 @$core.Deprecated('Use fundStatusRequestDescriptor instead')
 const FundStatusRequest$json = const {
   '1': 'FundStatusRequest',
@@ -64,7 +77,8 @@ const FundStatusRequest$json = const {
 };
 
 /// Descriptor for `FundStatusRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List fundStatusRequestDescriptor = $convert.base64Decode('ChFGdW5kU3RhdHVzUmVxdWVzdBIsChFub3RpZmljYXRpb25Ub2tlbhgBIAEoCVIRbm90aWZpY2F0aW9uVG9rZW4=');
+final $typed_data.Uint8List fundStatusRequestDescriptor = $convert
+    .base64Decode('ChFGdW5kU3RhdHVzUmVxdWVzdBIsChFub3RpZmljYXRpb25Ub2tlbhgBIAEoCVIRbm90aWZpY2F0aW9uVG9rZW4=');
 @$core.Deprecated('Use addInvoiceReplyDescriptor instead')
 const AddInvoiceReply$json = const {
   '1': 'AddInvoiceReply',
@@ -75,7 +89,8 @@ const AddInvoiceReply$json = const {
 };
 
 /// Descriptor for `AddInvoiceReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List addInvoiceReplyDescriptor = $convert.base64Decode('Cg9BZGRJbnZvaWNlUmVwbHkSJgoOcGF5bWVudFJlcXVlc3QYASABKAlSDnBheW1lbnRSZXF1ZXN0EhcKB2xzcF9mZWUYAiABKANSBmxzcEZlZQ==');
+final $typed_data.Uint8List addInvoiceReplyDescriptor = $convert.base64Decode(
+    'Cg9BZGRJbnZvaWNlUmVwbHkSJgoOcGF5bWVudFJlcXVlc3QYASABKAlSDnBheW1lbnRSZXF1ZXN0EhcKB2xzcF9mZWUYAiABKANSBmxzcEZlZQ==');
 @$core.Deprecated('Use chainStatusDescriptor instead')
 const ChainStatus$json = const {
   '1': 'ChainStatus',
@@ -86,7 +101,8 @@ const ChainStatus$json = const {
 };
 
 /// Descriptor for `ChainStatus`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List chainStatusDescriptor = $convert.base64Decode('CgtDaGFpblN0YXR1cxIgCgtibG9ja0hlaWdodBgBIAEoDVILYmxvY2tIZWlnaHQSJAoNc3luY2VkVG9DaGFpbhgCIAEoCFINc3luY2VkVG9DaGFpbg==');
+final $typed_data.Uint8List chainStatusDescriptor = $convert.base64Decode(
+    'CgtDaGFpblN0YXR1cxIgCgtibG9ja0hlaWdodBgBIAEoDVILYmxvY2tIZWlnaHQSJAoNc3luY2VkVG9DaGFpbhgCIAEoCFINc3luY2VkVG9DaGFpbg==');
 @$core.Deprecated('Use accountDescriptor instead')
 const Account$json = const {
   '1': 'Account',
@@ -123,7 +139,8 @@ const Account_AccountStatus$json = const {
 };
 
 /// Descriptor for `Account`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List accountDescriptor = $convert.base64Decode('CgdBY2NvdW50Eg4KAmlkGAEgASgJUgJpZBIYCgdiYWxhbmNlGAIgASgDUgdiYWxhbmNlEiQKDXdhbGxldEJhbGFuY2UYAyABKANSDXdhbGxldEJhbGFuY2USMwoGc3RhdHVzGAQgASgOMhsuZGF0YS5BY2NvdW50LkFjY291bnRTdGF0dXNSBnN0YXR1cxIwChNtYXhBbGxvd2VkVG9SZWNlaXZlGAUgASgDUhNtYXhBbGxvd2VkVG9SZWNlaXZlEigKD21heEFsbG93ZWRUb1BheRgGIAEoA1IPbWF4QWxsb3dlZFRvUGF5EioKEG1heFBheW1lbnRBbW91bnQYByABKANSEG1heFBheW1lbnRBbW91bnQSJgoOcm91dGluZ05vZGVGZWUYCCABKANSDnJvdXRpbmdOb2RlRmVlEhgKB2VuYWJsZWQYCSABKAhSB2VuYWJsZWQSJgoObWF4Q2hhblJlc2VydmUYCiABKANSDm1heENoYW5SZXNlcnZlEiIKDGNoYW5uZWxQb2ludBgLIAEoCVIMY2hhbm5lbFBvaW50EioKEHJlYWR5Rm9yUGF5bWVudHMYDCABKAhSEHJlYWR5Rm9yUGF5bWVudHMSHAoJdGlwSGVpZ2h0GA0gASgDUgl0aXBIZWlnaHQSJgoOY29ubmVjdGVkUGVlcnMYDiADKAlSDmNvbm5lY3RlZFBlZXJzEjIKFW1heF9pbmJvdW5kX2xpcXVpZGl0eRgPIAEoA1ITbWF4SW5ib3VuZExpcXVpZGl0eRIxChR1bmNvbmZpcm1lZF9jaGFubmVscxgQIAMoCVITdW5jb25maXJtZWRDaGFubmVscyJjCg1BY2NvdW50U3RhdHVzEhAKDERJU0NPTk5FQ1RFRBAAEhkKFVBST0NFU1NJTkdfQ09OTkVDVElPThABEhYKEkNMT1NJTkdfQ09OTkVDVElPThACEg0KCUNPTk5FQ1RFRBAD');
+final $typed_data.Uint8List accountDescriptor = $convert.base64Decode(
+    'CgdBY2NvdW50Eg4KAmlkGAEgASgJUgJpZBIYCgdiYWxhbmNlGAIgASgDUgdiYWxhbmNlEiQKDXdhbGxldEJhbGFuY2UYAyABKANSDXdhbGxldEJhbGFuY2USMwoGc3RhdHVzGAQgASgOMhsuZGF0YS5BY2NvdW50LkFjY291bnRTdGF0dXNSBnN0YXR1cxIwChNtYXhBbGxvd2VkVG9SZWNlaXZlGAUgASgDUhNtYXhBbGxvd2VkVG9SZWNlaXZlEigKD21heEFsbG93ZWRUb1BheRgGIAEoA1IPbWF4QWxsb3dlZFRvUGF5EioKEG1heFBheW1lbnRBbW91bnQYByABKANSEG1heFBheW1lbnRBbW91bnQSJgoOcm91dGluZ05vZGVGZWUYCCABKANSDnJvdXRpbmdOb2RlRmVlEhgKB2VuYWJsZWQYCSABKAhSB2VuYWJsZWQSJgoObWF4Q2hhblJlc2VydmUYCiABKANSDm1heENoYW5SZXNlcnZlEiIKDGNoYW5uZWxQb2ludBgLIAEoCVIMY2hhbm5lbFBvaW50EioKEHJlYWR5Rm9yUGF5bWVudHMYDCABKAhSEHJlYWR5Rm9yUGF5bWVudHMSHAoJdGlwSGVpZ2h0GA0gASgDUgl0aXBIZWlnaHQSJgoOY29ubmVjdGVkUGVlcnMYDiADKAlSDmNvbm5lY3RlZFBlZXJzEjIKFW1heF9pbmJvdW5kX2xpcXVpZGl0eRgPIAEoA1ITbWF4SW5ib3VuZExpcXVpZGl0eRIxChR1bmNvbmZpcm1lZF9jaGFubmVscxgQIAMoCVITdW5jb25maXJtZWRDaGFubmVscyJjCg1BY2NvdW50U3RhdHVzEhAKDERJU0NPTk5FQ1RFRBAAEhkKFVBST0NFU1NJTkdfQ09OTkVDVElPThABEhYKEkNMT1NJTkdfQ09OTkVDVElPThACEg0KCUNPTk5FQ1RFRBAD');
 @$core.Deprecated('Use paymentDescriptor instead')
 const Payment$json = const {
   '1': 'Payment',
@@ -167,7 +184,8 @@ const Payment_PaymentType$json = const {
 };
 
 /// Descriptor for `Payment`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List paymentDescriptor = $convert.base64Decode('CgdQYXltZW50Ei0KBHR5cGUYASABKA4yGS5kYXRhLlBheW1lbnQuUGF5bWVudFR5cGVSBHR5cGUSFgoGYW1vdW50GAMgASgDUgZhbW91bnQSLAoRY3JlYXRpb25UaW1lc3RhbXAYBCABKANSEWNyZWF0aW9uVGltZXN0YW1wEjMKC2ludm9pY2VNZW1vGAYgASgLMhEuZGF0YS5JbnZvaWNlTWVtb1ILaW52b2ljZU1lbW8SHgoKcmVkZWVtVHhJRBgHIAEoCVIKcmVkZWVtVHhJRBIgCgtwYXltZW50SGFzaBgIIAEoCVILcGF5bWVudEhhc2gSIAoLZGVzdGluYXRpb24YCSABKAlSC2Rlc3RpbmF0aW9uEjgKF1BlbmRpbmdFeHBpcmF0aW9uSGVpZ2h0GAogASgNUhdQZW5kaW5nRXhwaXJhdGlvbkhlaWdodBI+ChpQZW5kaW5nRXhwaXJhdGlvblRpbWVzdGFtcBgLIAEoA1IaUGVuZGluZ0V4cGlyYXRpb25UaW1lc3RhbXASEAoDZmVlGAwgASgDUgNmZWUSGgoIcHJlaW1hZ2UYDSABKAlSCHByZWltYWdlEi4KEmNsb3NlZENoYW5uZWxQb2ludBgOIAEoCVISY2xvc2VkQ2hhbm5lbFBvaW50EioKEGlzQ2hhbm5lbFBlbmRpbmcYDyABKAhSEGlzQ2hhbm5lbFBlbmRpbmcSNgoWaXNDaGFubmVsQ2xvc2VDb25maW1lZBgQIAEoCFIWaXNDaGFubmVsQ2xvc2VDb25maW1lZBIsChFjbG9zZWRDaGFubmVsVHhJRBgRIAEoCVIRY2xvc2VkQ2hhbm5lbFR4SUQSHAoJaXNLZXlTZW5kGBIgASgIUglpc0tleVNlbmQSIAoLUGVuZGluZ0Z1bGwYEyABKAhSC1BlbmRpbmdGdWxsEjgKF2Nsb3NlZENoYW5uZWxSZW1vdGVUeElEGBQgASgJUhdjbG9zZWRDaGFubmVsUmVtb3RlVHhJRBI2ChZjbG9zZWRDaGFubmVsU3dlZXBUeElEGBUgASgJUhZjbG9zZWRDaGFubmVsU3dlZXBUeElEEhoKCGdyb3VwS2V5GBYgASgJUghncm91cEtleRIcCglncm91cE5hbWUYFyABKAlSCWdyb3VwTmFtZRI2CgxsbnVybFBheUluZm8YGCABKAsyEi5kYXRhLkxOVXJsUGF5SW5mb1IMbG51cmxQYXlJbmZvIlYKC1BheW1lbnRUeXBlEgsKB0RFUE9TSVQQABIOCgpXSVRIRFJBV0FMEAESCAoEU0VOVBACEgwKCFJFQ0VJVkVEEAMSEgoOQ0xPU0VEX0NIQU5ORUwQBA==');
+final $typed_data.Uint8List paymentDescriptor = $convert.base64Decode(
+    'CgdQYXltZW50Ei0KBHR5cGUYASABKA4yGS5kYXRhLlBheW1lbnQuUGF5bWVudFR5cGVSBHR5cGUSFgoGYW1vdW50GAMgASgDUgZhbW91bnQSLAoRY3JlYXRpb25UaW1lc3RhbXAYBCABKANSEWNyZWF0aW9uVGltZXN0YW1wEjMKC2ludm9pY2VNZW1vGAYgASgLMhEuZGF0YS5JbnZvaWNlTWVtb1ILaW52b2ljZU1lbW8SHgoKcmVkZWVtVHhJRBgHIAEoCVIKcmVkZWVtVHhJRBIgCgtwYXltZW50SGFzaBgIIAEoCVILcGF5bWVudEhhc2gSIAoLZGVzdGluYXRpb24YCSABKAlSC2Rlc3RpbmF0aW9uEjgKF1BlbmRpbmdFeHBpcmF0aW9uSGVpZ2h0GAogASgNUhdQZW5kaW5nRXhwaXJhdGlvbkhlaWdodBI+ChpQZW5kaW5nRXhwaXJhdGlvblRpbWVzdGFtcBgLIAEoA1IaUGVuZGluZ0V4cGlyYXRpb25UaW1lc3RhbXASEAoDZmVlGAwgASgDUgNmZWUSGgoIcHJlaW1hZ2UYDSABKAlSCHByZWltYWdlEi4KEmNsb3NlZENoYW5uZWxQb2ludBgOIAEoCVISY2xvc2VkQ2hhbm5lbFBvaW50EioKEGlzQ2hhbm5lbFBlbmRpbmcYDyABKAhSEGlzQ2hhbm5lbFBlbmRpbmcSNgoWaXNDaGFubmVsQ2xvc2VDb25maW1lZBgQIAEoCFIWaXNDaGFubmVsQ2xvc2VDb25maW1lZBIsChFjbG9zZWRDaGFubmVsVHhJRBgRIAEoCVIRY2xvc2VkQ2hhbm5lbFR4SUQSHAoJaXNLZXlTZW5kGBIgASgIUglpc0tleVNlbmQSIAoLUGVuZGluZ0Z1bGwYEyABKAhSC1BlbmRpbmdGdWxsEjgKF2Nsb3NlZENoYW5uZWxSZW1vdGVUeElEGBQgASgJUhdjbG9zZWRDaGFubmVsUmVtb3RlVHhJRBI2ChZjbG9zZWRDaGFubmVsU3dlZXBUeElEGBUgASgJUhZjbG9zZWRDaGFubmVsU3dlZXBUeElEEhoKCGdyb3VwS2V5GBYgASgJUghncm91cEtleRIcCglncm91cE5hbWUYFyABKAlSCWdyb3VwTmFtZRI2CgxsbnVybFBheUluZm8YGCABKAsyEi5kYXRhLkxOVXJsUGF5SW5mb1IMbG51cmxQYXlJbmZvIlYKC1BheW1lbnRUeXBlEgsKB0RFUE9TSVQQABIOCgpXSVRIRFJBV0FMEAESCAoEU0VOVBACEgwKCFJFQ0VJVkVEEAMSEgoOQ0xPU0VEX0NIQU5ORUwQBA==');
 @$core.Deprecated('Use paymentsListDescriptor instead')
 const PaymentsList$json = const {
   '1': 'PaymentsList',
@@ -177,7 +195,8 @@ const PaymentsList$json = const {
 };
 
 /// Descriptor for `PaymentsList`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List paymentsListDescriptor = $convert.base64Decode('CgxQYXltZW50c0xpc3QSMQoMcGF5bWVudHNMaXN0GAEgAygLMg0uZGF0YS5QYXltZW50UgxwYXltZW50c0xpc3Q=');
+final $typed_data.Uint8List paymentsListDescriptor = $convert
+    .base64Decode('CgxQYXltZW50c0xpc3QSMQoMcGF5bWVudHNMaXN0GAEgAygLMg0uZGF0YS5QYXltZW50UgxwYXltZW50c0xpc3Q=');
 @$core.Deprecated('Use paymentResponseDescriptor instead')
 const PaymentResponse$json = const {
   '1': 'PaymentResponse',
@@ -188,7 +207,8 @@ const PaymentResponse$json = const {
 };
 
 /// Descriptor for `PaymentResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List paymentResponseDescriptor = $convert.base64Decode('Cg9QYXltZW50UmVzcG9uc2USIgoMcGF5bWVudEVycm9yGAEgASgJUgxwYXltZW50RXJyb3ISIAoLdHJhY2VSZXBvcnQYAiABKAlSC3RyYWNlUmVwb3J0');
+final $typed_data.Uint8List paymentResponseDescriptor = $convert.base64Decode(
+    'Cg9QYXltZW50UmVzcG9uc2USIgoMcGF5bWVudEVycm9yGAEgASgJUgxwYXltZW50RXJyb3ISIAoLdHJhY2VSZXBvcnQYAiABKAlSC3RyYWNlUmVwb3J0');
 @$core.Deprecated('Use sendWalletCoinsRequestDescriptor instead')
 const SendWalletCoinsRequest$json = const {
   '1': 'SendWalletCoinsRequest',
@@ -199,7 +219,8 @@ const SendWalletCoinsRequest$json = const {
 };
 
 /// Descriptor for `SendWalletCoinsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List sendWalletCoinsRequestDescriptor = $convert.base64Decode('ChZTZW5kV2FsbGV0Q29pbnNSZXF1ZXN0EhgKB2FkZHJlc3MYASABKAlSB2FkZHJlc3MSJAoNc2F0UGVyQnl0ZUZlZRgCIAEoA1INc2F0UGVyQnl0ZUZlZQ==');
+final $typed_data.Uint8List sendWalletCoinsRequestDescriptor = $convert.base64Decode(
+    'ChZTZW5kV2FsbGV0Q29pbnNSZXF1ZXN0EhgKB2FkZHJlc3MYASABKAlSB2FkZHJlc3MSJAoNc2F0UGVyQnl0ZUZlZRgCIAEoA1INc2F0UGVyQnl0ZUZlZQ==');
 @$core.Deprecated('Use payInvoiceRequestDescriptor instead')
 const PayInvoiceRequest$json = const {
   '1': 'PayInvoiceRequest',
@@ -211,7 +232,8 @@ const PayInvoiceRequest$json = const {
 };
 
 /// Descriptor for `PayInvoiceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List payInvoiceRequestDescriptor = $convert.base64Decode('ChFQYXlJbnZvaWNlUmVxdWVzdBIWCgZhbW91bnQYASABKANSBmFtb3VudBImCg5wYXltZW50UmVxdWVzdBgCIAEoCVIOcGF5bWVudFJlcXVlc3QSEAoDZmVlGAMgASgDUgNmZWU=');
+final $typed_data.Uint8List payInvoiceRequestDescriptor = $convert.base64Decode(
+    'ChFQYXlJbnZvaWNlUmVxdWVzdBIWCgZhbW91bnQYASABKANSBmFtb3VudBImCg5wYXltZW50UmVxdWVzdBgCIAEoCVIOcGF5bWVudFJlcXVlc3QSEAoDZmVlGAMgASgDUgNmZWU=');
 @$core.Deprecated('Use spontaneousPaymentRequestDescriptor instead')
 const SpontaneousPaymentRequest$json = const {
   '1': 'SpontaneousPaymentRequest',
@@ -238,7 +260,8 @@ const SpontaneousPaymentRequest_TlvEntry$json = const {
 };
 
 /// Descriptor for `SpontaneousPaymentRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List spontaneousPaymentRequestDescriptor = $convert.base64Decode('ChlTcG9udGFuZW91c1BheW1lbnRSZXF1ZXN0EhYKBmFtb3VudBgBIAEoA1IGYW1vdW50EhoKCGRlc3ROb2RlGAIgASgJUghkZXN0Tm9kZRIgCgtkZXNjcmlwdGlvbhgDIAEoCVILZGVzY3JpcHRpb24SGgoIZ3JvdXBLZXkYBCABKAlSCGdyb3VwS2V5EhwKCWdyb3VwTmFtZRgFIAEoCVIJZ3JvdXBOYW1lEiIKDGZlZUxpbWl0TXNhdBgGIAEoA1IMZmVlTGltaXRNc2F0EjoKA3RsdhgHIAMoCzIoLmRhdGEuU3BvbnRhbmVvdXNQYXltZW50UmVxdWVzdC5UbHZFbnRyeVIDdGx2GjYKCFRsdkVudHJ5EhAKA2tleRgBIAEoA1IDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAE=');
+final $typed_data.Uint8List spontaneousPaymentRequestDescriptor = $convert.base64Decode(
+    'ChlTcG9udGFuZW91c1BheW1lbnRSZXF1ZXN0EhYKBmFtb3VudBgBIAEoA1IGYW1vdW50EhoKCGRlc3ROb2RlGAIgASgJUghkZXN0Tm9kZRIgCgtkZXNjcmlwdGlvbhgDIAEoCVILZGVzY3JpcHRpb24SGgoIZ3JvdXBLZXkYBCABKAlSCGdyb3VwS2V5EhwKCWdyb3VwTmFtZRgFIAEoCVIJZ3JvdXBOYW1lEiIKDGZlZUxpbWl0TXNhdBgGIAEoA1IMZmVlTGltaXRNc2F0EjoKA3RsdhgHIAMoCzIoLmRhdGEuU3BvbnRhbmVvdXNQYXltZW50UmVxdWVzdC5UbHZFbnRyeVIDdGx2GjYKCFRsdkVudHJ5EhAKA2tleRgBIAEoA1IDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAE=');
 @$core.Deprecated('Use invoiceMemoDescriptor instead')
 const InvoiceMemo$json = const {
   '1': 'InvoiceMemo',
@@ -256,19 +279,28 @@ const InvoiceMemo$json = const {
 };
 
 /// Descriptor for `InvoiceMemo`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List invoiceMemoDescriptor = $convert.base64Decode('CgtJbnZvaWNlTWVtbxIgCgtkZXNjcmlwdGlvbhgBIAEoCVILZGVzY3JpcHRpb24SFgoGYW1vdW50GAIgASgDUgZhbW91bnQSHAoJcGF5ZWVOYW1lGAMgASgJUglwYXllZU5hbWUSJAoNcGF5ZWVJbWFnZVVSTBgEIAEoCVINcGF5ZWVJbWFnZVVSTBIcCglwYXllck5hbWUYBSABKAlSCXBheWVyTmFtZRIkCg1wYXllckltYWdlVVJMGAYgASgJUg1wYXllckltYWdlVVJMEigKD3RyYW5zZmVyUmVxdWVzdBgHIAEoCFIPdHJhbnNmZXJSZXF1ZXN0EhYKBmV4cGlyeRgIIAEoA1IGZXhwaXJ5EhoKCHByZWltYWdlGAkgASgMUghwcmVpbWFnZQ==');
+final $typed_data.Uint8List invoiceMemoDescriptor = $convert.base64Decode(
+    'CgtJbnZvaWNlTWVtbxIgCgtkZXNjcmlwdGlvbhgBIAEoCVILZGVzY3JpcHRpb24SFgoGYW1vdW50GAIgASgDUgZhbW91bnQSHAoJcGF5ZWVOYW1lGAMgASgJUglwYXllZU5hbWUSJAoNcGF5ZWVJbWFnZVVSTBgEIAEoCVINcGF5ZWVJbWFnZVVSTBIcCglwYXllck5hbWUYBSABKAlSCXBheWVyTmFtZRIkCg1wYXllckltYWdlVVJMGAYgASgJUg1wYXllckltYWdlVVJMEigKD3RyYW5zZmVyUmVxdWVzdBgHIAEoCFIPdHJhbnNmZXJSZXF1ZXN0EhYKBmV4cGlyeRgIIAEoA1IGZXhwaXJ5EhoKCHByZWltYWdlGAkgASgMUghwcmVpbWFnZQ==');
 @$core.Deprecated('Use addInvoiceRequestDescriptor instead')
 const AddInvoiceRequest$json = const {
   '1': 'AddInvoiceRequest',
   '2': const [
     const {'1': 'invoiceDetails', '3': 1, '4': 1, '5': 11, '6': '.data.InvoiceMemo', '10': 'invoiceDetails'},
     const {'1': 'lspInfo', '3': 2, '4': 1, '5': 11, '6': '.data.LSPInformation', '10': 'lspInfo'},
-    const {'1': 'opening_fee_params', '3': 3, '4': 1, '5': 11, '6': '.data.OpeningFeeParams', '10': 'openingFeeParams'},
+    const {
+      '1': 'opening_fee_params',
+      '3': 3,
+      '4': 1,
+      '5': 11,
+      '6': '.data.OpeningFeeParams',
+      '10': 'openingFeeParams'
+    },
   ],
 };
 
 /// Descriptor for `AddInvoiceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List addInvoiceRequestDescriptor = $convert.base64Decode('ChFBZGRJbnZvaWNlUmVxdWVzdBI5Cg5pbnZvaWNlRGV0YWlscxgBIAEoCzIRLmRhdGEuSW52b2ljZU1lbW9SDmludm9pY2VEZXRhaWxzEi4KB2xzcEluZm8YAiABKAsyFC5kYXRhLkxTUEluZm9ybWF0aW9uUgdsc3BJbmZvEkQKEm9wZW5pbmdfZmVlX3BhcmFtcxgDIAEoCzIWLmRhdGEuT3BlbmluZ0ZlZVBhcmFtc1IQb3BlbmluZ0ZlZVBhcmFtcw==');
+final $typed_data.Uint8List addInvoiceRequestDescriptor = $convert.base64Decode(
+    'ChFBZGRJbnZvaWNlUmVxdWVzdBI5Cg5pbnZvaWNlRGV0YWlscxgBIAEoCzIRLmRhdGEuSW52b2ljZU1lbW9SDmludm9pY2VEZXRhaWxzEi4KB2xzcEluZm8YAiABKAsyFC5kYXRhLkxTUEluZm9ybWF0aW9uUgdsc3BJbmZvEkQKEm9wZW5pbmdfZmVlX3BhcmFtcxgDIAEoCzIWLmRhdGEuT3BlbmluZ0ZlZVBhcmFtc1IQb3BlbmluZ0ZlZVBhcmFtcw==');
 @$core.Deprecated('Use invoiceDescriptor instead')
 const Invoice$json = const {
   '1': 'Invoice',
@@ -280,7 +312,8 @@ const Invoice$json = const {
 };
 
 /// Descriptor for `Invoice`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List invoiceDescriptor = $convert.base64Decode('CgdJbnZvaWNlEiUKBG1lbW8YASABKAsyES5kYXRhLkludm9pY2VNZW1vUgRtZW1vEhgKB3NldHRsZWQYAiABKAhSB3NldHRsZWQSGAoHYW10UGFpZBgDIAEoA1IHYW10UGFpZA==');
+final $typed_data.Uint8List invoiceDescriptor = $convert.base64Decode(
+    'CgdJbnZvaWNlEiUKBG1lbW8YASABKAsyES5kYXRhLkludm9pY2VNZW1vUgRtZW1vEhgKB3NldHRsZWQYAiABKAhSB3NldHRsZWQSGAoHYW10UGFpZBgDIAEoA1IHYW10UGFpZA==');
 @$core.Deprecated('Use checkLSPClosedChannelMismatchRequestDescriptor instead')
 const CheckLSPClosedChannelMismatchRequest$json = const {
   '1': 'CheckLSPClosedChannelMismatchRequest',
@@ -291,7 +324,8 @@ const CheckLSPClosedChannelMismatchRequest$json = const {
 };
 
 /// Descriptor for `CheckLSPClosedChannelMismatchRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List checkLSPClosedChannelMismatchRequestDescriptor = $convert.base64Decode('CiRDaGVja0xTUENsb3NlZENoYW5uZWxNaXNtYXRjaFJlcXVlc3QSLgoHbHNwSW5mbxgBIAEoCzIULmRhdGEuTFNQSW5mb3JtYXRpb25SB2xzcEluZm8SHAoJY2hhblBvaW50GAIgASgJUgljaGFuUG9pbnQ=');
+final $typed_data.Uint8List checkLSPClosedChannelMismatchRequestDescriptor = $convert.base64Decode(
+    'CiRDaGVja0xTUENsb3NlZENoYW5uZWxNaXNtYXRjaFJlcXVlc3QSLgoHbHNwSW5mbxgBIAEoCzIULmRhdGEuTFNQSW5mb3JtYXRpb25SB2xzcEluZm8SHAoJY2hhblBvaW50GAIgASgJUgljaGFuUG9pbnQ=');
 @$core.Deprecated('Use checkLSPClosedChannelMismatchResponseDescriptor instead')
 const CheckLSPClosedChannelMismatchResponse$json = const {
   '1': 'CheckLSPClosedChannelMismatchResponse',
@@ -301,7 +335,8 @@ const CheckLSPClosedChannelMismatchResponse$json = const {
 };
 
 /// Descriptor for `CheckLSPClosedChannelMismatchResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List checkLSPClosedChannelMismatchResponseDescriptor = $convert.base64Decode('CiVDaGVja0xTUENsb3NlZENoYW5uZWxNaXNtYXRjaFJlc3BvbnNlEhoKCG1pc21hdGNoGAEgASgIUghtaXNtYXRjaA==');
+final $typed_data.Uint8List checkLSPClosedChannelMismatchResponseDescriptor = $convert.base64Decode(
+    'CiVDaGVja0xTUENsb3NlZENoYW5uZWxNaXNtYXRjaFJlc3BvbnNlEhoKCG1pc21hdGNoGAEgASgIUghtaXNtYXRjaA==');
 @$core.Deprecated('Use resetClosedChannelChainInfoRequestDescriptor instead')
 const ResetClosedChannelChainInfoRequest$json = const {
   '1': 'ResetClosedChannelChainInfoRequest',
@@ -312,19 +347,28 @@ const ResetClosedChannelChainInfoRequest$json = const {
 };
 
 /// Descriptor for `ResetClosedChannelChainInfoRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List resetClosedChannelChainInfoRequestDescriptor = $convert.base64Decode('CiJSZXNldENsb3NlZENoYW5uZWxDaGFpbkluZm9SZXF1ZXN0EhwKCWNoYW5Qb2ludBgBIAEoCVIJY2hhblBvaW50EiAKC2Jsb2NrSGVpZ2h0GAIgASgDUgtibG9ja0hlaWdodA==');
+final $typed_data.Uint8List resetClosedChannelChainInfoRequestDescriptor = $convert.base64Decode(
+    'CiJSZXNldENsb3NlZENoYW5uZWxDaGFpbkluZm9SZXF1ZXN0EhwKCWNoYW5Qb2ludBgBIAEoCVIJY2hhblBvaW50EiAKC2Jsb2NrSGVpZ2h0GAIgASgDUgtibG9ja0hlaWdodA==');
 @$core.Deprecated('Use resetClosedChannelChainInfoReplyDescriptor instead')
 const ResetClosedChannelChainInfoReply$json = const {
   '1': 'ResetClosedChannelChainInfoReply',
 };
 
 /// Descriptor for `ResetClosedChannelChainInfoReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List resetClosedChannelChainInfoReplyDescriptor = $convert.base64Decode('CiBSZXNldENsb3NlZENoYW5uZWxDaGFpbkluZm9SZXBseQ==');
+final $typed_data.Uint8List resetClosedChannelChainInfoReplyDescriptor =
+    $convert.base64Decode('CiBSZXNldENsb3NlZENoYW5uZWxDaGFpbkluZm9SZXBseQ==');
 @$core.Deprecated('Use notificationEventDescriptor instead')
 const NotificationEvent$json = const {
   '1': 'NotificationEvent',
   '2': const [
-    const {'1': 'type', '3': 1, '4': 1, '5': 14, '6': '.data.NotificationEvent.NotificationType', '10': 'type'},
+    const {
+      '1': 'type',
+      '3': 1,
+      '4': 1,
+      '5': 14,
+      '6': '.data.NotificationEvent.NotificationType',
+      '10': 'type'
+    },
     const {'1': 'data', '3': 2, '4': 3, '5': 9, '10': 'data'},
   ],
   '4': const [NotificationEvent_NotificationType$json],
@@ -359,7 +403,8 @@ const NotificationEvent_NotificationType$json = const {
 };
 
 /// Descriptor for `NotificationEvent`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List notificationEventDescriptor = $convert.base64Decode('ChFOb3RpZmljYXRpb25FdmVudBI8CgR0eXBlGAEgASgOMiguZGF0YS5Ob3RpZmljYXRpb25FdmVudC5Ob3RpZmljYXRpb25UeXBlUgR0eXBlEhIKBGRhdGEYAiADKAlSBGRhdGEinAQKEE5vdGlmaWNhdGlvblR5cGUSCQoFUkVBRFkQABIZChVJTklUSUFMSVpBVElPTl9GQUlMRUQQARITCg9BQ0NPVU5UX0NIQU5HRUQQAhIQCgxQQVlNRU5UX1NFTlQQAxIQCgxJTlZPSUNFX1BBSUQQBBIaChZMSUdIVE5JTkdfU0VSVklDRV9ET1dOEAUSGAoURlVORF9BRERSRVNTX0NSRUFURUQQBhIgChxGVU5EX0FERFJFU1NfVU5TUEVOVF9DSEFOR0VEEAcSEgoOQkFDS1VQX1NVQ0NFU1MQCBIRCg1CQUNLVVBfRkFJTEVEEAkSFgoSQkFDS1VQX0FVVEhfRkFJTEVEEAoSGAoUQkFDS1VQX05PREVfQ09ORkxJQ1QQCxISCg5CQUNLVVBfUkVRVUVTVBAMEhIKDlBBWU1FTlRfRkFJTEVEEA0SFQoRUEFZTUVOVF9TVUNDRUVERUQQDhIeChpSRVZFUlNFX1NXQVBfQ0xBSU1fU1RBUlRFRBAPEiAKHFJFVkVSU0VfU1dBUF9DTEFJTV9TVUNDRUVERUQQEBIdChlSRVZFUlNFX1NXQVBfQ0xBSU1fRkFJTEVEEBESIAocUkVWRVJTRV9TV0FQX0NMQUlNX0NPTkZJUk1FRBASEhYKEkxTUF9DSEFOTkVMX09QRU5FRBATEh4KGkJBQ0tVUF9OT1RfTEFURVNUX0NPTkZMSUNUEBQ=');
+final $typed_data.Uint8List notificationEventDescriptor = $convert.base64Decode(
+    'ChFOb3RpZmljYXRpb25FdmVudBI8CgR0eXBlGAEgASgOMiguZGF0YS5Ob3RpZmljYXRpb25FdmVudC5Ob3RpZmljYXRpb25UeXBlUgR0eXBlEhIKBGRhdGEYAiADKAlSBGRhdGEinAQKEE5vdGlmaWNhdGlvblR5cGUSCQoFUkVBRFkQABIZChVJTklUSUFMSVpBVElPTl9GQUlMRUQQARITCg9BQ0NPVU5UX0NIQU5HRUQQAhIQCgxQQVlNRU5UX1NFTlQQAxIQCgxJTlZPSUNFX1BBSUQQBBIaChZMSUdIVE5JTkdfU0VSVklDRV9ET1dOEAUSGAoURlVORF9BRERSRVNTX0NSRUFURUQQBhIgChxGVU5EX0FERFJFU1NfVU5TUEVOVF9DSEFOR0VEEAcSEgoOQkFDS1VQX1NVQ0NFU1MQCBIRCg1CQUNLVVBfRkFJTEVEEAkSFgoSQkFDS1VQX0FVVEhfRkFJTEVEEAoSGAoUQkFDS1VQX05PREVfQ09ORkxJQ1QQCxISCg5CQUNLVVBfUkVRVUVTVBAMEhIKDlBBWU1FTlRfRkFJTEVEEA0SFQoRUEFZTUVOVF9TVUNDRUVERUQQDhIeChpSRVZFUlNFX1NXQVBfQ0xBSU1fU1RBUlRFRBAPEiAKHFJFVkVSU0VfU1dBUF9DTEFJTV9TVUNDRUVERUQQEBIdChlSRVZFUlNFX1NXQVBfQ0xBSU1fRkFJTEVEEBESIAocUkVWRVJTRV9TV0FQX0NMQUlNX0NPTkZJUk1FRBASEhYKEkxTUF9DSEFOTkVMX09QRU5FRBATEh4KGkJBQ0tVUF9OT1RfTEFURVNUX0NPTkZMSUNUEBQ=');
 @$core.Deprecated('Use addFundInitReplyDescriptor instead')
 const AddFundInitReply$json = const {
   '1': 'AddFundInitReply',
@@ -374,7 +419,8 @@ const AddFundInitReply$json = const {
 };
 
 /// Descriptor for `AddFundInitReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List addFundInitReplyDescriptor = $convert.base64Decode('ChBBZGRGdW5kSW5pdFJlcGx5EhgKB2FkZHJlc3MYASABKAlSB2FkZHJlc3MSLAoRbWF4QWxsb3dlZERlcG9zaXQYAiABKANSEW1heEFsbG93ZWREZXBvc2l0EiIKDGVycm9yTWVzc2FnZRgDIAEoCVIMZXJyb3JNZXNzYWdlEh4KCmJhY2t1cEpzb24YBCABKAlSCmJhY2t1cEpzb24SKAoPcmVxdWlyZWRSZXNlcnZlGAUgASgDUg9yZXF1aXJlZFJlc2VydmUSLAoRbWluQWxsb3dlZERlcG9zaXQYBiABKANSEW1pbkFsbG93ZWREZXBvc2l0');
+final $typed_data.Uint8List addFundInitReplyDescriptor = $convert.base64Decode(
+    'ChBBZGRGdW5kSW5pdFJlcGx5EhgKB2FkZHJlc3MYASABKAlSB2FkZHJlc3MSLAoRbWF4QWxsb3dlZERlcG9zaXQYAiABKANSEW1heEFsbG93ZWREZXBvc2l0EiIKDGVycm9yTWVzc2FnZRgDIAEoCVIMZXJyb3JNZXNzYWdlEh4KCmJhY2t1cEpzb24YBCABKAlSCmJhY2t1cEpzb24SKAoPcmVxdWlyZWRSZXNlcnZlGAUgASgDUg9yZXF1aXJlZFJlc2VydmUSLAoRbWluQWxsb3dlZERlcG9zaXQYBiABKANSEW1pbkFsbG93ZWREZXBvc2l0');
 @$core.Deprecated('Use addFundReplyDescriptor instead')
 const AddFundReply$json = const {
   '1': 'AddFundReply',
@@ -384,7 +430,8 @@ const AddFundReply$json = const {
 };
 
 /// Descriptor for `AddFundReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List addFundReplyDescriptor = $convert.base64Decode('CgxBZGRGdW5kUmVwbHkSIgoMZXJyb3JNZXNzYWdlGAEgASgJUgxlcnJvck1lc3NhZ2U=');
+final $typed_data.Uint8List addFundReplyDescriptor =
+    $convert.base64Decode('CgxBZGRGdW5kUmVwbHkSIgoMZXJyb3JNZXNzYWdlGAEgASgJUgxlcnJvck1lc3NhZ2U=');
 @$core.Deprecated('Use refundRequestDescriptor instead')
 const RefundRequest$json = const {
   '1': 'RefundRequest',
@@ -397,30 +444,61 @@ const RefundRequest$json = const {
 };
 
 /// Descriptor for `RefundRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List refundRequestDescriptor = $convert.base64Decode('Cg1SZWZ1bmRSZXF1ZXN0EhgKB2FkZHJlc3MYASABKAlSB2FkZHJlc3MSJAoNcmVmdW5kQWRkcmVzcxgCIAEoCVINcmVmdW5kQWRkcmVzcxIfCgt0YXJnZXRfY29uZhgDIAEoBVIKdGFyZ2V0Q29uZhIgCgxzYXRfcGVyX2J5dGUYBCABKANSCnNhdFBlckJ5dGU=');
+final $typed_data.Uint8List refundRequestDescriptor = $convert.base64Decode(
+    'Cg1SZWZ1bmRSZXF1ZXN0EhgKB2FkZHJlc3MYASABKAlSB2FkZHJlc3MSJAoNcmVmdW5kQWRkcmVzcxgCIAEoCVINcmVmdW5kQWRkcmVzcxIfCgt0YXJnZXRfY29uZhgDIAEoBVIKdGFyZ2V0Q29uZhIgCgxzYXRfcGVyX2J5dGUYBCABKANSCnNhdFBlckJ5dGU=');
 @$core.Deprecated('Use addFundErrorDescriptor instead')
 const AddFundError$json = const {
   '1': 'AddFundError',
   '2': const [
-    const {'1': 'swapAddressInfo', '3': 1, '4': 1, '5': 11, '6': '.data.SwapAddressInfo', '10': 'swapAddressInfo'},
+    const {
+      '1': 'swapAddressInfo',
+      '3': 1,
+      '4': 1,
+      '5': 11,
+      '6': '.data.SwapAddressInfo',
+      '10': 'swapAddressInfo'
+    },
     const {'1': 'hoursToUnlock', '3': 2, '4': 1, '5': 2, '10': 'hoursToUnlock'},
   ],
 };
 
 /// Descriptor for `AddFundError`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List addFundErrorDescriptor = $convert.base64Decode('CgxBZGRGdW5kRXJyb3ISPwoPc3dhcEFkZHJlc3NJbmZvGAEgASgLMhUuZGF0YS5Td2FwQWRkcmVzc0luZm9SD3N3YXBBZGRyZXNzSW5mbxIkCg1ob3Vyc1RvVW5sb2NrGAIgASgCUg1ob3Vyc1RvVW5sb2Nr');
+final $typed_data.Uint8List addFundErrorDescriptor = $convert.base64Decode(
+    'CgxBZGRGdW5kRXJyb3ISPwoPc3dhcEFkZHJlc3NJbmZvGAEgASgLMhUuZGF0YS5Td2FwQWRkcmVzc0luZm9SD3N3YXBBZGRyZXNzSW5mbxIkCg1ob3Vyc1RvVW5sb2NrGAIgASgCUg1ob3Vyc1RvVW5sb2Nr');
 @$core.Deprecated('Use fundStatusReplyDescriptor instead')
 const FundStatusReply$json = const {
   '1': 'FundStatusReply',
   '2': const [
-    const {'1': 'unConfirmedAddresses', '3': 1, '4': 3, '5': 11, '6': '.data.SwapAddressInfo', '10': 'unConfirmedAddresses'},
-    const {'1': 'confirmedAddresses', '3': 2, '4': 3, '5': 11, '6': '.data.SwapAddressInfo', '10': 'confirmedAddresses'},
-    const {'1': 'refundableAddresses', '3': 3, '4': 3, '5': 11, '6': '.data.SwapAddressInfo', '10': 'refundableAddresses'},
+    const {
+      '1': 'unConfirmedAddresses',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.data.SwapAddressInfo',
+      '10': 'unConfirmedAddresses'
+    },
+    const {
+      '1': 'confirmedAddresses',
+      '3': 2,
+      '4': 3,
+      '5': 11,
+      '6': '.data.SwapAddressInfo',
+      '10': 'confirmedAddresses'
+    },
+    const {
+      '1': 'refundableAddresses',
+      '3': 3,
+      '4': 3,
+      '5': 11,
+      '6': '.data.SwapAddressInfo',
+      '10': 'refundableAddresses'
+    },
   ],
 };
 
 /// Descriptor for `FundStatusReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List fundStatusReplyDescriptor = $convert.base64Decode('Cg9GdW5kU3RhdHVzUmVwbHkSSQoUdW5Db25maXJtZWRBZGRyZXNzZXMYASADKAsyFS5kYXRhLlN3YXBBZGRyZXNzSW5mb1IUdW5Db25maXJtZWRBZGRyZXNzZXMSRQoSY29uZmlybWVkQWRkcmVzc2VzGAIgAygLMhUuZGF0YS5Td2FwQWRkcmVzc0luZm9SEmNvbmZpcm1lZEFkZHJlc3NlcxJHChNyZWZ1bmRhYmxlQWRkcmVzc2VzGAMgAygLMhUuZGF0YS5Td2FwQWRkcmVzc0luZm9SE3JlZnVuZGFibGVBZGRyZXNzZXM=');
+final $typed_data.Uint8List fundStatusReplyDescriptor = $convert.base64Decode(
+    'Cg9GdW5kU3RhdHVzUmVwbHkSSQoUdW5Db25maXJtZWRBZGRyZXNzZXMYASADKAsyFS5kYXRhLlN3YXBBZGRyZXNzSW5mb1IUdW5Db25maXJtZWRBZGRyZXNzZXMSRQoSY29uZmlybWVkQWRkcmVzc2VzGAIgAygLMhUuZGF0YS5Td2FwQWRkcmVzc0luZm9SEmNvbmZpcm1lZEFkZHJlc3NlcxJHChNyZWZ1bmRhYmxlQWRkcmVzc2VzGAMgAygLMhUuZGF0YS5Td2FwQWRkcmVzc0luZm9SE3JlZnVuZGFibGVBZGRyZXNzZXM=');
 @$core.Deprecated('Use removeFundRequestDescriptor instead')
 const RemoveFundRequest$json = const {
   '1': 'RemoveFundRequest',
@@ -431,7 +509,8 @@ const RemoveFundRequest$json = const {
 };
 
 /// Descriptor for `RemoveFundRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removeFundRequestDescriptor = $convert.base64Decode('ChFSZW1vdmVGdW5kUmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEhYKBmFtb3VudBgCIAEoA1IGYW1vdW50');
+final $typed_data.Uint8List removeFundRequestDescriptor = $convert.base64Decode(
+    'ChFSZW1vdmVGdW5kUmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEhYKBmFtb3VudBgCIAEoA1IGYW1vdW50');
 @$core.Deprecated('Use removeFundReplyDescriptor instead')
 const RemoveFundReply$json = const {
   '1': 'RemoveFundReply',
@@ -442,7 +521,8 @@ const RemoveFundReply$json = const {
 };
 
 /// Descriptor for `RemoveFundReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List removeFundReplyDescriptor = $convert.base64Decode('Cg9SZW1vdmVGdW5kUmVwbHkSEgoEdHhpZBgBIAEoCVIEdHhpZBIiCgxlcnJvck1lc3NhZ2UYAiABKAlSDGVycm9yTWVzc2FnZQ==');
+final $typed_data.Uint8List removeFundReplyDescriptor = $convert.base64Decode(
+    'Cg9SZW1vdmVGdW5kUmVwbHkSEgoEdHhpZBgBIAEoCVIEdHhpZBIiCgxlcnJvck1lc3NhZ2UYAiABKAlSDGVycm9yTWVzc2FnZQ==');
 @$core.Deprecated('Use swapAddressInfoDescriptor instead')
 const SwapAddressInfo$json = const {
   '1': 'SwapAddressInfo',
@@ -463,7 +543,8 @@ const SwapAddressInfo$json = const {
 };
 
 /// Descriptor for `SwapAddressInfo`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List swapAddressInfoDescriptor = $convert.base64Decode('Cg9Td2FwQWRkcmVzc0luZm8SGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIgCgtQYXltZW50SGFzaBgCIAEoCVILUGF5bWVudEhhc2gSKAoPQ29uZmlybWVkQW1vdW50GAMgASgDUg9Db25maXJtZWRBbW91bnQSOAoXQ29uZmlybWVkVHJhbnNhY3Rpb25JZHMYBCADKAlSF0NvbmZpcm1lZFRyYW5zYWN0aW9uSWRzEh4KClBhaWRBbW91bnQYBSABKANSClBhaWRBbW91bnQSHgoKbG9ja0hlaWdodBgGIAEoDVIKbG9ja0hlaWdodBIiCgxlcnJvck1lc3NhZ2UYByABKAlSDGVycm9yTWVzc2FnZRImCg5sYXN0UmVmdW5kVHhJRBgIIAEoCVIObGFzdFJlZnVuZFR4SUQSLQoJc3dhcEVycm9yGAkgASgOMg8uZGF0YS5Td2FwRXJyb3JSCXN3YXBFcnJvchIgCgtGdW5kaW5nVHhJRBgKIAEoCVILRnVuZGluZ1R4SUQSJAoNaG91cnNUb1VubG9jaxgLIAEoAlINaG91cnNUb1VubG9jaxIgCgtub25CbG9ja2luZxgMIAEoCFILbm9uQmxvY2tpbmc=');
+final $typed_data.Uint8List swapAddressInfoDescriptor = $convert.base64Decode(
+    'Cg9Td2FwQWRkcmVzc0luZm8SGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIgCgtQYXltZW50SGFzaBgCIAEoCVILUGF5bWVudEhhc2gSKAoPQ29uZmlybWVkQW1vdW50GAMgASgDUg9Db25maXJtZWRBbW91bnQSOAoXQ29uZmlybWVkVHJhbnNhY3Rpb25JZHMYBCADKAlSF0NvbmZpcm1lZFRyYW5zYWN0aW9uSWRzEh4KClBhaWRBbW91bnQYBSABKANSClBhaWRBbW91bnQSHgoKbG9ja0hlaWdodBgGIAEoDVIKbG9ja0hlaWdodBIiCgxlcnJvck1lc3NhZ2UYByABKAlSDGVycm9yTWVzc2FnZRImCg5sYXN0UmVmdW5kVHhJRBgIIAEoCVIObGFzdFJlZnVuZFR4SUQSLQoJc3dhcEVycm9yGAkgASgOMg8uZGF0YS5Td2FwRXJyb3JSCXN3YXBFcnJvchIgCgtGdW5kaW5nVHhJRBgKIAEoCVILRnVuZGluZ1R4SUQSJAoNaG91cnNUb1VubG9jaxgLIAEoAlINaG91cnNUb1VubG9jaxIgCgtub25CbG9ja2luZxgMIAEoCFILbm9uQmxvY2tpbmc=');
 @$core.Deprecated('Use swapAddressListDescriptor instead')
 const SwapAddressList$json = const {
   '1': 'SwapAddressList',
@@ -473,7 +554,8 @@ const SwapAddressList$json = const {
 };
 
 /// Descriptor for `SwapAddressList`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List swapAddressListDescriptor = $convert.base64Decode('Cg9Td2FwQWRkcmVzc0xpc3QSMwoJYWRkcmVzc2VzGAEgAygLMhUuZGF0YS5Td2FwQWRkcmVzc0luZm9SCWFkZHJlc3Nlcw==');
+final $typed_data.Uint8List swapAddressListDescriptor = $convert.base64Decode(
+    'Cg9Td2FwQWRkcmVzc0xpc3QSMwoJYWRkcmVzc2VzGAEgAygLMhUuZGF0YS5Td2FwQWRkcmVzc0luZm9SCWFkZHJlc3Nlcw==');
 @$core.Deprecated('Use createRatchetSessionRequestDescriptor instead')
 const CreateRatchetSessionRequest$json = const {
   '1': 'CreateRatchetSessionRequest',
@@ -486,7 +568,8 @@ const CreateRatchetSessionRequest$json = const {
 };
 
 /// Descriptor for `CreateRatchetSessionRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createRatchetSessionRequestDescriptor = $convert.base64Decode('ChtDcmVhdGVSYXRjaGV0U2Vzc2lvblJlcXVlc3QSFgoGc2VjcmV0GAEgASgJUgZzZWNyZXQSIgoMcmVtb3RlUHViS2V5GAIgASgJUgxyZW1vdGVQdWJLZXkSHAoJc2Vzc2lvbklEGAMgASgJUglzZXNzaW9uSUQSFgoGZXhwaXJ5GAQgASgEUgZleHBpcnk=');
+final $typed_data.Uint8List createRatchetSessionRequestDescriptor = $convert.base64Decode(
+    'ChtDcmVhdGVSYXRjaGV0U2Vzc2lvblJlcXVlc3QSFgoGc2VjcmV0GAEgASgJUgZzZWNyZXQSIgoMcmVtb3RlUHViS2V5GAIgASgJUgxyZW1vdGVQdWJLZXkSHAoJc2Vzc2lvbklEGAMgASgJUglzZXNzaW9uSUQSFgoGZXhwaXJ5GAQgASgEUgZleHBpcnk=');
 @$core.Deprecated('Use createRatchetSessionReplyDescriptor instead')
 const CreateRatchetSessionReply$json = const {
   '1': 'CreateRatchetSessionReply',
@@ -498,7 +581,8 @@ const CreateRatchetSessionReply$json = const {
 };
 
 /// Descriptor for `CreateRatchetSessionReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List createRatchetSessionReplyDescriptor = $convert.base64Decode('ChlDcmVhdGVSYXRjaGV0U2Vzc2lvblJlcGx5EhwKCXNlc3Npb25JRBgBIAEoCVIJc2Vzc2lvbklEEhYKBnNlY3JldBgCIAEoCVIGc2VjcmV0EhYKBnB1YktleRgDIAEoCVIGcHViS2V5');
+final $typed_data.Uint8List createRatchetSessionReplyDescriptor = $convert.base64Decode(
+    'ChlDcmVhdGVSYXRjaGV0U2Vzc2lvblJlcGx5EhwKCXNlc3Npb25JRBgBIAEoCVIJc2Vzc2lvbklEEhYKBnNlY3JldBgCIAEoCVIGc2VjcmV0EhYKBnB1YktleRgDIAEoCVIGcHViS2V5');
 @$core.Deprecated('Use ratchetSessionInfoReplyDescriptor instead')
 const RatchetSessionInfoReply$json = const {
   '1': 'RatchetSessionInfoReply',
@@ -510,7 +594,8 @@ const RatchetSessionInfoReply$json = const {
 };
 
 /// Descriptor for `RatchetSessionInfoReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List ratchetSessionInfoReplyDescriptor = $convert.base64Decode('ChdSYXRjaGV0U2Vzc2lvbkluZm9SZXBseRIcCglzZXNzaW9uSUQYASABKAlSCXNlc3Npb25JRBIcCglpbml0aWF0ZWQYAiABKAhSCWluaXRpYXRlZBIaCgh1c2VySW5mbxgDIAEoCVIIdXNlckluZm8=');
+final $typed_data.Uint8List ratchetSessionInfoReplyDescriptor = $convert.base64Decode(
+    'ChdSYXRjaGV0U2Vzc2lvbkluZm9SZXBseRIcCglzZXNzaW9uSUQYASABKAlSCXNlc3Npb25JRBIcCglpbml0aWF0ZWQYAiABKAhSCWluaXRpYXRlZBIaCgh1c2VySW5mbxgDIAEoCVIIdXNlckluZm8=');
 @$core.Deprecated('Use ratchetSessionSetInfoRequestDescriptor instead')
 const RatchetSessionSetInfoRequest$json = const {
   '1': 'RatchetSessionSetInfoRequest',
@@ -521,7 +606,8 @@ const RatchetSessionSetInfoRequest$json = const {
 };
 
 /// Descriptor for `RatchetSessionSetInfoRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List ratchetSessionSetInfoRequestDescriptor = $convert.base64Decode('ChxSYXRjaGV0U2Vzc2lvblNldEluZm9SZXF1ZXN0EhwKCXNlc3Npb25JRBgBIAEoCVIJc2Vzc2lvbklEEhoKCHVzZXJJbmZvGAIgASgJUgh1c2VySW5mbw==');
+final $typed_data.Uint8List ratchetSessionSetInfoRequestDescriptor = $convert.base64Decode(
+    'ChxSYXRjaGV0U2Vzc2lvblNldEluZm9SZXF1ZXN0EhwKCXNlc3Npb25JRBgBIAEoCVIJc2Vzc2lvbklEEhoKCHVzZXJJbmZvGAIgASgJUgh1c2VySW5mbw==');
 @$core.Deprecated('Use ratchetEncryptRequestDescriptor instead')
 const RatchetEncryptRequest$json = const {
   '1': 'RatchetEncryptRequest',
@@ -532,7 +618,8 @@ const RatchetEncryptRequest$json = const {
 };
 
 /// Descriptor for `RatchetEncryptRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List ratchetEncryptRequestDescriptor = $convert.base64Decode('ChVSYXRjaGV0RW5jcnlwdFJlcXVlc3QSHAoJc2Vzc2lvbklEGAEgASgJUglzZXNzaW9uSUQSGAoHbWVzc2FnZRgCIAEoCVIHbWVzc2FnZQ==');
+final $typed_data.Uint8List ratchetEncryptRequestDescriptor = $convert.base64Decode(
+    'ChVSYXRjaGV0RW5jcnlwdFJlcXVlc3QSHAoJc2Vzc2lvbklEGAEgASgJUglzZXNzaW9uSUQSGAoHbWVzc2FnZRgCIAEoCVIHbWVzc2FnZQ==');
 @$core.Deprecated('Use ratchetDecryptRequestDescriptor instead')
 const RatchetDecryptRequest$json = const {
   '1': 'RatchetDecryptRequest',
@@ -543,7 +630,8 @@ const RatchetDecryptRequest$json = const {
 };
 
 /// Descriptor for `RatchetDecryptRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List ratchetDecryptRequestDescriptor = $convert.base64Decode('ChVSYXRjaGV0RGVjcnlwdFJlcXVlc3QSHAoJc2Vzc2lvbklEGAEgASgJUglzZXNzaW9uSUQSKgoQZW5jcnlwdGVkTWVzc2FnZRgCIAEoCVIQZW5jcnlwdGVkTWVzc2FnZQ==');
+final $typed_data.Uint8List ratchetDecryptRequestDescriptor = $convert.base64Decode(
+    'ChVSYXRjaGV0RGVjcnlwdFJlcXVlc3QSHAoJc2Vzc2lvbklEGAEgASgJUglzZXNzaW9uSUQSKgoQZW5jcnlwdGVkTWVzc2FnZRgCIAEoCVIQZW5jcnlwdGVkTWVzc2FnZQ==');
 @$core.Deprecated('Use bootstrapFilesRequestDescriptor instead')
 const BootstrapFilesRequest$json = const {
   '1': 'BootstrapFilesRequest',
@@ -554,7 +642,8 @@ const BootstrapFilesRequest$json = const {
 };
 
 /// Descriptor for `BootstrapFilesRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List bootstrapFilesRequestDescriptor = $convert.base64Decode('ChVCb290c3RyYXBGaWxlc1JlcXVlc3QSHgoKV29ya2luZ0RpchgBIAEoCVIKV29ya2luZ0RpchIcCglGdWxsUGF0aHMYAiADKAlSCUZ1bGxQYXRocw==');
+final $typed_data.Uint8List bootstrapFilesRequestDescriptor = $convert.base64Decode(
+    'ChVCb290c3RyYXBGaWxlc1JlcXVlc3QSHgoKV29ya2luZ0RpchgBIAEoCVIKV29ya2luZ0RpchIcCglGdWxsUGF0aHMYAiADKAlSCUZ1bGxQYXRocw==');
 @$core.Deprecated('Use peersDescriptor instead')
 const Peers$json = const {
   '1': 'Peers',
@@ -565,7 +654,8 @@ const Peers$json = const {
 };
 
 /// Descriptor for `Peers`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List peersDescriptor = $convert.base64Decode('CgVQZWVycxIcCglpc0RlZmF1bHQYASABKAhSCWlzRGVmYXVsdBISCgRwZWVyGAIgAygJUgRwZWVy');
+final $typed_data.Uint8List peersDescriptor =
+    $convert.base64Decode('CgVQZWVycxIcCglpc0RlZmF1bHQYASABKAhSCWlzRGVmYXVsdBISCgRwZWVyGAIgAygJUgRwZWVy');
 @$core.Deprecated('Use txSpentURLDescriptor instead')
 const TxSpentURL$json = const {
   '1': 'TxSpentURL',
@@ -577,7 +667,8 @@ const TxSpentURL$json = const {
 };
 
 /// Descriptor for `TxSpentURL`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List txSpentURLDescriptor = $convert.base64Decode('CgpUeFNwZW50VVJMEhAKA1VSTBgBIAEoCVIDVVJMEhwKCWlzRGVmYXVsdBgCIAEoCFIJaXNEZWZhdWx0EhoKCGRpc2FibGVkGAMgASgIUghkaXNhYmxlZA==');
+final $typed_data.Uint8List txSpentURLDescriptor = $convert.base64Decode(
+    'CgpUeFNwZW50VVJMEhAKA1VSTBgBIAEoCVIDVVJMEhwKCWlzRGVmYXVsdBgCIAEoCFIJaXNEZWZhdWx0EhoKCGRpc2FibGVkGAMgASgIUghkaXNhYmxlZA==');
 @$core.Deprecated('Use rateDescriptor instead')
 const rate$json = const {
   '1': 'rate',
@@ -588,7 +679,8 @@ const rate$json = const {
 };
 
 /// Descriptor for `rate`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List rateDescriptor = $convert.base64Decode('CgRyYXRlEhIKBGNvaW4YASABKAlSBGNvaW4SFAoFdmFsdWUYAiABKAFSBXZhbHVl');
+final $typed_data.Uint8List rateDescriptor =
+    $convert.base64Decode('CgRyYXRlEhIKBGNvaW4YASABKAlSBGNvaW4SFAoFdmFsdWUYAiABKAFSBXZhbHVl');
 @$core.Deprecated('Use ratesDescriptor instead')
 const Rates$json = const {
   '1': 'Rates',
@@ -598,7 +690,8 @@ const Rates$json = const {
 };
 
 /// Descriptor for `Rates`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List ratesDescriptor = $convert.base64Decode('CgVSYXRlcxIgCgVyYXRlcxgBIAMoCzIKLmRhdGEucmF0ZVIFcmF0ZXM=');
+final $typed_data.Uint8List ratesDescriptor =
+    $convert.base64Decode('CgVSYXRlcxIgCgVyYXRlcxgBIAMoCzIKLmRhdGEucmF0ZVIFcmF0ZXM=');
 @$core.Deprecated('Use lSPInformationDescriptor instead')
 const LSPInformation$json = const {
   '1': 'LSPInformation',
@@ -639,13 +732,28 @@ const LSPInformation$json = const {
       '8': const {'3': true},
       '10': 'channelMinimumFeeMsat',
     },
-    const {'1': 'cheapest_opening_fee_params', '3': 16, '4': 1, '5': 11, '6': '.data.OpeningFeeParams', '10': 'cheapestOpeningFeeParams'},
-    const {'1': 'longest_valid_opening_fee_params', '3': 17, '4': 1, '5': 11, '6': '.data.OpeningFeeParams', '10': 'longestValidOpeningFeeParams'},
+    const {
+      '1': 'cheapest_opening_fee_params',
+      '3': 16,
+      '4': 1,
+      '5': 11,
+      '6': '.data.OpeningFeeParams',
+      '10': 'cheapestOpeningFeeParams'
+    },
+    const {
+      '1': 'longest_valid_opening_fee_params',
+      '3': 17,
+      '4': 1,
+      '5': 11,
+      '6': '.data.OpeningFeeParams',
+      '10': 'longestValidOpeningFeeParams'
+    },
   ],
 };
 
 /// Descriptor for `LSPInformation`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List lSPInformationDescriptor = $convert.base64Decode('Cg5MU1BJbmZvcm1hdGlvbhIOCgJpZBgBIAEoCVICaWQSEgoEbmFtZRgCIAEoCVIEbmFtZRIdCgp3aWRnZXRfdXJsGAMgASgJUgl3aWRnZXRVcmwSFgoGcHVia2V5GAQgASgJUgZwdWJrZXkSEgoEaG9zdBgFIAEoCVIEaG9zdBIpChBjaGFubmVsX2NhcGFjaXR5GAYgASgDUg9jaGFubmVsQ2FwYWNpdHkSHwoLdGFyZ2V0X2NvbmYYByABKAVSCnRhcmdldENvbmYSIgoNYmFzZV9mZWVfbXNhdBgIIAEoA1ILYmFzZUZlZU1zYXQSGQoIZmVlX3JhdGUYCSABKAFSB2ZlZVJhdGUSJgoPdGltZV9sb2NrX2RlbHRhGAogASgNUg10aW1lTG9ja0RlbHRhEiIKDW1pbl9odGxjX21zYXQYCyABKANSC21pbkh0bGNNc2F0EjYKFWNoYW5uZWxfZmVlX3Blcm15cmlhZBgMIAEoA0ICGAFSE2NoYW5uZWxGZWVQZXJteXJpYWQSHQoKbHNwX3B1YmtleRgNIAEoDFIJbHNwUHVia2V5EjYKFW1heF9pbmFjdGl2ZV9kdXJhdGlvbhgOIAEoA0ICGAFSE21heEluYWN0aXZlRHVyYXRpb24SOwoYY2hhbm5lbF9taW5pbXVtX2ZlZV9tc2F0GA8gASgDQgIYAVIVY2hhbm5lbE1pbmltdW1GZWVNc2F0ElUKG2NoZWFwZXN0X29wZW5pbmdfZmVlX3BhcmFtcxgQIAEoCzIWLmRhdGEuT3BlbmluZ0ZlZVBhcmFtc1IYY2hlYXBlc3RPcGVuaW5nRmVlUGFyYW1zEl4KIGxvbmdlc3RfdmFsaWRfb3BlbmluZ19mZWVfcGFyYW1zGBEgASgLMhYuZGF0YS5PcGVuaW5nRmVlUGFyYW1zUhxsb25nZXN0VmFsaWRPcGVuaW5nRmVlUGFyYW1z');
+final $typed_data.Uint8List lSPInformationDescriptor = $convert.base64Decode(
+    'Cg5MU1BJbmZvcm1hdGlvbhIOCgJpZBgBIAEoCVICaWQSEgoEbmFtZRgCIAEoCVIEbmFtZRIdCgp3aWRnZXRfdXJsGAMgASgJUgl3aWRnZXRVcmwSFgoGcHVia2V5GAQgASgJUgZwdWJrZXkSEgoEaG9zdBgFIAEoCVIEaG9zdBIpChBjaGFubmVsX2NhcGFjaXR5GAYgASgDUg9jaGFubmVsQ2FwYWNpdHkSHwoLdGFyZ2V0X2NvbmYYByABKAVSCnRhcmdldENvbmYSIgoNYmFzZV9mZWVfbXNhdBgIIAEoA1ILYmFzZUZlZU1zYXQSGQoIZmVlX3JhdGUYCSABKAFSB2ZlZVJhdGUSJgoPdGltZV9sb2NrX2RlbHRhGAogASgNUg10aW1lTG9ja0RlbHRhEiIKDW1pbl9odGxjX21zYXQYCyABKANSC21pbkh0bGNNc2F0EjYKFWNoYW5uZWxfZmVlX3Blcm15cmlhZBgMIAEoA0ICGAFSE2NoYW5uZWxGZWVQZXJteXJpYWQSHQoKbHNwX3B1YmtleRgNIAEoDFIJbHNwUHVia2V5EjYKFW1heF9pbmFjdGl2ZV9kdXJhdGlvbhgOIAEoA0ICGAFSE21heEluYWN0aXZlRHVyYXRpb24SOwoYY2hhbm5lbF9taW5pbXVtX2ZlZV9tc2F0GA8gASgDQgIYAVIVY2hhbm5lbE1pbmltdW1GZWVNc2F0ElUKG2NoZWFwZXN0X29wZW5pbmdfZmVlX3BhcmFtcxgQIAEoCzIWLmRhdGEuT3BlbmluZ0ZlZVBhcmFtc1IYY2hlYXBlc3RPcGVuaW5nRmVlUGFyYW1zEl4KIGxvbmdlc3RfdmFsaWRfb3BlbmluZ19mZWVfcGFyYW1zGBEgASgLMhYuZGF0YS5PcGVuaW5nRmVlUGFyYW1zUhxsb25nZXN0VmFsaWRPcGVuaW5nRmVlUGFyYW1z');
 @$core.Deprecated('Use openingFeeParamsDescriptor instead')
 const OpeningFeeParams$json = const {
   '1': 'OpeningFeeParams',
@@ -660,7 +768,8 @@ const OpeningFeeParams$json = const {
 };
 
 /// Descriptor for `OpeningFeeParams`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List openingFeeParamsDescriptor = $convert.base64Decode('ChBPcGVuaW5nRmVlUGFyYW1zEhkKCG1pbl9tc2F0GAEgASgEUgdtaW5Nc2F0EiIKDHByb3BvcnRpb25hbBgCIAEoDVIMcHJvcG9ydGlvbmFsEh8KC3ZhbGlkX3VudGlsGAMgASgJUgp2YWxpZFVudGlsEiIKDW1heF9pZGxlX3RpbWUYBCABKA1SC21heElkbGVUaW1lEjYKGG1heF9jbGllbnRfdG9fc2VsZl9kZWxheRgFIAEoDVIUbWF4Q2xpZW50VG9TZWxmRGVsYXkSGAoHcHJvbWlzZRgGIAEoCVIHcHJvbWlzZQ==');
+final $typed_data.Uint8List openingFeeParamsDescriptor = $convert.base64Decode(
+    'ChBPcGVuaW5nRmVlUGFyYW1zEhkKCG1pbl9tc2F0GAEgASgEUgdtaW5Nc2F0EiIKDHByb3BvcnRpb25hbBgCIAEoDVIMcHJvcG9ydGlvbmFsEh8KC3ZhbGlkX3VudGlsGAMgASgJUgp2YWxpZFVudGlsEiIKDW1heF9pZGxlX3RpbWUYBCABKA1SC21heElkbGVUaW1lEjYKGG1heF9jbGllbnRfdG9fc2VsZl9kZWxheRgFIAEoDVIUbWF4Q2xpZW50VG9TZWxmRGVsYXkSGAoHcHJvbWlzZRgGIAEoCVIHcHJvbWlzZQ==');
 @$core.Deprecated('Use lSPListRequestDescriptor instead')
 const LSPListRequest$json = const {
   '1': 'LSPListRequest',
@@ -688,12 +797,20 @@ const LSPList_LspsEntry$json = const {
 };
 
 /// Descriptor for `LSPList`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List lSPListDescriptor = $convert.base64Decode('CgdMU1BMaXN0EisKBGxzcHMYASADKAsyFy5kYXRhLkxTUExpc3QuTHNwc0VudHJ5UgRsc3BzGk0KCUxzcHNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIqCgV2YWx1ZRgCIAEoCzIULmRhdGEuTFNQSW5mb3JtYXRpb25SBXZhbHVlOgI4AQ==');
+final $typed_data.Uint8List lSPListDescriptor = $convert.base64Decode(
+    'CgdMU1BMaXN0EisKBGxzcHMYASADKAsyFy5kYXRhLkxTUExpc3QuTHNwc0VudHJ5UgRsc3BzGk0KCUxzcHNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIqCgV2YWx1ZRgCIAEoCzIULmRhdGEuTFNQSW5mb3JtYXRpb25SBXZhbHVlOgI4AQ==');
 @$core.Deprecated('Use lSPActivityDescriptor instead')
 const LSPActivity$json = const {
   '1': 'LSPActivity',
   '2': const [
-    const {'1': 'activity', '3': 1, '4': 3, '5': 11, '6': '.data.LSPActivity.ActivityEntry', '10': 'activity'},
+    const {
+      '1': 'activity',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.data.LSPActivity.ActivityEntry',
+      '10': 'activity'
+    },
   ],
   '3': const [LSPActivity_ActivityEntry$json],
 };
@@ -709,7 +826,8 @@ const LSPActivity_ActivityEntry$json = const {
 };
 
 /// Descriptor for `LSPActivity`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List lSPActivityDescriptor = $convert.base64Decode('CgtMU1BBY3Rpdml0eRI7CghhY3Rpdml0eRgBIAMoCzIfLmRhdGEuTFNQQWN0aXZpdHkuQWN0aXZpdHlFbnRyeVIIYWN0aXZpdHkaOwoNQWN0aXZpdHlFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoA1IFdmFsdWU6AjgB');
+final $typed_data.Uint8List lSPActivityDescriptor = $convert.base64Decode(
+    'CgtMU1BBY3Rpdml0eRI7CghhY3Rpdml0eRgBIAMoCzIfLmRhdGEuTFNQQWN0aXZpdHkuQWN0aXZpdHlFbnRyeVIIYWN0aXZpdHkaOwoNQWN0aXZpdHlFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoA1IFdmFsdWU6AjgB');
 @$core.Deprecated('Use connectLSPRequestDescriptor instead')
 const ConnectLSPRequest$json = const {
   '1': 'ConnectLSPRequest',
@@ -719,7 +837,8 @@ const ConnectLSPRequest$json = const {
 };
 
 /// Descriptor for `ConnectLSPRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List connectLSPRequestDescriptor = $convert.base64Decode('ChFDb25uZWN0TFNQUmVxdWVzdBIVCgZsc3BfaWQYASABKAlSBWxzcElk');
+final $typed_data.Uint8List connectLSPRequestDescriptor =
+    $convert.base64Decode('ChFDb25uZWN0TFNQUmVxdWVzdBIVCgZsc3BfaWQYASABKAlSBWxzcElk');
 @$core.Deprecated('Use connectLSPReplyDescriptor instead')
 const ConnectLSPReply$json = const {
   '1': 'ConnectLSPReply',
@@ -734,7 +853,15 @@ const LNUrlResponse$json = const {
     const {'1': 'withdraw', '3': 1, '4': 1, '5': 11, '6': '.data.LNUrlWithdraw', '9': 0, '10': 'withdraw'},
     const {'1': 'channel', '3': 2, '4': 1, '5': 11, '6': '.data.LNURLChannel', '9': 0, '10': 'channel'},
     const {'1': 'auth', '3': 3, '4': 1, '5': 11, '6': '.data.LNURLAuth', '9': 0, '10': 'auth'},
-    const {'1': 'payResponse1', '3': 4, '4': 1, '5': 11, '6': '.data.LNURLPayResponse1', '9': 0, '10': 'payResponse1'},
+    const {
+      '1': 'payResponse1',
+      '3': 4,
+      '4': 1,
+      '5': 11,
+      '6': '.data.LNURLPayResponse1',
+      '9': 0,
+      '10': 'payResponse1'
+    },
   ],
   '8': const [
     const {'1': 'action'},
@@ -742,7 +869,8 @@ const LNUrlResponse$json = const {
 };
 
 /// Descriptor for `LNUrlResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List lNUrlResponseDescriptor = $convert.base64Decode('Cg1MTlVybFJlc3BvbnNlEjEKCHdpdGhkcmF3GAEgASgLMhMuZGF0YS5MTlVybFdpdGhkcmF3SABSCHdpdGhkcmF3Ei4KB2NoYW5uZWwYAiABKAsyEi5kYXRhLkxOVVJMQ2hhbm5lbEgAUgdjaGFubmVsEiUKBGF1dGgYAyABKAsyDy5kYXRhLkxOVVJMQXV0aEgAUgRhdXRoEj0KDHBheVJlc3BvbnNlMRgEIAEoCzIXLmRhdGEuTE5VUkxQYXlSZXNwb25zZTFIAFIMcGF5UmVzcG9uc2UxQggKBmFjdGlvbg==');
+final $typed_data.Uint8List lNUrlResponseDescriptor = $convert.base64Decode(
+    'Cg1MTlVybFJlc3BvbnNlEjEKCHdpdGhkcmF3GAEgASgLMhMuZGF0YS5MTlVybFdpdGhkcmF3SABSCHdpdGhkcmF3Ei4KB2NoYW5uZWwYAiABKAsyEi5kYXRhLkxOVVJMQ2hhbm5lbEgAUgdjaGFubmVsEiUKBGF1dGgYAyABKAsyDy5kYXRhLkxOVVJMQXV0aEgAUgRhdXRoEj0KDHBheVJlc3BvbnNlMRgEIAEoCzIXLmRhdGEuTE5VUkxQYXlSZXNwb25zZTFIAFIMcGF5UmVzcG9uc2UxQggKBmFjdGlvbg==');
 @$core.Deprecated('Use lNUrlWithdrawDescriptor instead')
 const LNUrlWithdraw$json = const {
   '1': 'LNUrlWithdraw',
@@ -754,7 +882,8 @@ const LNUrlWithdraw$json = const {
 };
 
 /// Descriptor for `LNUrlWithdraw`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List lNUrlWithdrawDescriptor = $convert.base64Decode('Cg1MTlVybFdpdGhkcmF3Eh0KCm1pbl9hbW91bnQYASABKANSCW1pbkFtb3VudBIdCgptYXhfYW1vdW50GAIgASgDUgltYXhBbW91bnQSLwoTZGVmYXVsdF9kZXNjcmlwdGlvbhgDIAEoCVISZGVmYXVsdERlc2NyaXB0aW9u');
+final $typed_data.Uint8List lNUrlWithdrawDescriptor = $convert.base64Decode(
+    'Cg1MTlVybFdpdGhkcmF3Eh0KCm1pbl9hbW91bnQYASABKANSCW1pbkFtb3VudBIdCgptYXhfYW1vdW50GAIgASgDUgltYXhBbW91bnQSLwoTZGVmYXVsdF9kZXNjcmlwdGlvbhgDIAEoCVISZGVmYXVsdERlc2NyaXB0aW9u');
 @$core.Deprecated('Use lNURLChannelDescriptor instead')
 const LNURLChannel$json = const {
   '1': 'LNURLChannel',
@@ -766,7 +895,8 @@ const LNURLChannel$json = const {
 };
 
 /// Descriptor for `LNURLChannel`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List lNURLChannelDescriptor = $convert.base64Decode('CgxMTlVSTENoYW5uZWwSDgoCazEYASABKAlSAmsxEhoKCGNhbGxiYWNrGAIgASgJUghjYWxsYmFjaxIQCgN1cmkYAyABKAlSA3VyaQ==');
+final $typed_data.Uint8List lNURLChannelDescriptor = $convert.base64Decode(
+    'CgxMTlVSTENoYW5uZWwSDgoCazEYASABKAlSAmsxEhoKCGNhbGxiYWNrGAIgASgJUghjYWxsYmFjaxIQCgN1cmkYAyABKAlSA3VyaQ==');
 @$core.Deprecated('Use lNURLAuthDescriptor instead')
 const LNURLAuth$json = const {
   '1': 'LNURLAuth',
@@ -780,7 +910,8 @@ const LNURLAuth$json = const {
 };
 
 /// Descriptor for `LNURLAuth`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List lNURLAuthDescriptor = $convert.base64Decode('CglMTlVSTEF1dGgSEAoDdGFnGAEgASgJUgN0YWcSDgoCazEYAiABKAlSAmsxEhoKCGNhbGxiYWNrGAMgASgJUghjYWxsYmFjaxISCgRob3N0GAQgASgJUgRob3N0EhAKA2p3dBgFIAEoCFIDand0');
+final $typed_data.Uint8List lNURLAuthDescriptor = $convert.base64Decode(
+    'CglMTlVSTEF1dGgSEAoDdGFnGAEgASgJUgN0YWcSDgoCazEYAiABKAlSAmsxEhoKCGNhbGxiYWNrGAMgASgJUghjYWxsYmFjaxISCgRob3N0GAQgASgJUgRob3N0EhAKA2p3dBgFIAEoCFIDand0');
 @$core.Deprecated('Use lNUrlPayImageDescriptor instead')
 const LNUrlPayImage$json = const {
   '1': 'LNUrlPayImage',
@@ -792,7 +923,8 @@ const LNUrlPayImage$json = const {
 };
 
 /// Descriptor for `LNUrlPayImage`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List lNUrlPayImageDescriptor = $convert.base64Decode('Cg1MTlVybFBheUltYWdlEhkKCGRhdGFfdXJpGAEgASgJUgdkYXRhVXJpEhAKA2V4dBgCIAEoCVIDZXh0EhQKBWJ5dGVzGAMgASgMUgVieXRlcw==');
+final $typed_data.Uint8List lNUrlPayImageDescriptor = $convert.base64Decode(
+    'Cg1MTlVybFBheUltYWdlEhkKCGRhdGFfdXJpGAEgASgJUgdkYXRhVXJpEhAKA2V4dBgCIAEoCVIDZXh0EhQKBWJ5dGVzGAMgASgMUgVieXRlcw==');
 @$core.Deprecated('Use lNUrlPayMetadataDescriptor instead')
 const LNUrlPayMetadata$json = const {
   '1': 'LNUrlPayMetadata',
@@ -805,7 +937,8 @@ const LNUrlPayMetadata$json = const {
 };
 
 /// Descriptor for `LNUrlPayMetadata`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List lNUrlPayMetadataDescriptor = $convert.base64Decode('ChBMTlVybFBheU1ldGFkYXRhEhQKBWVudHJ5GAEgAygJUgVlbnRyeRIgCgtkZXNjcmlwdGlvbhgCIAEoCVILZGVzY3JpcHRpb24SKQoQbG9uZ19kZXNjcmlwdGlvbhgDIAEoCVIPbG9uZ0Rlc2NyaXB0aW9uEikKBWltYWdlGAQgASgLMhMuZGF0YS5MTlVybFBheUltYWdlUgVpbWFnZQ==');
+final $typed_data.Uint8List lNUrlPayMetadataDescriptor = $convert.base64Decode(
+    'ChBMTlVybFBheU1ldGFkYXRhEhQKBWVudHJ5GAEgAygJUgVlbnRyeRIgCgtkZXNjcmlwdGlvbhgCIAEoCVILZGVzY3JpcHRpb24SKQoQbG9uZ19kZXNjcmlwdGlvbhgDIAEoCVIPbG9uZ0Rlc2NyaXB0aW9uEikKBWltYWdlGAQgASgLMhMuZGF0YS5MTlVybFBheUltYWdlUgVpbWFnZQ==');
 @$core.Deprecated('Use lNURLPayResponse1Descriptor instead')
 const LNURLPayResponse1$json = const {
   '1': 'LNURLPayResponse1',
@@ -825,7 +958,8 @@ const LNURLPayResponse1$json = const {
 };
 
 /// Descriptor for `LNURLPayResponse1`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List lNURLPayResponse1Descriptor = $convert.base64Decode('ChFMTlVSTFBheVJlc3BvbnNlMRIaCghjYWxsYmFjaxgBIAEoCVIIY2FsbGJhY2sSHQoKbWluX2Ftb3VudBgCIAEoA1IJbWluQW1vdW50Eh0KCm1heF9hbW91bnQYAyABKANSCW1heEFtb3VudBIyCghtZXRhZGF0YRgEIAMoCzIWLmRhdGEuTE5VcmxQYXlNZXRhZGF0YVIIbWV0YWRhdGESEAoDdGFnGAUgASgJUgN0YWcSFgoGYW1vdW50GAYgASgEUgZhbW91bnQSHQoKZnJvbV9ub2RlcxgHIAEoCVIJZnJvbU5vZGVzEhgKB2NvbW1lbnQYCCABKAlSB2NvbW1lbnQSEgoEaG9zdBgJIAEoCVIEaG9zdBInCg9jb21tZW50X2FsbG93ZWQYCiABKANSDmNvbW1lbnRBbGxvd2VkEisKEWxpZ2h0bmluZ19hZGRyZXNzGAsgASgJUhBsaWdodG5pbmdBZGRyZXNz');
+final $typed_data.Uint8List lNURLPayResponse1Descriptor = $convert.base64Decode(
+    'ChFMTlVSTFBheVJlc3BvbnNlMRIaCghjYWxsYmFjaxgBIAEoCVIIY2FsbGJhY2sSHQoKbWluX2Ftb3VudBgCIAEoA1IJbWluQW1vdW50Eh0KCm1heF9hbW91bnQYAyABKANSCW1heEFtb3VudBIyCghtZXRhZGF0YRgEIAMoCzIWLmRhdGEuTE5VcmxQYXlNZXRhZGF0YVIIbWV0YWRhdGESEAoDdGFnGAUgASgJUgN0YWcSFgoGYW1vdW50GAYgASgEUgZhbW91bnQSHQoKZnJvbV9ub2RlcxgHIAEoCVIJZnJvbU5vZGVzEhgKB2NvbW1lbnQYCCABKAlSB2NvbW1lbnQSEgoEaG9zdBgJIAEoCVIEaG9zdBInCg9jb21tZW50X2FsbG93ZWQYCiABKANSDmNvbW1lbnRBbGxvd2VkEisKEWxpZ2h0bmluZ19hZGRyZXNzGAsgASgJUhBsaWdodG5pbmdBZGRyZXNz');
 @$core.Deprecated('Use successActionDescriptor instead')
 const SuccessAction$json = const {
   '1': 'SuccessAction',
@@ -840,7 +974,8 @@ const SuccessAction$json = const {
 };
 
 /// Descriptor for `SuccessAction`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List successActionDescriptor = $convert.base64Decode('Cg1TdWNjZXNzQWN0aW9uEhAKA3RhZxgBIAEoCVIDdGFnEiAKC2Rlc2NyaXB0aW9uGAIgASgJUgtkZXNjcmlwdGlvbhIQCgN1cmwYAyABKAlSA3VybBIYCgdtZXNzYWdlGAQgASgJUgdtZXNzYWdlEh4KCmNpcGhlcnRleHQYBSABKAlSCmNpcGhlcnRleHQSDgoCaXYYBiABKAlSAml2');
+final $typed_data.Uint8List successActionDescriptor = $convert.base64Decode(
+    'Cg1TdWNjZXNzQWN0aW9uEhAKA3RhZxgBIAEoCVIDdGFnEiAKC2Rlc2NyaXB0aW9uGAIgASgJUgtkZXNjcmlwdGlvbhIQCgN1cmwYAyABKAlSA3VybBIYCgdtZXNzYWdlGAQgASgJUgdtZXNzYWdlEh4KCmNpcGhlcnRleHQYBSABKAlSCmNpcGhlcnRleHQSDgoCaXYYBiABKAlSAml2');
 @$core.Deprecated('Use lNUrlPayInfoDescriptor instead')
 const LNUrlPayInfo$json = const {
   '1': 'LNUrlPayInfo',
@@ -857,7 +992,8 @@ const LNUrlPayInfo$json = const {
 };
 
 /// Descriptor for `LNUrlPayInfo`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List lNUrlPayInfoDescriptor = $convert.base64Decode('CgxMTlVybFBheUluZm8SIAoLcGF5bWVudEhhc2gYASABKAlSC3BheW1lbnRIYXNoEhgKB2ludm9pY2UYAiABKAlSB2ludm9pY2USOgoOc3VjY2Vzc19hY3Rpb24YAyABKAsyEy5kYXRhLlN1Y2Nlc3NBY3Rpb25SDXN1Y2Nlc3NBY3Rpb24SGAoHY29tbWVudBgEIAEoCVIHY29tbWVudBIvChNpbnZvaWNlX2Rlc2NyaXB0aW9uGAUgASgJUhJpbnZvaWNlRGVzY3JpcHRpb24SMgoIbWV0YWRhdGEYBiADKAsyFi5kYXRhLkxOVXJsUGF5TWV0YWRhdGFSCG1ldGFkYXRhEhIKBGhvc3QYByABKAlSBGhvc3QSKwoRbGlnaHRuaW5nX2FkZHJlc3MYCCABKAlSEGxpZ2h0bmluZ0FkZHJlc3M=');
+final $typed_data.Uint8List lNUrlPayInfoDescriptor = $convert.base64Decode(
+    'CgxMTlVybFBheUluZm8SIAoLcGF5bWVudEhhc2gYASABKAlSC3BheW1lbnRIYXNoEhgKB2ludm9pY2UYAiABKAlSB2ludm9pY2USOgoOc3VjY2Vzc19hY3Rpb24YAyABKAsyEy5kYXRhLlN1Y2Nlc3NBY3Rpb25SDXN1Y2Nlc3NBY3Rpb24SGAoHY29tbWVudBgEIAEoCVIHY29tbWVudBIvChNpbnZvaWNlX2Rlc2NyaXB0aW9uGAUgASgJUhJpbnZvaWNlRGVzY3JpcHRpb24SMgoIbWV0YWRhdGEYBiADKAsyFi5kYXRhLkxOVXJsUGF5TWV0YWRhdGFSCG1ldGFkYXRhEhIKBGhvc3QYByABKAlSBGhvc3QSKwoRbGlnaHRuaW5nX2FkZHJlc3MYCCABKAlSEGxpZ2h0bmluZ0FkZHJlc3M=');
 @$core.Deprecated('Use lNUrlPayInfoListDescriptor instead')
 const LNUrlPayInfoList$json = const {
   '1': 'LNUrlPayInfoList',
@@ -867,7 +1003,8 @@ const LNUrlPayInfoList$json = const {
 };
 
 /// Descriptor for `LNUrlPayInfoList`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List lNUrlPayInfoListDescriptor = $convert.base64Decode('ChBMTlVybFBheUluZm9MaXN0Ei4KCGluZm9MaXN0GAEgAygLMhIuZGF0YS5MTlVybFBheUluZm9SCGluZm9MaXN0');
+final $typed_data.Uint8List lNUrlPayInfoListDescriptor = $convert
+    .base64Decode('ChBMTlVybFBheUluZm9MaXN0Ei4KCGluZm9MaXN0GAEgAygLMhIuZGF0YS5MTlVybFBheUluZm9SCGluZm9MaXN0');
 @$core.Deprecated('Use reverseSwapRequestDescriptor instead')
 const ReverseSwapRequest$json = const {
   '1': 'ReverseSwapRequest',
@@ -879,7 +1016,8 @@ const ReverseSwapRequest$json = const {
 };
 
 /// Descriptor for `ReverseSwapRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List reverseSwapRequestDescriptor = $convert.base64Decode('ChJSZXZlcnNlU3dhcFJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIWCgZhbW91bnQYAiABKANSBmFtb3VudBIbCglmZWVzX2hhc2gYAyABKAlSCGZlZXNIYXNo');
+final $typed_data.Uint8List reverseSwapRequestDescriptor = $convert.base64Decode(
+    'ChJSZXZlcnNlU3dhcFJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcxIWCgZhbW91bnQYAiABKANSBmFtb3VudBIbCglmZWVzX2hhc2gYAyABKAlSCGZlZXNIYXNo');
 @$core.Deprecated('Use reverseSwapDescriptor instead')
 const ReverseSwap$json = const {
   '1': 'ReverseSwap',
@@ -901,7 +1039,8 @@ const ReverseSwap$json = const {
 };
 
 /// Descriptor for `ReverseSwap`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List reverseSwapDescriptor = $convert.base64Decode('CgtSZXZlcnNlU3dhcBIOCgJpZBgBIAEoCVICaWQSGAoHaW52b2ljZRgCIAEoCVIHaW52b2ljZRIWCgZzY3JpcHQYAyABKAlSBnNjcmlwdBIlCg5sb2NrdXBfYWRkcmVzcxgEIAEoCVINbG9ja3VwQWRkcmVzcxIaCghwcmVpbWFnZRgFIAEoCVIIcHJlaW1hZ2USEAoDa2V5GAYgASgJUgNrZXkSIwoNY2xhaW1fYWRkcmVzcxgHIAEoCVIMY2xhaW1BZGRyZXNzEhsKCWxuX2Ftb3VudBgIIAEoA1IIbG5BbW91bnQSJQoOb25jaGFpbl9hbW91bnQYCSABKANSDW9uY2hhaW5BbW91bnQSMAoUdGltZW91dF9ibG9ja19oZWlnaHQYCiABKANSEnRpbWVvdXRCbG9ja0hlaWdodBIsChJzdGFydF9ibG9ja19oZWlnaHQYCyABKANSEHN0YXJ0QmxvY2tIZWlnaHQSGwoJY2xhaW1fZmVlGAwgASgDUghjbGFpbUZlZRIdCgpjbGFpbV90eGlkGA0gASgJUgljbGFpbVR4aWQ=');
+final $typed_data.Uint8List reverseSwapDescriptor = $convert.base64Decode(
+    'CgtSZXZlcnNlU3dhcBIOCgJpZBgBIAEoCVICaWQSGAoHaW52b2ljZRgCIAEoCVIHaW52b2ljZRIWCgZzY3JpcHQYAyABKAlSBnNjcmlwdBIlCg5sb2NrdXBfYWRkcmVzcxgEIAEoCVINbG9ja3VwQWRkcmVzcxIaCghwcmVpbWFnZRgFIAEoCVIIcHJlaW1hZ2USEAoDa2V5GAYgASgJUgNrZXkSIwoNY2xhaW1fYWRkcmVzcxgHIAEoCVIMY2xhaW1BZGRyZXNzEhsKCWxuX2Ftb3VudBgIIAEoA1IIbG5BbW91bnQSJQoOb25jaGFpbl9hbW91bnQYCSABKANSDW9uY2hhaW5BbW91bnQSMAoUdGltZW91dF9ibG9ja19oZWlnaHQYCiABKANSEnRpbWVvdXRCbG9ja0hlaWdodBIsChJzdGFydF9ibG9ja19oZWlnaHQYCyABKANSEHN0YXJ0QmxvY2tIZWlnaHQSGwoJY2xhaW1fZmVlGAwgASgDUghjbGFpbUZlZRIdCgpjbGFpbV90eGlkGA0gASgJUgljbGFpbVR4aWQ=');
 @$core.Deprecated('Use reverseSwapFeesDescriptor instead')
 const ReverseSwapFees$json = const {
   '1': 'ReverseSwapFees',
@@ -913,7 +1052,8 @@ const ReverseSwapFees$json = const {
 };
 
 /// Descriptor for `ReverseSwapFees`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List reverseSwapFeesDescriptor = $convert.base64Decode('Cg9SZXZlcnNlU3dhcEZlZXMSHgoKcGVyY2VudGFnZRgBIAEoAVIKcGVyY2VudGFnZRIWCgZsb2NrdXAYAiABKANSBmxvY2t1cBIUCgVjbGFpbRgDIAEoA1IFY2xhaW0=');
+final $typed_data.Uint8List reverseSwapFeesDescriptor = $convert.base64Decode(
+    'Cg9SZXZlcnNlU3dhcEZlZXMSHgoKcGVyY2VudGFnZRgBIAEoAVIKcGVyY2VudGFnZRIWCgZsb2NrdXAYAiABKANSBmxvY2t1cBIUCgVjbGFpbRgDIAEoA1IFY2xhaW0=');
 @$core.Deprecated('Use reverseSwapInfoDescriptor instead')
 const ReverseSwapInfo$json = const {
   '1': 'ReverseSwapInfo',
@@ -926,19 +1066,28 @@ const ReverseSwapInfo$json = const {
 };
 
 /// Descriptor for `ReverseSwapInfo`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List reverseSwapInfoDescriptor = $convert.base64Decode('Cg9SZXZlcnNlU3dhcEluZm8SEAoDbWluGAEgASgDUgNtaW4SEAoDbWF4GAIgASgDUgNtYXgSKQoEZmVlcxgDIAEoCzIVLmRhdGEuUmV2ZXJzZVN3YXBGZWVzUgRmZWVzEhsKCWZlZXNfaGFzaBgEIAEoCVIIZmVlc0hhc2g=');
+final $typed_data.Uint8List reverseSwapInfoDescriptor = $convert.base64Decode(
+    'Cg9SZXZlcnNlU3dhcEluZm8SEAoDbWluGAEgASgDUgNtaW4SEAoDbWF4GAIgASgDUgNtYXgSKQoEZmVlcxgDIAEoCzIVLmRhdGEuUmV2ZXJzZVN3YXBGZWVzUgRmZWVzEhsKCWZlZXNfaGFzaBgEIAEoCVIIZmVlc0hhc2g=');
 @$core.Deprecated('Use reverseSwapPaymentRequestDescriptor instead')
 const ReverseSwapPaymentRequest$json = const {
   '1': 'ReverseSwapPaymentRequest',
   '2': const [
     const {'1': 'hash', '3': 1, '4': 1, '5': 9, '10': 'hash'},
-    const {'1': 'push_notification_details', '3': 2, '4': 1, '5': 11, '6': '.data.PushNotificationDetails', '10': 'pushNotificationDetails'},
+    const {
+      '1': 'push_notification_details',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.data.PushNotificationDetails',
+      '10': 'pushNotificationDetails'
+    },
     const {'1': 'fee', '3': 3, '4': 1, '5': 3, '10': 'fee'},
   ],
 };
 
 /// Descriptor for `ReverseSwapPaymentRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List reverseSwapPaymentRequestDescriptor = $convert.base64Decode('ChlSZXZlcnNlU3dhcFBheW1lbnRSZXF1ZXN0EhIKBGhhc2gYASABKAlSBGhhc2gSWQoZcHVzaF9ub3RpZmljYXRpb25fZGV0YWlscxgCIAEoCzIdLmRhdGEuUHVzaE5vdGlmaWNhdGlvbkRldGFpbHNSF3B1c2hOb3RpZmljYXRpb25EZXRhaWxzEhAKA2ZlZRgDIAEoA1IDZmVl');
+final $typed_data.Uint8List reverseSwapPaymentRequestDescriptor = $convert.base64Decode(
+    'ChlSZXZlcnNlU3dhcFBheW1lbnRSZXF1ZXN0EhIKBGhhc2gYASABKAlSBGhhc2gSWQoZcHVzaF9ub3RpZmljYXRpb25fZGV0YWlscxgCIAEoCzIdLmRhdGEuUHVzaE5vdGlmaWNhdGlvbkRldGFpbHNSF3B1c2hOb3RpZmljYXRpb25EZXRhaWxzEhAKA2ZlZRgDIAEoA1IDZmVl');
 @$core.Deprecated('Use pushNotificationDetailsDescriptor instead')
 const PushNotificationDetails$json = const {
   '1': 'PushNotificationDetails',
@@ -950,7 +1099,8 @@ const PushNotificationDetails$json = const {
 };
 
 /// Descriptor for `PushNotificationDetails`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List pushNotificationDetailsDescriptor = $convert.base64Decode('ChdQdXNoTm90aWZpY2F0aW9uRGV0YWlscxIbCglkZXZpY2VfaWQYASABKAlSCGRldmljZUlkEhQKBXRpdGxlGAIgASgJUgV0aXRsZRISCgRib2R5GAMgASgJUgRib2R5');
+final $typed_data.Uint8List pushNotificationDetailsDescriptor = $convert.base64Decode(
+    'ChdQdXNoTm90aWZpY2F0aW9uRGV0YWlscxIbCglkZXZpY2VfaWQYASABKAlSCGRldmljZUlkEhQKBXRpdGxlGAIgASgJUgV0aXRsZRISCgRib2R5GAMgASgJUgRib2R5');
 @$core.Deprecated('Use reverseSwapPaymentStatusDescriptor instead')
 const ReverseSwapPaymentStatus$json = const {
   '1': 'ReverseSwapPaymentStatus',
@@ -962,17 +1112,26 @@ const ReverseSwapPaymentStatus$json = const {
 };
 
 /// Descriptor for `ReverseSwapPaymentStatus`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List reverseSwapPaymentStatusDescriptor = $convert.base64Decode('ChhSZXZlcnNlU3dhcFBheW1lbnRTdGF0dXMSEgoEaGFzaBgBIAEoCVIEaGFzaBISCgR0eElEGAIgASgJUgR0eElEEhAKA2V0YRgDIAEoBVIDZXRh');
+final $typed_data.Uint8List reverseSwapPaymentStatusDescriptor = $convert.base64Decode(
+    'ChhSZXZlcnNlU3dhcFBheW1lbnRTdGF0dXMSEgoEaGFzaBgBIAEoCVIEaGFzaBISCgR0eElEGAIgASgJUgR0eElEEhAKA2V0YRgDIAEoBVIDZXRh');
 @$core.Deprecated('Use reverseSwapPaymentStatusesDescriptor instead')
 const ReverseSwapPaymentStatuses$json = const {
   '1': 'ReverseSwapPaymentStatuses',
   '2': const [
-    const {'1': 'payments_status', '3': 1, '4': 3, '5': 11, '6': '.data.ReverseSwapPaymentStatus', '10': 'paymentsStatus'},
+    const {
+      '1': 'payments_status',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.data.ReverseSwapPaymentStatus',
+      '10': 'paymentsStatus'
+    },
   ],
 };
 
 /// Descriptor for `ReverseSwapPaymentStatuses`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List reverseSwapPaymentStatusesDescriptor = $convert.base64Decode('ChpSZXZlcnNlU3dhcFBheW1lbnRTdGF0dXNlcxJHCg9wYXltZW50c19zdGF0dXMYASADKAsyHi5kYXRhLlJldmVyc2VTd2FwUGF5bWVudFN0YXR1c1IOcGF5bWVudHNTdGF0dXM=');
+final $typed_data.Uint8List reverseSwapPaymentStatusesDescriptor = $convert.base64Decode(
+    'ChpSZXZlcnNlU3dhcFBheW1lbnRTdGF0dXNlcxJHCg9wYXltZW50c19zdGF0dXMYASADKAsyHi5kYXRhLlJldmVyc2VTd2FwUGF5bWVudFN0YXR1c1IOcGF5bWVudHNTdGF0dXM=');
 @$core.Deprecated('Use reverseSwapClaimFeeDescriptor instead')
 const ReverseSwapClaimFee$json = const {
   '1': 'ReverseSwapClaimFee',
@@ -983,7 +1142,8 @@ const ReverseSwapClaimFee$json = const {
 };
 
 /// Descriptor for `ReverseSwapClaimFee`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List reverseSwapClaimFeeDescriptor = $convert.base64Decode('ChNSZXZlcnNlU3dhcENsYWltRmVlEhIKBGhhc2gYASABKAlSBGhhc2gSEAoDZmVlGAIgASgDUgNmZWU=');
+final $typed_data.Uint8List reverseSwapClaimFeeDescriptor =
+    $convert.base64Decode('ChNSZXZlcnNlU3dhcENsYWltRmVlEhIKBGhhc2gYASABKAlSBGhhc2gSEAoDZmVlGAIgASgDUgNmZWU=');
 @$core.Deprecated('Use claimFeeEstimatesDescriptor instead')
 const ClaimFeeEstimates$json = const {
   '1': 'ClaimFeeEstimates',
@@ -1004,7 +1164,8 @@ const ClaimFeeEstimates_FeesEntry$json = const {
 };
 
 /// Descriptor for `ClaimFeeEstimates`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List claimFeeEstimatesDescriptor = $convert.base64Decode('ChFDbGFpbUZlZUVzdGltYXRlcxI1CgRmZWVzGAEgAygLMiEuZGF0YS5DbGFpbUZlZUVzdGltYXRlcy5GZWVzRW50cnlSBGZlZXMaNwoJRmVlc0VudHJ5EhAKA2tleRgBIAEoBVIDa2V5EhQKBXZhbHVlGAIgASgDUgV2YWx1ZToCOAE=');
+final $typed_data.Uint8List claimFeeEstimatesDescriptor = $convert.base64Decode(
+    'ChFDbGFpbUZlZUVzdGltYXRlcxI1CgRmZWVzGAEgAygLMiEuZGF0YS5DbGFpbUZlZUVzdGltYXRlcy5GZWVzRW50cnlSBGZlZXMaNwoJRmVlc0VudHJ5EhAKA2tleRgBIAEoBVIDa2V5EhQKBXZhbHVlGAIgASgDUgV2YWx1ZToCOAE=');
 @$core.Deprecated('Use unspendLockupInformationDescriptor instead')
 const UnspendLockupInformation$json = const {
   '1': 'UnspendLockupInformation',
@@ -1016,7 +1177,8 @@ const UnspendLockupInformation$json = const {
 };
 
 /// Descriptor for `UnspendLockupInformation`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List unspendLockupInformationDescriptor = $convert.base64Decode('ChhVbnNwZW5kTG9ja3VwSW5mb3JtYXRpb24SHwoLaGVpZ2h0X2hpbnQYASABKA1SCmhlaWdodEhpbnQSIwoNbG9ja3VwX3NjcmlwdBgCIAEoDFIMbG9ja3VwU2NyaXB0EiIKDWNsYWltX3R4X2hhc2gYAyABKAxSC2NsYWltVHhIYXNo');
+final $typed_data.Uint8List unspendLockupInformationDescriptor = $convert.base64Decode(
+    'ChhVbnNwZW5kTG9ja3VwSW5mb3JtYXRpb24SHwoLaGVpZ2h0X2hpbnQYASABKA1SCmhlaWdodEhpbnQSIwoNbG9ja3VwX3NjcmlwdBgCIAEoDFIMbG9ja3VwU2NyaXB0EiIKDWNsYWltX3R4X2hhc2gYAyABKAxSC2NsYWltVHhIYXNo');
 @$core.Deprecated('Use transactionDetailsDescriptor instead')
 const TransactionDetails$json = const {
   '1': 'TransactionDetails',
@@ -1028,13 +1190,21 @@ const TransactionDetails$json = const {
 };
 
 /// Descriptor for `TransactionDetails`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List transactionDetailsDescriptor = $convert.base64Decode('ChJUcmFuc2FjdGlvbkRldGFpbHMSDgoCdHgYASABKAxSAnR4EhcKB3R4X2hhc2gYAiABKAlSBnR4SGFzaBISCgRmZWVzGAMgASgDUgRmZWVz');
+final $typed_data.Uint8List transactionDetailsDescriptor = $convert.base64Decode(
+    'ChJUcmFuc2FjdGlvbkRldGFpbHMSDgoCdHgYASABKAxSAnR4EhcKB3R4X2hhc2gYAiABKAlSBnR4SGFzaBISCgRmZWVzGAMgASgDUgRmZWVz');
 @$core.Deprecated('Use sweepAllCoinsTransactionsDescriptor instead')
 const SweepAllCoinsTransactions$json = const {
   '1': 'SweepAllCoinsTransactions',
   '2': const [
     const {'1': 'amt', '3': 1, '4': 1, '5': 3, '10': 'amt'},
-    const {'1': 'transactions', '3': 2, '4': 3, '5': 11, '6': '.data.SweepAllCoinsTransactions.TransactionsEntry', '10': 'transactions'},
+    const {
+      '1': 'transactions',
+      '3': 2,
+      '4': 3,
+      '5': 11,
+      '6': '.data.SweepAllCoinsTransactions.TransactionsEntry',
+      '10': 'transactions'
+    },
   ],
   '3': const [SweepAllCoinsTransactions_TransactionsEntry$json],
 };
@@ -1050,7 +1220,8 @@ const SweepAllCoinsTransactions_TransactionsEntry$json = const {
 };
 
 /// Descriptor for `SweepAllCoinsTransactions`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List sweepAllCoinsTransactionsDescriptor = $convert.base64Decode('ChlTd2VlcEFsbENvaW5zVHJhbnNhY3Rpb25zEhAKA2FtdBgBIAEoA1IDYW10ElUKDHRyYW5zYWN0aW9ucxgCIAMoCzIxLmRhdGEuU3dlZXBBbGxDb2luc1RyYW5zYWN0aW9ucy5UcmFuc2FjdGlvbnNFbnRyeVIMdHJhbnNhY3Rpb25zGlkKEVRyYW5zYWN0aW9uc0VudHJ5EhAKA2tleRgBIAEoBVIDa2V5Ei4KBXZhbHVlGAIgASgLMhguZGF0YS5UcmFuc2FjdGlvbkRldGFpbHNSBXZhbHVlOgI4AQ==');
+final $typed_data.Uint8List sweepAllCoinsTransactionsDescriptor = $convert.base64Decode(
+    'ChlTd2VlcEFsbENvaW5zVHJhbnNhY3Rpb25zEhAKA2FtdBgBIAEoA1IDYW10ElUKDHRyYW5zYWN0aW9ucxgCIAMoCzIxLmRhdGEuU3dlZXBBbGxDb2luc1RyYW5zYWN0aW9ucy5UcmFuc2FjdGlvbnNFbnRyeVIMdHJhbnNhY3Rpb25zGlkKEVRyYW5zYWN0aW9uc0VudHJ5EhAKA2tleRgBIAEoBVIDa2V5Ei4KBXZhbHVlGAIgASgLMhguZGF0YS5UcmFuc2FjdGlvbkRldGFpbHNSBXZhbHVlOgI4AQ==');
 @$core.Deprecated('Use downloadBackupResponseDescriptor instead')
 const DownloadBackupResponse$json = const {
   '1': 'DownloadBackupResponse',
@@ -1060,7 +1231,8 @@ const DownloadBackupResponse$json = const {
 };
 
 /// Descriptor for `DownloadBackupResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List downloadBackupResponseDescriptor = $convert.base64Decode('ChZEb3dubG9hZEJhY2t1cFJlc3BvbnNlEhQKBWZpbGVzGAEgAygJUgVmaWxlcw==');
+final $typed_data.Uint8List downloadBackupResponseDescriptor =
+    $convert.base64Decode('ChZEb3dubG9hZEJhY2t1cFJlc3BvbnNlEhQKBWZpbGVzGAEgAygJUgVmaWxlcw==');
 @$core.Deprecated('Use torConfigDescriptor instead')
 const TorConfig$json = const {
   '1': 'TorConfig',
@@ -1072,7 +1244,8 @@ const TorConfig$json = const {
 };
 
 /// Descriptor for `TorConfig`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List torConfigDescriptor = $convert.base64Decode('CglUb3JDb25maWcSGAoHY29udHJvbBgBIAEoCVIHY29udHJvbBISCgRodHRwGAIgASgJUgRodHRwEhQKBXNvY2tzGAMgASgJUgVzb2Nrcw==');
+final $typed_data.Uint8List torConfigDescriptor = $convert.base64Decode(
+    'CglUb3JDb25maWcSGAoHY29udHJvbBgBIAEoCVIHY29udHJvbBISCgRodHRwGAIgASgJUgRodHRwEhQKBXNvY2tzGAMgASgJUgVzb2Nrcw==');
 @$core.Deprecated('Use closeChannelsRequestDescriptor instead')
 const CloseChannelsRequest$json = const {
   '1': 'CloseChannelsRequest',
@@ -1082,7 +1255,8 @@ const CloseChannelsRequest$json = const {
 };
 
 /// Descriptor for `CloseChannelsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List closeChannelsRequestDescriptor = $convert.base64Decode('ChRDbG9zZUNoYW5uZWxzUmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNz');
+final $typed_data.Uint8List closeChannelsRequestDescriptor =
+    $convert.base64Decode('ChRDbG9zZUNoYW5uZWxzUmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNz');
 @$core.Deprecated('Use closeChannelsReplyDescriptor instead')
 const CloseChannelsReply$json = const {
   '1': 'CloseChannelsReply',
@@ -1092,7 +1266,8 @@ const CloseChannelsReply$json = const {
 };
 
 /// Descriptor for `CloseChannelsReply`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List closeChannelsReplyDescriptor = $convert.base64Decode('ChJDbG9zZUNoYW5uZWxzUmVwbHkSNAoIY2hhbm5lbHMYASADKAsyGC5kYXRhLkNsb3NlQ2hhbm5lbFJlc3VsdFIIY2hhbm5lbHM=');
+final $typed_data.Uint8List closeChannelsReplyDescriptor = $convert.base64Decode(
+    'ChJDbG9zZUNoYW5uZWxzUmVwbHkSNAoIY2hhbm5lbHMYASADKAsyGC5kYXRhLkNsb3NlQ2hhbm5lbFJlc3VsdFIIY2hhbm5lbHM=');
 @$core.Deprecated('Use closeChannelResultDescriptor instead')
 const CloseChannelResult$json = const {
   '1': 'CloseChannelResult',
@@ -1106,4 +1281,5 @@ const CloseChannelResult$json = const {
 };
 
 /// Descriptor for `CloseChannelResult`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List closeChannelResultDescriptor = $convert.base64Decode('ChJDbG9zZUNoYW5uZWxSZXN1bHQSIwoNcmVtb3RlX3B1YmtleRgBIAEoCVIMcmVtb3RlUHVia2V5EiMKDWNoYW5uZWxfcG9pbnQYAiABKAlSDGNoYW5uZWxQb2ludBIdCgppc19za2lwcGVkGAMgASgIUglpc1NraXBwZWQSIQoMY2xvc2luZ190eGlkGAQgASgJUgtjbG9zaW5nVHhpZBIZCghmYWlsX2VychgFIAEoCVIHZmFpbEVycg==');
+final $typed_data.Uint8List closeChannelResultDescriptor = $convert.base64Decode(
+    'ChJDbG9zZUNoYW5uZWxSZXN1bHQSIwoNcmVtb3RlX3B1YmtleRgBIAEoCVIMcmVtb3RlUHVia2V5EiMKDWNoYW5uZWxfcG9pbnQYAiABKAlSDGNoYW5uZWxQb2ludBIdCgppc19za2lwcGVkGAMgASgIUglpc1NraXBwZWQSIQoMY2xvc2luZ190eGlkGAQgASgJUgtjbG9zaW5nVHhpZBIZCghmYWlsX2VychgFIAEoCVIHZmFpbEVycg==');

--- a/lib/services/breezlib/graph_downloader.dart
+++ b/lib/services/breezlib/graph_downloader.dart
@@ -30,11 +30,9 @@ class GraphDownloader {
       _log.info("GraphDownloader event: ${event.percentage}");
       var tasks = await downloadManager.loadTasks();
       var downloadURL = (await preferences).getString("graph_url");
-      var currentTask = tasks.firstWhere(
-          (t) => t.url == downloadURL && t.taskId == event.id,
-          orElse: () => null);
-      if (currentTask != null &&
-          finalTaskStatuses.contains(currentTask.status)) {
+      var currentTask =
+          tasks.firstWhere((t) => t.url == downloadURL && t.taskId == event.id, orElse: () => null);
+      if (currentTask != null && finalTaskStatuses.contains(currentTask.status)) {
         _log.info("GraphDownloader task status = ${currentTask.status}");
         await _onTaskFinished(currentTask);
       }
@@ -44,9 +42,8 @@ class GraphDownloader {
   Future _onTaskFinished(DownloadTask currentTask) async {
     if (_downloadCompleter != null) {
       if (currentTask.status == DownloadTaskStatus.complete) {
-        _downloadCompleter.complete(File(currentTask.savedDir +
-            Platform.pathSeparator +
-            currentTask.filename));
+        _downloadCompleter
+            .complete(File(currentTask.savedDir + Platform.pathSeparator + currentTask.filename));
       } else {
         _downloadCompleter.completeError("graph sync failed");
       }
@@ -74,15 +71,13 @@ class GraphDownloader {
         }
 
         if (tasks[i].status == DownloadTaskStatus.complete) {
-          _log.info(
-              "Already has a recently completed graph download task, using it");
+          _log.info("Already has a recently completed graph download task, using it");
           _onTaskFinished(tasks[i]);
           return _downloadCompleter.future;
         }
 
         if (tasks[i].status == DownloadTaskStatus.running) {
-          _log.info(
-              "Already has graph download task running, not starting another one");
+          _log.info("Already has graph download task running, not starting another one");
           return _downloadCompleter.future;
         }
       }
@@ -93,8 +88,7 @@ class GraphDownloader {
     var downloadDirPath = '${appDir.path}${Platform.pathSeparator}Download';
     var downloadDir = Directory(downloadDirPath);
     downloadDir.createSync(recursive: true);
-    await downloadManager.enqueTask(
-        downloadURL, downloadDir.path, "channel.db");
+    await downloadManager.enqueTask(downloadURL, downloadDir.path, "channel.db");
     return _downloadCompleter.future;
   }
 

--- a/lib/services/currency_data.dart
+++ b/lib/services/currency_data.dart
@@ -3,8 +3,7 @@ import 'dart:convert';
 import 'package:breez_translations/breez_translations_locales.dart';
 
 Map<String, CurrencyData> currencyDataFromJson(String str) =>
-    Map.from(json.decode(str)).map((k, v) =>
-        MapEntry<String, CurrencyData>(k, CurrencyData.fromJson(k, v)));
+    Map.from(json.decode(str)).map((k, v) => MapEntry<String, CurrencyData>(k, CurrencyData.fromJson(k, v)));
 
 Map<String, CurrencyDataOverride> currencyDataOverrideFromJson(
   CurrencyData base,

--- a/lib/services/currency_service.dart
+++ b/lib/services/currency_service.dart
@@ -5,8 +5,7 @@ class CurrencyService {
   CurrencyService();
 
   Future<Map<String, CurrencyData>> currencies() async {
-    String jsonCurrencies =
-        await rootBundle.loadString('src/json/currencies.json');
+    String jsonCurrencies = await rootBundle.loadString('src/json/currencies.json');
     return currencyDataFromJson(jsonCurrencies);
   }
 }

--- a/lib/services/deep_links.dart
+++ b/lib/services/deep_links.dart
@@ -9,8 +9,7 @@ final _log = Logger("DeepLinksService");
 class DeepLinksService {
   static const SESSION_SECRET = "sessionSecret";
 
-  final StreamController<String> _linksNotificationsController =
-      BehaviorSubject<String>();
+  final StreamController<String> _linksNotificationsController = BehaviorSubject<String>();
   Stream<String> get linksNotifications => _linksNotificationsController.stream;
 
   FirebaseDynamicLinks _dynamicLinks;
@@ -43,10 +42,8 @@ class DeepLinksService {
     final DynamicLinkParameters parameters = DynamicLinkParameters(
         uriPrefix: "https://breez.page.link",
         link: Uri.parse('https://breez.technology?${link.toLinkQuery()}'),
-        androidParameters:
-            const AndroidParameters(packageName: "com.breez.client"),
-        iosParameters:
-            const IOSParameters(bundleId: "technology.breez.client"));
+        androidParameters: const AndroidParameters(packageName: "com.breez.client"),
+        iosParameters: const IOSParameters(bundleId: "technology.breez.client"));
     final ShortDynamicLink shortLink = await _dynamicLinks.buildShortLink(
       parameters,
       shortLinkType: ShortDynamicLinkType.unguessable,
@@ -77,8 +74,7 @@ class SessionLinkModel {
 
   static SessionLinkModel fromLinkQuery(String queryStr) {
     Map<String, String> query = Uri.splitQueryString(queryStr);
-    return SessionLinkModel(
-        query["sessionID"], query["sessionSecret"], query["pubKey"]);
+    return SessionLinkModel(query["sessionID"], query["sessionSecret"], query["pubKey"]);
   }
 }
 
@@ -95,8 +91,6 @@ class PodcastShareLinkModel {
   static PodcastShareLinkModel fromLinkQuery(String queryStr) {
     Map<String, String> query = Uri.splitQueryString(queryStr);
     return PodcastShareLinkModel(Uri.decodeComponent(query["feedURL"]),
-        episodeID: query["episodeID"] == null
-            ? null
-            : Uri.decodeComponent(query["episodeID"]));
+        episodeID: query["episodeID"] == null ? null : Uri.decodeComponent(query["episodeID"]));
   }
 }

--- a/lib/services/device.dart
+++ b/lib/services/device.dart
@@ -16,17 +16,14 @@ class Device extends ClipboardListener {
   static const EventChannel _notificationsChannel =
       EventChannel('com.breez.client/lifecycle_events_notifications');
 
-  final StreamController _eventsController =
-      StreamController<NotificationType>.broadcast();
+  final StreamController _eventsController = StreamController<NotificationType>.broadcast();
   Stream<NotificationType> get eventStream => _eventsController.stream;
 
   final _clipboardController = BehaviorSubject<String>();
-  Stream<String> get clipboardStream =>
-      _clipboardController.stream.where((e) => e != _lastFromAppClip);
+  Stream<String> get clipboardStream => _clipboardController.stream.where((e) => e != _lastFromAppClip);
 
   static const String LAST_CLIPPING_PREFERENCES_KEY = "lastClipping";
-  static const String LAST_FROM_APP_CLIPPING_PREFERENCES_KEY =
-      "lastFromAppClipping";
+  static const String LAST_FROM_APP_CLIPPING_PREFERENCES_KEY = "lastFromAppClipping";
 
   String _lastFromAppClip;
 
@@ -35,12 +32,10 @@ class Device extends ClipboardListener {
 
     var sharedPreferences = SharedPreferences.getInstance();
     sharedPreferences.then((preferences) {
-      _lastFromAppClip =
-          preferences.getString(LAST_FROM_APP_CLIPPING_PREFERENCES_KEY);
+      _lastFromAppClip = preferences.getString(LAST_FROM_APP_CLIPPING_PREFERENCES_KEY);
       // Start with the last clipping of the previous session so we can avoid
       // triggering a repeat of the same action handled on the previous session.
-      _clipboardController
-          .add(preferences.getString(LAST_CLIPPING_PREFERENCES_KEY) ?? "");
+      _clipboardController.add(preferences.getString(LAST_CLIPPING_PREFERENCES_KEY) ?? "");
       _log.finest("Last clipping: $_lastFromAppClip");
       fetchClipboard(preferences);
     });

--- a/lib/services/download_manager.dart
+++ b/lib/services/download_manager.dart
@@ -39,8 +39,7 @@ class DownloadTaskManager {
     await FlutterDownloader.initialize(ignoreSsl: true, debug: true);
     _log.info("GraphDownloader after Initialize");
 
-    bool success = IsolateNameServer.registerPortWithName(
-        _port.sendPort, 'downloader_send_port');
+    bool success = IsolateNameServer.registerPortWithName(_port.sendPort, 'downloader_send_port');
     _port.listen((dynamic data) {
       final id = (data as List<dynamic>)[0] as String;
       final status = DownloadTaskStatus(data[1] as int);
@@ -60,8 +59,7 @@ class DownloadTaskManager {
   }
 
   void pollTasksStatus() {
-    _downloadTimer ??=
-        Timer.periodic(const Duration(seconds: 3), (timer) async {
+    _downloadTimer ??= Timer.periodic(const Duration(seconds: 3), (timer) async {
       var tasks = await loadTasks();
       final polledTasks = tasks.where((t) => _tasksToPoll.contains(t.taskId));
       for (var task in polledTasks) {
@@ -120,8 +118,7 @@ class DownloadTaskManager {
   }
 
   Future removeTask(String taskID, {shouldDeleteContent = true}) async {
-    await FlutterDownloader.remove(
-        taskId: taskID, shouldDeleteContent: shouldDeleteContent);
+    await FlutterDownloader.remove(taskId: taskID, shouldDeleteContent: shouldDeleteContent);
     _tasksToPoll.remove(taskID);
   }
 

--- a/lib/services/injector.dart
+++ b/lib/services/injector.dart
@@ -29,8 +29,7 @@ class ServiceInjector {
   LightningLinksService _lightningLinksService;
   Device _device;
   TorBloc _torBloc;
-  Future<SharedPreferences> _sharedPreferences =
-      SharedPreferences.getInstance();
+  Future<SharedPreferences> _sharedPreferences = SharedPreferences.getInstance();
   Permissions _permissions;
   BackgroundTaskService _backgroundTaskService;
   CurrencyService _currencyService;
@@ -74,11 +73,9 @@ class ServiceInjector {
 
   DeepLinksService get deepLinks => _deepLinksService ??= DeepLinksService();
 
-  LightningLinksService get lightningLinks =>
-      _lightningLinksService ??= LightningLinksService();
+  LightningLinksService get lightningLinks => _lightningLinksService ??= LightningLinksService();
 
-  Future<SharedPreferences> get sharedPreferences =>
-      _sharedPreferences ??= SharedPreferences.getInstance();
+  Future<SharedPreferences> get sharedPreferences => _sharedPreferences ??= SharedPreferences.getInstance();
 
   Permissions get permissions {
     return _permissions ??= Permissions();

--- a/lib/services/lightning_links.dart
+++ b/lib/services/lightning_links.dart
@@ -8,15 +8,12 @@ import 'package:uni_links/uni_links.dart';
 final _log = Logger("LightningLinksService");
 
 class LightningLinksService {
-  final StreamController<String> _linksNotificationsController =
-      BehaviorSubject<String>();
+  final StreamController<String> _linksNotificationsController = BehaviorSubject<String>();
 
   Stream<String> get linksNotifications => _linksNotificationsController.stream;
 
   LightningLinksService() {
-    Rx.merge([getInitialLink().asStream(), linkStream])
-        .where(canHandleScheme)
-        .listen((l) {
+    Rx.merge([getInitialLink().asStream(), linkStream]).where(canHandleScheme).listen((l) {
       _log.info("Got lightning link: $l");
       if (l.startsWith("breez:")) {
         l = l.substring(6);

--- a/lib/services/local_auth_service.dart
+++ b/lib/services/local_auth_service.dart
@@ -19,14 +19,10 @@ class LocalAuthenticationService {
   Future<LocalAuthenticationOption> _getLocalAuthenticationOption() async {
     final availableBiometrics = await _auth.getAvailableBiometrics();
     if (availableBiometrics.contains(BiometricType.face)) {
-      return Platform.isIOS
-          ? LocalAuthenticationOption.FACE_ID
-          : LocalAuthenticationOption.FACE;
+      return Platform.isIOS ? LocalAuthenticationOption.FACE_ID : LocalAuthenticationOption.FACE;
     }
     if (availableBiometrics.contains(BiometricType.fingerprint)) {
-      return Platform.isIOS
-          ? LocalAuthenticationOption.TOUCH_ID
-          : LocalAuthenticationOption.FINGERPRINT;
+      return Platform.isIOS ? LocalAuthenticationOption.TOUCH_ID : LocalAuthenticationOption.FINGERPRINT;
     }
     return LocalAuthenticationOption.NONE;
   }

--- a/lib/services/nfc.dart
+++ b/lib/services/nfc.dart
@@ -12,8 +12,7 @@ final _log = Logger("NFC");
 
 class NFCService {
   static const _platform = MethodChannel('com.breez.client/nfc');
-  final StreamController<String> _lnLinkController =
-      StreamController<String>.broadcast();
+  final StreamController<String> _lnLinkController = StreamController<String>.broadcast();
   StreamSubscription _lnLinkListener;
   Timer _checkNfcStartedWithTimer;
 
@@ -25,8 +24,7 @@ class NFCService {
     if (Platform.isAndroid) {
       int fnCalls = 0;
       // Wrap with Future.delayed on debug mode.
-      _checkNfcStartedWithTimer =
-          Timer.periodic(const Duration(milliseconds: 100), (Timer t) {
+      _checkNfcStartedWithTimer = Timer.periodic(const Duration(milliseconds: 100), (Timer t) {
         if (fnCalls == 5) {
           _checkNfcStartedWithTimer.cancel();
           return;

--- a/lib/services/notifications.dart
+++ b/lib/services/notifications.dart
@@ -18,8 +18,7 @@ class FirebaseNotifications implements Notifications {
   final StreamController<Map<dynamic, dynamic>> _notificationController =
       BehaviorSubject<Map<dynamic, dynamic>>();
   @override
-  Stream<Map<dynamic, dynamic>> get notifications =>
-      _notificationController.stream;
+  Stream<Map<dynamic, dynamic>> get notifications => _notificationController.stream;
 
   FirebaseNotifications() {
     _firebaseMessaging = FirebaseMessaging.instance;
@@ -47,10 +46,9 @@ class FirebaseNotifications implements Notifications {
 
   @override
   Future<String> getToken() async {
-    _firebaseNotificationSettings = await _firebaseMessaging.requestPermission(
-        sound: true, badge: true, alert: true);
-    if (_firebaseNotificationSettings.authorizationStatus ==
-        AuthorizationStatus.authorized) {
+    _firebaseNotificationSettings =
+        await _firebaseMessaging.requestPermission(sound: true, badge: true, alert: true);
+    if (_firebaseNotificationSettings.authorizationStatus == AuthorizationStatus.authorized) {
       return _firebaseMessaging.getToken();
     } else {
       return null;

--- a/lib/services/permissions.dart
+++ b/lib/services/permissions.dart
@@ -1,24 +1,17 @@
 import 'package:flutter/services.dart';
 
 class Permissions {
-  static const MethodChannel channel =
-      MethodChannel('com.breez.client/permissions');
+  static const MethodChannel channel = MethodChannel('com.breez.client/permissions');
 
   Future<bool> requestOptimizationWhitelist() {
-    return channel
-        .invokeMethod('requestOptimizationWhitelist')
-        .then((res) => res as bool);
+    return channel.invokeMethod('requestOptimizationWhitelist').then((res) => res as bool);
   }
 
   Future<bool> requestOptimizationSettings() {
-    return channel
-        .invokeMethod('requestOptimizationSettings')
-        .then((res) => res as bool);
+    return channel.invokeMethod('requestOptimizationSettings').then((res) => res as bool);
   }
 
   Future<bool> isInOptimizationWhitelist() {
-    return channel
-        .invokeMethod("isInOptimizationWhitelist")
-        .then((res) => res as bool);
+    return channel.invokeMethod("isInOptimizationWhitelist").then((res) => res as bool);
   }
 }

--- a/lib/theme_data.dart
+++ b/lib/theme_data.dart
@@ -45,10 +45,7 @@ final CustomData darkThemeCustomData = CustomData(
   navigationDrawerBgColor: const Color(0xFF152a3d),
   navigationDrawerHeaderBgColor: const Color.fromRGBO(13, 32, 50, 1),
 );
-final Map<String, CustomData> customData = {
-  "BLUE": blueThemeCustomData,
-  "DARK": darkThemeCustomData
-};
+final Map<String, CustomData> customData = {"BLUE": blueThemeCustomData, "DARK": darkThemeCustomData};
 
 final ThemeData blueTheme = ThemeData(
   brightness: Brightness.dark,
@@ -240,19 +237,15 @@ final ThemeData darkTheme = ThemeData(
     ),
     actionsIconTheme: const IconThemeData(color: Colors.white),
     toolbarTextStyle: const TextTheme(
-      titleLarge:
-          TextStyle(color: Colors.white, fontSize: 18.0, letterSpacing: 0.22),
+      titleLarge: TextStyle(color: Colors.white, fontSize: 18.0, letterSpacing: 0.22),
     ).bodyMedium,
     titleTextStyle: const TextTheme(
-      titleLarge:
-          TextStyle(color: Colors.white, fontSize: 18.0, letterSpacing: 0.22),
+      titleLarge: TextStyle(color: Colors.white, fontSize: 18.0, letterSpacing: 0.22),
     ).titleLarge,
   ),
   dialogTheme: const DialogTheme(
-    titleTextStyle:
-        TextStyle(color: Colors.white, fontSize: 20.5, letterSpacing: 0.25),
-    contentTextStyle:
-        TextStyle(color: Colors.white70, fontSize: 16.0, height: 1.5),
+    titleTextStyle: TextStyle(color: Colors.white, fontSize: 20.5, letterSpacing: 0.25),
+    contentTextStyle: TextStyle(color: Colors.white70, fontSize: 16.0, height: 1.5),
     backgroundColor: Color(0xFF152a3d),
     shape: RoundedRectangleBorder(
       borderRadius: BorderRadius.all(Radius.circular(12.0)),
@@ -263,11 +256,9 @@ final ThemeData darkTheme = ThemeData(
   cardColor: const Color(0xFF121212),
   highlightColor: const Color(0xFF0085fb),
   textTheme: const TextTheme(
-    titleSmall:
-        TextStyle(color: Colors.white, fontSize: 14.3, letterSpacing: 0.2),
+    titleSmall: TextStyle(color: Colors.white, fontSize: 14.3, letterSpacing: 0.2),
     headlineSmall: TextStyle(color: Colors.white, fontSize: 26.0),
-    labelLarge:
-        TextStyle(color: Colors.white, fontSize: 14.3, letterSpacing: 1.25),
+    labelLarge: TextStyle(color: Colors.white, fontSize: 14.3, letterSpacing: 1.25),
     headlineMedium: TextStyle(
       color: Color(0xffffe685),
       fontSize: 18.0,
@@ -365,8 +356,7 @@ final VendorTheme fastbitcoins = VendorTheme(
     iconBgColor: const Color(0xFFff7c10),
     iconFgColor: const Color(0xFF1f2a44),
     textColor: const Color(0xFF1f2a44));
-final VendorTheme geyser =
-    VendorTheme(iconBgColor: const Color.fromRGBO(41, 241, 205, 1));
+final VendorTheme geyser = VendorTheme(iconBgColor: const Color.fromRGBO(41, 241, 205, 1));
 final VendorTheme wavlake = VendorTheme(iconBgColor: const Color(0xFF171817));
 final VendorTheme lightsats = VendorTheme(
   iconBgColor: Colors.black,
@@ -402,15 +392,11 @@ final Map<String, VendorTheme> vendorTheme = {
   "azteco": azteco,
 };
 
-const TextStyle drawerItemTextStyle =
-    TextStyle(height: 1.2, letterSpacing: 0.25, fontSize: 14.3);
-final TextStyle notificationTextStyle = TextStyle(
-    color: BreezColors.grey[500],
-    fontSize: 10.0,
-    letterSpacing: 0.06,
-    height: 1.10);
-final TextStyle addFundsBtnStyle = TextStyle(
-    color: BreezColors.white[400], fontSize: 16.0, letterSpacing: 1.25);
+const TextStyle drawerItemTextStyle = TextStyle(height: 1.2, letterSpacing: 0.25, fontSize: 14.3);
+final TextStyle notificationTextStyle =
+    TextStyle(color: BreezColors.grey[500], fontSize: 10.0, letterSpacing: 0.06, height: 1.10);
+final TextStyle addFundsBtnStyle =
+    TextStyle(color: BreezColors.white[400], fontSize: 16.0, letterSpacing: 1.25);
 const TextStyle bottomAppBarBtnStyle = TextStyle(
     color: Colors.white,
     fontSize: 13.5,
@@ -419,11 +405,7 @@ const TextStyle bottomAppBarBtnStyle = TextStyle(
     height: 1.24,
     fontFamily: 'IBMPlexSans');
 const TextStyle bottomSheetTextStyle = TextStyle(
-    fontFamily: 'IBMPlexSans',
-    fontSize: 15,
-    letterSpacing: 1.2,
-    fontWeight: FontWeight.w400,
-    height: 1.30);
+    fontFamily: 'IBMPlexSans', fontSize: 15, letterSpacing: 1.2, fontWeight: FontWeight.w400, height: 1.30);
 final TextStyle addFundsItemsStyle = TextStyle(
     color: BreezColors.white[500],
     fontSize: 14.3,
@@ -431,12 +413,10 @@ final TextStyle addFundsItemsStyle = TextStyle(
     height: 1.16,
     fontWeight: FontWeight.w500,
     fontFamily: 'IBMPlexSans');
-final TextStyle bottomSheetMenuItemStyle = TextStyle(
-    color: BreezColors.white[400], fontSize: 14.3, letterSpacing: 0.55);
-const TextStyle autoCompleteStyle =
-    TextStyle(color: Colors.black, fontSize: 14.0);
-final TextStyle blueLinkStyle =
-    TextStyle(color: BreezColors.blue[500], fontSize: 16.0, height: 1.5);
+final TextStyle bottomSheetMenuItemStyle =
+    TextStyle(color: BreezColors.white[400], fontSize: 14.3, letterSpacing: 0.55);
+const TextStyle autoCompleteStyle = TextStyle(color: Colors.black, fontSize: 14.0);
+final TextStyle blueLinkStyle = TextStyle(color: BreezColors.blue[500], fontSize: 16.0, height: 1.5);
 final TextStyle avatarDialogStyle = TextStyle(
     color: BreezColors.blue[900],
     fontSize: 16.4,
@@ -444,47 +424,28 @@ final TextStyle avatarDialogStyle = TextStyle(
     fontWeight: FontWeight.w500,
     fontFamily: 'IBMPlexSans');
 const TextStyle errorStyle = TextStyle(color: errorColor, fontSize: 12.0);
-final TextStyle textStyle =
-    TextStyle(color: BreezColors.white[400], fontSize: 16.0);
+final TextStyle textStyle = TextStyle(color: BreezColors.white[400], fontSize: 16.0);
 const TextStyle navigationDrawerHandleStyle = TextStyle(
   fontSize: 16.0,
   letterSpacing: 0.2,
   color: Color.fromRGBO(255, 255, 255, 0.6),
 );
 const TextStyle warningStyle = TextStyle(color: errorColor, fontSize: 16.0);
-final TextStyle instructionStyle =
-    TextStyle(color: BreezColors.white[400], fontSize: 14.3);
-const TextStyle validatorStyle =
-    TextStyle(color: Color(0xFFe3b42f), fontSize: 12.0, height: 1.25);
-final TextStyle welcomeTextStyle =
-    TextStyle(color: BreezColors.white[500], fontSize: 16.0, height: 1.1);
-final TextStyle skipStyle = TextStyle(
-    color: BreezColors.white[500], fontSize: 16.0, letterSpacing: 1.25);
-final TextStyle buttonStyle = TextStyle(
-    color: BreezColors.blue[500], fontSize: 14.3, letterSpacing: 1.25);
-final TextStyle whiteButtonStyle = TextStyle(
-    color: BreezColors.white[500], fontSize: 14.3, letterSpacing: 1.25);
+final TextStyle instructionStyle = TextStyle(color: BreezColors.white[400], fontSize: 14.3);
+const TextStyle validatorStyle = TextStyle(color: Color(0xFFe3b42f), fontSize: 12.0, height: 1.25);
+final TextStyle welcomeTextStyle = TextStyle(color: BreezColors.white[500], fontSize: 16.0, height: 1.1);
+final TextStyle skipStyle = TextStyle(color: BreezColors.white[500], fontSize: 16.0, letterSpacing: 1.25);
+final TextStyle buttonStyle = TextStyle(color: BreezColors.blue[500], fontSize: 14.3, letterSpacing: 1.25);
+final TextStyle whiteButtonStyle =
+    TextStyle(color: BreezColors.white[500], fontSize: 14.3, letterSpacing: 1.25);
 final TextStyle appBarLogoStyle = TextStyle(
-    color: BreezColors.logo[2],
-    fontSize: 23.5,
-    letterSpacing: 0.15,
-    fontFamily: 'Breez Logo',
-    height: 0.9);
-final TextStyle posTransactionTitleStyle = TextStyle(
-    color: BreezColors.white[500],
-    fontSize: 14.4,
-    letterSpacing: 0.44,
-    height: 1.28);
-final TextStyle transactionTitleStyle = TextStyle(
-    color: BreezColors.white[500],
-    fontSize: 14.3,
-    letterSpacing: 0.25,
-    height: 1.2);
-final TextStyle transactionSubtitleStyle = TextStyle(
-    color: BreezColors.white[200],
-    fontSize: 12.3,
-    letterSpacing: 0.4,
-    height: 1.16);
+    color: BreezColors.logo[2], fontSize: 23.5, letterSpacing: 0.15, fontFamily: 'Breez Logo', height: 0.9);
+final TextStyle posTransactionTitleStyle =
+    TextStyle(color: BreezColors.white[500], fontSize: 14.4, letterSpacing: 0.44, height: 1.28);
+final TextStyle transactionTitleStyle =
+    TextStyle(color: BreezColors.white[500], fontSize: 14.3, letterSpacing: 0.25, height: 1.2);
+final TextStyle transactionSubtitleStyle =
+    TextStyle(color: BreezColors.white[200], fontSize: 12.3, letterSpacing: 0.4, height: 1.16);
 final TextStyle transactionAmountStyle = TextStyle(
     color: BreezColors.white[500],
     fontSize: 16.4,
@@ -492,11 +453,8 @@ final TextStyle transactionAmountStyle = TextStyle(
     height: 1.28,
     fontWeight: FontWeight.w500,
     fontFamily: 'IBMPlexSans');
-const TextStyle posWithdrawalTransactionTitleStyle = TextStyle(
-    color: Color.fromRGBO(255, 255, 255, 0.7),
-    fontSize: 14.4,
-    letterSpacing: 0.44,
-    height: 1.28);
+const TextStyle posWithdrawalTransactionTitleStyle =
+    TextStyle(color: Color.fromRGBO(255, 255, 255, 0.7), fontSize: 14.4, letterSpacing: 0.44, height: 1.28);
 const TextStyle posWithdrawalTransactionAmountStyle = TextStyle(
     color: Color.fromRGBO(255, 255, 255, 0.7),
     fontSize: 16.4,
@@ -511,11 +469,8 @@ final TextStyle cancelButtonStyle = TextStyle(
     fontSize: 14.0,
     fontWeight: FontWeight.w500,
     fontFamily: 'IBMPlexSans');
-final TextStyle backupPhraseInformationTextStyle = TextStyle(
-    color: BreezColors.white[500],
-    fontSize: 14.3,
-    letterSpacing: 0.4,
-    height: 1.16);
+final TextStyle backupPhraseInformationTextStyle =
+    TextStyle(color: BreezColors.white[500], fontSize: 14.3, letterSpacing: 0.4, height: 1.16);
 final TextStyle backupPhraseConfirmationTextStyle = TextStyle(
     color: BreezColors.white[500],
     fontSize: 14.3,
@@ -523,37 +478,22 @@ final TextStyle backupPhraseConfirmationTextStyle = TextStyle(
     height: 1.16,
     fontWeight: FontWeight.w500,
     fontFamily: 'IBMPlexSans');
-final TextStyle mnemonicsTextStyle = TextStyle(
-    color: BreezColors.white[400],
-    fontSize: 16.4,
-    letterSpacing: 0.73,
-    height: 1.25);
-final TextStyle invoiceMemoStyle = TextStyle(
-    color: BreezColors.grey[500],
-    fontSize: 12.3,
-    height: 1.16,
-    letterSpacing: 0.4);
-final TextStyle invoiceChargeAmountStyle = TextStyle(
-    color: BreezColors.white[500],
-    fontSize: 14.3,
-    height: 1.16,
-    letterSpacing: 1.25);
-final TextStyle invoiceAmountStyle = TextStyle(
-    color: BreezColors.grey[600],
-    fontSize: 18.0,
-    height: 1.32,
-    letterSpacing: 0.2);
-final TextStyle currencyDropdownStyle = TextStyle(
-    color: BreezColors.grey[600],
-    fontSize: 16.3,
-    height: 1.32,
-    letterSpacing: 0.15);
-final TextStyle numPadNumberStyle = TextStyle(
-    color: BreezColors.white[500], fontSize: 20.0, letterSpacing: 0.18);
-final TextStyle numPadAdditionStyle = TextStyle(
-    color: BreezColors.white[500], fontSize: 32.0, letterSpacing: 0.18);
-final TextStyle smallTextStyle = TextStyle(
-    color: BreezColors.white[500], fontSize: 10.0, letterSpacing: 0.09);
+final TextStyle mnemonicsTextStyle =
+    TextStyle(color: BreezColors.white[400], fontSize: 16.4, letterSpacing: 0.73, height: 1.25);
+final TextStyle invoiceMemoStyle =
+    TextStyle(color: BreezColors.grey[500], fontSize: 12.3, height: 1.16, letterSpacing: 0.4);
+final TextStyle invoiceChargeAmountStyle =
+    TextStyle(color: BreezColors.white[500], fontSize: 14.3, height: 1.16, letterSpacing: 1.25);
+final TextStyle invoiceAmountStyle =
+    TextStyle(color: BreezColors.grey[600], fontSize: 18.0, height: 1.32, letterSpacing: 0.2);
+final TextStyle currencyDropdownStyle =
+    TextStyle(color: BreezColors.grey[600], fontSize: 16.3, height: 1.32, letterSpacing: 0.15);
+final TextStyle numPadNumberStyle =
+    TextStyle(color: BreezColors.white[500], fontSize: 20.0, letterSpacing: 0.18);
+final TextStyle numPadAdditionStyle =
+    TextStyle(color: BreezColors.white[500], fontSize: 32.0, letterSpacing: 0.18);
+final TextStyle smallTextStyle =
+    TextStyle(color: BreezColors.white[500], fontSize: 10.0, letterSpacing: 0.09);
 final TextStyle linkStyle = TextStyle(
     color: BreezColors.white[300],
     fontSize: 12.3,
@@ -566,11 +506,8 @@ final TextStyle restoreLinkStyle = TextStyle(
     letterSpacing: 0.4,
     height: 1.2,
     decoration: TextDecoration.underline);
-final TextStyle snackBarStyle = TextStyle(
-    color: BreezColors.white[500],
-    fontSize: 14.0,
-    letterSpacing: 0.25,
-    height: 1.2);
+final TextStyle snackBarStyle =
+    TextStyle(color: BreezColors.white[500], fontSize: 14.0, letterSpacing: 0.25, height: 1.2);
 const TextStyle sessionActionBtnStyle = TextStyle(fontSize: 12.3);
 const TextStyle sessionNotificationStyle = TextStyle(fontSize: 14.2);
 final TextStyle paymentDetailsTitleStyle = TextStyle(
@@ -580,29 +517,19 @@ final TextStyle paymentDetailsTitleStyle = TextStyle(
     height: 1.28,
     fontWeight: FontWeight.w500,
     fontFamily: 'IBMPlexSans');
-final TextStyle paymentDetailsSubtitleStyle = TextStyle(
-    color: BreezColors.grey[500],
-    fontSize: 14.0,
-    letterSpacing: 0.0,
-    height: 1.28);
-final TextStyle fastbitcoinsTextStyle = TextStyle(
-    color: fastbitcoins.textColor,
-    fontSize: 11.0,
-    letterSpacing: 0.0,
-    fontFamily: 'ComfortaaBold');
+final TextStyle paymentDetailsSubtitleStyle =
+    TextStyle(color: BreezColors.grey[500], fontSize: 14.0, letterSpacing: 0.0, height: 1.28);
+final TextStyle fastbitcoinsTextStyle =
+    TextStyle(color: fastbitcoins.textColor, fontSize: 11.0, letterSpacing: 0.0, fontFamily: 'ComfortaaBold');
 final TextStyle vendorTitleStyle = TextStyle(
     color: BreezColors.white[500],
     fontSize: 36.0,
     fontWeight: FontWeight.w600,
     letterSpacing: 1.1,
     fontFamily: 'Roboto');
-final TextStyle fiatConversionTitleStyle = TextStyle(
-    color: BreezColors.white[500],
-    fontSize: 16.3,
-    letterSpacing: 0.25,
-    height: 1.2);
-final TextStyle fiatConversionDescriptionStyle =
-    TextStyle(color: BreezColors.white[200], fontSize: 14.3);
+final TextStyle fiatConversionTitleStyle =
+    TextStyle(color: BreezColors.white[500], fontSize: 16.3, letterSpacing: 0.25, height: 1.2);
+final TextStyle fiatConversionDescriptionStyle = TextStyle(color: BreezColors.white[200], fontSize: 14.3);
 final BoxDecoration boxDecoration = BoxDecoration(
   border: Border(
     bottom: BorderSide(color: BreezColors.white[500], width: 1.5),
@@ -625,11 +552,9 @@ final Color circularLoaderColor = BreezColors.blue[200].withOpacity(0.7);
 const Color warningBoxColor = Color.fromRGBO(251, 233, 148, 0.1);
 final BorderSide greyBorderSide = BorderSide(color: BreezColors.grey[500]);
 
-ThemeData get calendarTheme =>
-    themeId == "BLUE" ? calendarLightTheme : calendarDarkTheme;
+ThemeData get calendarTheme => themeId == "BLUE" ? calendarLightTheme : calendarDarkTheme;
 
-Color get buttonColor =>
-    themeId == "BLUE" ? Colors.white : const Color(0xFF4B89EB);
+Color get buttonColor => themeId == "BLUE" ? Colors.white : const Color(0xFF4B89EB);
 
 final ThemeData calendarLightTheme = ThemeData.light().copyWith(
   colorScheme: const ColorScheme.light(
@@ -669,10 +594,8 @@ final ThemeData calendarDarkTheme = ThemeData.dark().copyWith(
 class FieldTextStyle {
   FieldTextStyle._();
 
-  static TextStyle textStyle = TextStyle(
-      color: BreezColors.white[500], fontSize: 16.4, letterSpacing: 0.15);
-  static TextStyle labelStyle =
-      TextStyle(color: BreezColors.white[200], letterSpacing: 0.4);
+  static TextStyle textStyle = TextStyle(color: BreezColors.white[500], fontSize: 16.4, letterSpacing: 0.15);
+  static TextStyle labelStyle = TextStyle(color: BreezColors.white[200], letterSpacing: 0.4);
 }
 
 class BreezColors {
@@ -718,25 +641,22 @@ class VendorTheme {
 }
 
 extension CustomStyles on TextTheme {
-  TextStyle get itemTitleStyle =>
-      TextStyle(color: BreezColors.white[500], fontSize: 16.4);
+  TextStyle get itemTitleStyle => TextStyle(color: BreezColors.white[500], fontSize: 16.4);
 
-  TextStyle get itemPriceStyle => TextStyle(
-      color: BreezColors.white[500], letterSpacing: 0.5, fontSize: 14.3);
+  TextStyle get itemPriceStyle =>
+      TextStyle(color: BreezColors.white[500], letterSpacing: 0.5, fontSize: 14.3);
 }
 
 extension CustomIconThemes on IconThemeData {
-  IconThemeData get deleteBadgeIconTheme =>
-      IconThemeData(color: BreezColors.grey[500], size: 20.0);
+  IconThemeData get deleteBadgeIconTheme => IconThemeData(color: BreezColors.grey[500], size: 20.0);
 }
 
 extension ThemeExtensions on ThemeData {
   bool get isLightTheme => primaryColor == blueTheme.primaryColor;
 
   // Replaces accentTextTheme.bodyMedium
-  TextStyle get statusTextStyle => isLightTheme
-      ? TextStyle(color: BreezColors.grey[600])
-      : const TextStyle(color: Colors.white);
+  TextStyle get statusTextStyle =>
+      isLightTheme ? TextStyle(color: BreezColors.grey[600]) : const TextStyle(color: Colors.white);
 
   // Replaces accentTextTheme.titleSmall
   TextStyle get paymentItemTitleTextStyle => isLightTheme
@@ -792,15 +712,8 @@ extension ThemeExtensions on ThemeData {
   // Replaces accentTextTheme.headlineMedium
   TextStyle get walletDashboardHeaderTextStyle => isLightTheme
       ? const TextStyle(
-          color: Color.fromRGBO(0, 133, 251, 1.0),
-          fontSize: 30.0,
-          fontWeight: FontWeight.w600,
-          height: 1.52)
-      : const TextStyle(
-          color: Colors.white,
-          fontSize: 30.0,
-          fontWeight: FontWeight.w600,
-          height: 1.56);
+          color: Color.fromRGBO(0, 133, 251, 1.0), fontSize: 30.0, fontWeight: FontWeight.w600, height: 1.52)
+      : const TextStyle(color: Colors.white, fontSize: 30.0, fontWeight: FontWeight.w600, height: 1.56);
 
   // Replaces accentTextTheme.titleMedium
   TextStyle get walletDashboardFiatTextStyle => isLightTheme
@@ -811,9 +724,5 @@ extension ThemeExtensions on ThemeData {
           height: 1.24,
           letterSpacing: 0.2)
       : const TextStyle(
-          color: Colors.white,
-          fontSize: 15,
-          fontWeight: FontWeight.w500,
-          height: 1.24,
-          letterSpacing: 0.2);
+          color: Colors.white, fontSize: 15, fontWeight: FontWeight.w500, height: 1.24, letterSpacing: 0.2);
 }

--- a/lib/user_app.dart
+++ b/lib/user_app.dart
@@ -60,8 +60,7 @@ Widget _withTheme(BreezUserModel user, Widget child) {
 // ignore: must_be_immutable
 class UserApp extends StatelessWidget {
   final GlobalKey<NavigatorState> _navigatorKey = GlobalKey<NavigatorState>();
-  final GlobalKey<NavigatorState> _homeNavigatorKey =
-      GlobalKey<NavigatorState>();
+  final GlobalKey<NavigatorState> _homeNavigatorKey = GlobalKey<NavigatorState>();
   Sink<bool> _reloadDatabaseSink;
 
   UserApp(Sink<bool> reloadDatabaseSink) {
@@ -120,17 +119,13 @@ class UserApp extends StatelessWidget {
                 final MediaQueryData data = MediaQuery.of(context);
                 return MediaQuery(
                   data: data.copyWith(
-                    textScaleFactor: (data.textScaleFactor >= 1.3)
-                        ? 1.3
-                        : data.textScaleFactor,
+                    textScaleFactor: (data.textScaleFactor >= 1.3) ? 1.3 : data.textScaleFactor,
                   ),
                   child: _withTheme(user, child),
                 );
               },
             ),
-            initialRoute: user.registrationRequested
-                ? (user.locked ? '/lockscreen' : "/")
-                : '/splash',
+            initialRoute: user.registrationRequested ? (user.locked ? '/lockscreen' : "/") : '/splash',
             // ignore: missing_return
             onGenerateRoute: (RouteSettings settings) {
               switch (settings.name) {
@@ -163,21 +158,20 @@ class UserApp extends StatelessWidget {
                             );
                           });
                         },
-                        onFingerprintEntered:
-                            user.securityModel.isFingerprintEnabled
-                                ? (isValid) async {
-                                    if (isValid) {
-                                      final navigator = Navigator.of(ctx);
-                                      await Future.delayed(
-                                        const Duration(milliseconds: 200),
-                                      );
-                                      navigator.pop();
-                                      userProfileBloc.userActionsSink.add(
-                                        SetLockState(false),
-                                      );
-                                    }
-                                  }
-                                : null,
+                        onFingerprintEntered: user.securityModel.isFingerprintEnabled
+                            ? (isValid) async {
+                                if (isValid) {
+                                  final navigator = Navigator.of(ctx);
+                                  await Future.delayed(
+                                    const Duration(milliseconds: 200),
+                                  );
+                                  navigator.pop();
+                                  userProfileBloc.userActionsSink.add(
+                                    SetLockState(false),
+                                  );
+                                }
+                              }
+                            : null,
                         userProfileBloc: userProfileBloc,
                       ),
                     ),

--- a/lib/utils/bip21.dart
+++ b/lib/utils/bip21.dart
@@ -20,8 +20,7 @@ String extractBitcoinAddress(String address) {
   if (address.toLowerCase().startsWith(URN_SCHEME)) {
     try {
       int split = address.indexOf("?");
-      String addr =
-          address.substring(URN_SCHEME.length, split == -1 ? null : split);
+      String addr = address.substring(URN_SCHEME.length, split == -1 ? null : split);
       if (addr.isNotEmpty) {
         isLegacyOrNestedSegwit(addr) ? addr : addr = addr.toLowerCase();
         return addr;

--- a/lib/utils/date.dart
+++ b/lib/utils/date.dart
@@ -8,16 +8,13 @@ class BreezDateUtils {
   static final localeName = Platform.localeName ?? "en";
   static final DateFormat _monthDateFormat = DateFormat.Md(localeName);
   static final DateFormat _yearMonthDayFormat = DateFormat.yMd(localeName);
-  static final DateFormat _yearMonthDayHourMinuteFormat =
-      DateFormat.yMd().add_jm();
-  static final DateFormat _yearMonthDayHourMinuteSecondFormat =
-      DateFormat.yMd(localeName).add_Hms();
+  static final DateFormat _yearMonthDayHourMinuteFormat = DateFormat.yMd().add_jm();
+  static final DateFormat _yearMonthDayHourMinuteSecondFormat = DateFormat.yMd(localeName).add_Hms();
   static final DateFormat _hourMinuteDayFormat = DateFormat.jm(localeName);
 
   static String formatMonthDate(DateTime d) => _monthDateFormat.format(d);
   static String formatYearMonthDay(DateTime d) => _yearMonthDayFormat.format(d);
-  static String formatYearMonthDayHourMinute(DateTime d) =>
-      _yearMonthDayHourMinuteFormat.format(d);
+  static String formatYearMonthDayHourMinute(DateTime d) => _yearMonthDayHourMinuteFormat.format(d);
   static String formatYearMonthDayHourMinuteSecond(DateTime d) =>
       _yearMonthDayHourMinuteSecondFormat.format(d);
 
@@ -32,15 +29,12 @@ class BreezDateUtils {
   static String formatHourMinute(DateTime d) => _hourMinuteDayFormat.format(d);
 
   static String formatFilterDateRange(DateTime startDate, DateTime endDate) {
-    var formatter = (startDate.year == endDate.year)
-        ? _monthDateFormat
-        : _yearMonthDayFormat;
+    var formatter = (startDate.year == endDate.year) ? _monthDateFormat : _yearMonthDayFormat;
     return "${formatter.format(startDate)}-${formatter.format(endDate)}";
   }
 
   static void setupLocales() {
-    timeago.setLocaleMessages(
-        'bg', timeago.EnMessages()); // TODO: add bg locale
+    timeago.setLocaleMessages('bg', timeago.EnMessages()); // TODO: add bg locale
     timeago.setLocaleMessages('cs', timeago.CsMessages());
     timeago.setLocaleMessages('de', timeago.DeMessages());
     timeago.setLocaleMessages('el', timeago.GrMessages());
@@ -50,8 +44,7 @@ class BreezDateUtils {
     timeago.setLocaleMessages('fr', timeago.FrMessages());
     timeago.setLocaleMessages('it', timeago.ItMessages());
     timeago.setLocaleMessages('pt', timeago.PtBrMessages());
-    timeago.setLocaleMessages(
-        'sk', timeago.EnMessages()); // TODO: add sk locale
+    timeago.setLocaleMessages('sk', timeago.EnMessages()); // TODO: add sk locale
     timeago.setLocaleMessages('sv', timeago.SvMessages());
   }
 }

--- a/lib/utils/dynamic_fees.dart
+++ b/lib/utils/dynamic_fees.dart
@@ -11,6 +11,5 @@ Future<List<LSPInfo>> fetchLSPList(LSPBloc lspBloc) async {
 
 bool hasFeesChanged(OpeningFeeParams oldFees, OpeningFeeParams newFees) {
   // Mark fee as changed only if new fees are higher
-  return (newFees.minMsat > oldFees.minMsat) ||
-      (newFees.proportional > oldFees.proportional);
+  return (newFees.minMsat > oldFees.minMsat) || (newFees.proportional > oldFees.proportional);
 }

--- a/lib/utils/lnurl.dart
+++ b/lib/utils/lnurl.dart
@@ -24,8 +24,7 @@ bool isLNURL(String url) {
     Uri uri = Uri.parse(lower);
     String lightning = uri.queryParameters["lightning"];
     return lightning != null &&
-        (_lnurlPrefix.firstMatch(lightning) != null ||
-            _lnurlRfc17Prefix.firstMatch(lightning) != null);
+        (_lnurlPrefix.firstMatch(lightning) != null || _lnurlRfc17Prefix.firstMatch(lightning) != null);
   } on FormatException {
     // do nothing.
   }
@@ -43,8 +42,7 @@ bool isLightningAddressURI(String uri) {
   var result = false;
 
   if (uri != null) {
-    result = uri.toLowerCase().startsWith(_lightningProtocolPrefix) &&
-        isLightningAddress(uri);
+    result = uri.toLowerCase().startsWith(_lightningProtocolPrefix) && isLightningAddress(uri);
   }
   return result;
 }

--- a/lib/utils/min_font_size.dart
+++ b/lib/utils/min_font_size.dart
@@ -6,7 +6,5 @@ class MinFontSize {
 
   MinFontSize(this.context, {this.fontSize});
 
-  double get minFontSize =>
-      ((fontSize ?? 12) / MediaQuery.of(context).textScaleFactor)
-          .floorToDouble();
+  double get minFontSize => ((fontSize ?? 12) / MediaQuery.of(context).textScaleFactor).floorToDouble();
 }

--- a/lib/utils/node_id.dart
+++ b/lib/utils/node_id.dart
@@ -14,8 +14,7 @@ String parseNodeId(String nodeID) {
   }
 
   if (nodeID.length > NODE_ID_LENGTH &&
-      nodeID.substring(NODE_ID_LENGTH, NODE_ID_LENGTH + 1) ==
-          NODE_URI_SEPARATOR) {
+      nodeID.substring(NODE_ID_LENGTH, NODE_ID_LENGTH + 1) == NODE_URI_SEPARATOR) {
     nodeID = nodeID.substring(0, NODE_ID_LENGTH);
     if (_isParsable(nodeID)) {
       return nodeID;

--- a/lib/utils/print_pdf.dart
+++ b/lib/utils/print_pdf.dart
@@ -281,13 +281,9 @@ class PrintService {
             : [
                 pw.Text(
                   "${addParenthesis ? "(" : ""}${_buildPriceValue(saleCurrency, amount)}${addParenthesis ? ")" : ""}",
-                  textDirection: saleCurrency.rtl
-                      ? pw.TextDirection.rtl
-                      : pw.TextDirection.ltr,
+                  textDirection: saleCurrency.rtl ? pw.TextDirection.rtl : pw.TextDirection.ltr,
                   style: pw.TextStyle(
-                    font: saleCurrency.rtl
-                        ? pw.Font.ttf(fontMap["rtl"])
-                        : pw.Font.ttf(fontMap["ltr"]),
+                    font: saleCurrency.rtl ? pw.Font.ttf(fontMap["rtl"]) : pw.Font.ttf(fontMap["ltr"]),
                     fontSize: 12.3,
                   ),
                 ),

--- a/lib/utils/stream_builder_extensions.dart
+++ b/lib/utils/stream_builder_extensions.dart
@@ -66,8 +66,7 @@ class StreamBuilder3<A, B, C> extends StatelessWidget {
         stream: streamB,
         builder: (context, snapshotB) => StreamBuilder(
           stream: streamC,
-          builder: (context, snapshotC) =>
-              builder(context, snapshotA, snapshotB, snapshotC),
+          builder: (context, snapshotC) => builder(context, snapshotA, snapshotB, snapshotC),
         ),
       ),
     );
@@ -113,8 +112,7 @@ class StreamBuilder4<A, B, C, D> extends StatelessWidget {
           stream: streamC,
           builder: (context, snapshotC) => StreamBuilder(
             stream: streamD,
-            builder: (context, snapshotD) =>
-                builder(context, snapshotA, snapshotB, snapshotC, snapshotD),
+            builder: (context, snapshotD) => builder(context, snapshotA, snapshotB, snapshotC, snapshotD),
           ),
         ),
       ),

--- a/lib/utils/webview_controller_util.dart
+++ b/lib/utils/webview_controller_util.dart
@@ -20,8 +20,7 @@ WebViewController setWebViewController({
     )
     ..addJavaScriptChannel(
       "BreezWebView",
-      onMessageReceived: (JavaScriptMessage message) =>
-          onMessageReceived(message),
+      onMessageReceived: (JavaScriptMessage message) => onMessageReceived(message),
     )
     ..loadRequest(Uri.parse(url));
 }

--- a/lib/widgets/amount_form_field.dart
+++ b/lib/widgets/amount_form_field.dart
@@ -59,8 +59,7 @@ class AmountFormField extends TextFormField {
                       context: context,
                       builder: (_) => CurrencyConverterDialog(
                         returnFN ??
-                            (value) =>
-                                controller.text = accountModel.currency.format(
+                            (value) => controller.text = accountModel.currency.format(
                                   accountModel.currency.parse(value),
                                   includeCurrencySymbol: false,
                                   includeDisplayName: false,

--- a/lib/widgets/animated_loader_dialog.dart
+++ b/lib/widgets/animated_loader_dialog.dart
@@ -29,9 +29,7 @@ AlertDialog createAnimatedLoaderDialog(
           textAlign: TextAlign.center,
         ),
         Image.asset(
-          theme.themeId == "BLUE"
-              ? 'src/images/breez_loader_blue.gif'
-              : 'src/images/breez_loader_dark.gif',
+          theme.themeId == "BLUE" ? 'src/images/breez_loader_blue.gif' : 'src/images/breez_loader_dark.gif',
           height: 64.0,
           gaplessPlayback: true,
         ),

--- a/lib/widgets/breez_avatar.dart
+++ b/lib/widgets/breez_avatar.dart
@@ -22,8 +22,7 @@ class BreezAvatar extends StatelessWidget {
     if (avatarURL != null && avatarURL.isNotEmpty) {
       if (avatarURL.startsWith("breez://profile_image?")) {
         var queryParams = Uri.parse(avatarURL).queryParameters;
-        return _GeneratedAvatar(
-            radius, queryParams["animal"], queryParams["color"], avatarBgColor);
+        return _GeneratedAvatar(radius, queryParams["animal"], queryParams["color"], avatarBgColor);
       }
 
       if (avatarURL.startsWith("src/icon/vendors/")) {
@@ -79,8 +78,7 @@ class _GeneratedAvatar extends StatelessWidget {
   final String color;
   final Color backgroundColor;
 
-  const _GeneratedAvatar(
-      this.radius, this.animal, this.color, this.backgroundColor);
+  const _GeneratedAvatar(this.radius, this.animal, this.color, this.backgroundColor);
 
   @override
   Widget build(BuildContext context) {
@@ -180,11 +178,9 @@ class _VendorAvatar extends StatelessWidget {
   }
 
   Widget _vendorAvatar() {
-    String vendorName =
-        RegExp("(?<=vendors/)(.*)(?=_logo)").stringMatch(avatarURL);
+    String vendorName = RegExp("(?<=vendors/)(.*)(?=_logo)").stringMatch(avatarURL);
     var bgColor = theme.vendorTheme[vendorName]?.iconBgColor ?? Colors.white;
-    var fgColor =
-        theme.vendorTheme[vendorName]?.iconFgColor ?? Colors.transparent;
+    var fgColor = theme.vendorTheme[vendorName]?.iconFgColor ?? Colors.transparent;
     return CircleAvatar(
       radius: radius,
       child: Container(
@@ -192,8 +188,7 @@ class _VendorAvatar extends StatelessWidget {
             color: bgColor,
             shape: CircleBorder(side: BorderSide(color: bgColor)),
             image: DecorationImage(
-                image: AssetImage(avatarURL),
-                colorFilter: ColorFilter.mode(fgColor, BlendMode.color))),
+                image: AssetImage(avatarURL), colorFilter: ColorFilter.mode(fgColor, BlendMode.color))),
       ),
     );
   }

--- a/lib/widgets/breez_avatar_dialog.dart
+++ b/lib/widgets/breez_avatar_dialog.dart
@@ -65,9 +65,7 @@ Widget breezAvatarDialog(BuildContext context, UserProfileBloc userBloc) {
                       top: Radius.circular(12.0),
                     ),
                   ),
-                  color: theme.themeId == "BLUE"
-                      ? themeData.primaryColorDark
-                      : themeData.canvasColor,
+                  color: theme.themeId == "BLUE" ? themeData.primaryColorDark : themeData.canvasColor,
                 ),
               ),
               SizedBox(
@@ -116,13 +114,10 @@ Widget breezAvatarDialog(BuildContext context, UserProfileBloc userBloc) {
                                       child: AspectRatio(
                                         aspectRatio: 1,
                                         child: CircularProgressIndicator(
-                                          valueColor:
-                                              AlwaysStoppedAnimation<Color>(
-                                            themeData.primaryTextTheme
-                                                .labelLarge.color,
+                                          valueColor: AlwaysStoppedAnimation<Color>(
+                                            themeData.primaryTextTheme.labelLarge.color,
                                           ),
-                                          backgroundColor:
-                                              themeData.colorScheme.background,
+                                          backgroundColor: themeData.colorScheme.background,
                                         ),
                                       ),
                                     )
@@ -251,10 +246,7 @@ Widget breezAvatarDialog(BuildContext context, UserProfileBloc userBloc) {
 }
 
 Future _uploadImage(File pickedImage, UserProfileBloc userBloc) async {
-  return pickedImage
-      .readAsBytes()
-      .then(_scaleAndFormatPNG)
-      .then((imageBytes) async {
+  return pickedImage.readAsBytes().then(_scaleAndFormatPNG).then((imageBytes) async {
     var action = UploadProfilePicture(imageBytes);
     userBloc.userActionsSink.add(action);
     return action.future;

--- a/lib/widgets/breez_drawer_header.dart
+++ b/lib/widgets/breez_drawer_header.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: overridden_fields
+
 import 'package:flutter/material.dart';
 
 const double _kBreezDrawerHeaderHeight = 160.0 + 1.0; // bottom edge

--- a/lib/widgets/breez_navigation_drawer.dart
+++ b/lib/widgets/breez_navigation_drawer.dart
@@ -220,9 +220,7 @@ GestureDetector _buildThemeSwitch(
                   "src/icon/ic_lightmode.png",
                   height: 24,
                   width: 24,
-                  color: snapshot.data.themeId == "BLUE"
-                      ? Colors.white
-                      : Colors.white30,
+                  color: snapshot.data.themeId == "BLUE" ? Colors.white : Colors.white30,
                 ),
                 const SizedBox(
                   height: 20,
@@ -233,9 +231,7 @@ GestureDetector _buildThemeSwitch(
                 ),
                 ImageIcon(
                   const AssetImage("src/icon/ic_darkmode.png"),
-                  color: snapshot.data.themeId == "DARK"
-                      ? Colors.white
-                      : Colors.white30,
+                  color: snapshot.data.themeId == "DARK" ? Colors.white : Colors.white30,
                   size: 24.0,
                 ),
               ],
@@ -327,9 +323,7 @@ Widget _actionTile(
       decoration: subTile != null
           ? null
           : BoxDecoration(
-              color: action.isSelected
-                  ? themeData.primaryColorLight
-                  : Colors.transparent,
+              color: action.isSelected ? themeData.primaryColorLight : Colors.transparent,
               borderRadius: const BorderRadius.horizontal(
                 right: Radius.circular(32),
               ),

--- a/lib/widgets/calendar_dialog.dart
+++ b/lib/widgets/calendar_dialog.dart
@@ -70,9 +70,7 @@ class CalendarDialogState extends State<CalendarDialog> {
           child: Text(
             texts.pos_transactions_range_dialog_clear,
             style: theme.cancelButtonStyle.copyWith(
-              color: theme.themeId == "BLUE"
-                  ? Colors.red
-                  : themeData.colorScheme.error,
+              color: theme.themeId == "BLUE" ? Colors.red : themeData.colorScheme.error,
             ),
           ),
         ),
@@ -142,9 +140,8 @@ class CalendarDialogState extends State<CalendarDialog> {
       },
     );
     if (selectedDate != null) {
-      Duration difference = isStartBtn
-          ? selectedDate.difference(_endDate)
-          : selectedDate.difference(_startDate);
+      Duration difference =
+          isStartBtn ? selectedDate.difference(_endDate) : selectedDate.difference(_startDate);
       if (difference.inDays < 0) {
         setState(() {
           isStartBtn ? _startDate = selectedDate : _endDate = selectedDate;
@@ -164,9 +161,7 @@ class CalendarDialogState extends State<CalendarDialog> {
   }
 
   void _applyControllers() {
-    if (_startDate != null &&
-        _endDate != null &&
-        _endDate.isBefore(_startDate)) {
+    if (_startDate != null && _endDate != null && _endDate.isBefore(_startDate)) {
       final temp = _endDate;
       _endDate = _startDate;
       _startDate = temp;

--- a/lib/widgets/circular_button.dart
+++ b/lib/widgets/circular_button.dart
@@ -13,11 +13,14 @@ class CircularButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return InkWell(
-        customBorder: const CircleBorder(),
-        onTap: onTap,
-        child: TextButton(
-            // ignore: missing_required_param
-            style: TextButton.styleFrom(padding: const EdgeInsets.all(24)),
-            child: child));
+      customBorder: const CircleBorder(),
+      onTap: onTap,
+      // ignore: missing_required_param
+      child: TextButton(
+        // ignore: missing_required_param
+        style: TextButton.styleFrom(padding: const EdgeInsets.all(24)),
+        child: child,
+      ),
+    );
   }
 }

--- a/lib/widgets/circular_progress.dart
+++ b/lib/widgets/circular_progress.dart
@@ -9,9 +9,7 @@ class CircularProgress extends StatelessWidget {
   final double size;
   final Color color;
 
-  const CircularProgress(
-      {Key key, this.value, this.title, this.size, this.color})
-      : super(key: key);
+  const CircularProgress({Key key, this.value, this.title, this.size, this.color}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/collapsible_list_item.dart
+++ b/lib/widgets/collapsible_list_item.dart
@@ -53,9 +53,7 @@ class CollapsibleListItem extends StatelessWidget {
                       textAlign: TextAlign.left,
                       overflow: TextOverflow.clip,
                       maxLines: 4,
-                      style: textTheme.displaySmall
-                          .copyWith(fontSize: 10)
-                          .merge(userStyle),
+                      style: textTheme.displaySmall.copyWith(fontSize: 10).merge(userStyle),
                     ),
                   ),
                 ),
@@ -77,9 +75,7 @@ class CollapsibleListItem extends StatelessWidget {
                             IconData(0xe90b, fontFamily: 'icomoon'),
                           ),
                           onPressed: () {
-                            ServiceInjector()
-                                .device
-                                .setClipboardText(sharedValue);
+                            ServiceInjector().device.setClipboardText(sharedValue);
                             Navigator.pop(context);
                             showFlushbar(
                               context,

--- a/lib/widgets/currency_amount_field_formatter.dart
+++ b/lib/widgets/currency_amount_field_formatter.dart
@@ -41,15 +41,11 @@ class CurrencyAmountFieldFormatter extends TextInputFormatter {
           return oldValue;
         }
         final digits = parts.last.substring(0, currencyData.fractionSize);
-        final dotted = rightSideSymbol
-            ? "${parts.first}.$digits $symbol"
-            : "$symbol ${parts.first}.$digits";
+        final dotted = rightSideSymbol ? "${parts.first}.$digits $symbol" : "$symbol ${parts.first}.$digits";
         return TextEditingValue(
           text: dotted,
           selection: TextSelection.collapsed(
-            offset: rightSideSymbol
-                ? dotted.length - symbol.length - 1
-                : dotted.length,
+            offset: rightSideSymbol ? dotted.length - symbol.length - 1 : dotted.length,
           ),
         );
       }
@@ -59,9 +55,7 @@ class CurrencyAmountFieldFormatter extends TextInputFormatter {
     return TextEditingValue(
       text: formatted,
       selection: TextSelection.collapsed(
-        offset: rightSideSymbol
-            ? formatted.length - symbol.length - 1
-            : formatted.length,
+        offset: rightSideSymbol ? formatted.length - symbol.length - 1 : formatted.length,
       ),
     );
   }

--- a/lib/widgets/currency_converter_dialog.dart
+++ b/lib/widgets/currency_converter_dialog.dart
@@ -126,16 +126,14 @@ class CurrencyConverterDialogState extends State<CurrencyConverterDialog>
           return Container();
         }
 
-        if (account.preferredFiatConversionList.isEmpty ||
-            account.fiatCurrency == null) {
+        if (account.preferredFiatConversionList.isEmpty || account.fiatCurrency == null) {
           return const Loader();
         }
 
         double exchangeRate = account.preferredFiatConversionList
             .firstWhere(
               (fiatConversion) =>
-                  fiatConversion.currencyData.symbol ==
-                  account.fiatCurrency.currencyData.symbol,
+                  fiatConversion.currencyData.symbol == account.fiatCurrency.currencyData.symbol,
               orElse: () => null,
             )
             .exchangeRate;
@@ -305,8 +303,7 @@ class CurrencyConverterDialogState extends State<CurrencyConverterDialog>
     ];
 
     // Show done button only when the converted amount is bigger than 0
-    if (_fiatAmountController.text.isNotEmpty &&
-        _convertedSatoshies(account) > 0) {
+    if (_fiatAmountController.text.isNotEmpty && _convertedSatoshies(account) > 0) {
       actions.add(
         TextButton(
           onPressed: () {

--- a/lib/widgets/currency_converter_dialog.dart
+++ b/lib/widgets/currency_converter_dialog.dart
@@ -69,6 +69,7 @@ class CurrencyConverterDialogState extends State<CurrencyConverterDialog>
 
   @override
   void didChangeDependencies() {
+    super.didChangeDependencies();
     if (!_isInit) {
       final themeData = Theme.of(context);
       final texts = context.texts();
@@ -104,7 +105,6 @@ class CurrencyConverterDialogState extends State<CurrencyConverterDialog>
         });
       _isInit = true;
     }
-    super.didChangeDependencies();
   }
 
   @override

--- a/lib/widgets/designsystem/button/action_button.dart
+++ b/lib/widgets/designsystem/button/action_button.dart
@@ -36,9 +36,7 @@ class ActionButton extends StatelessWidget {
           _backgroundColor(themeData),
         ),
         padding: MaterialStateProperty.all<EdgeInsetsGeometry>(
-          text != null
-              ? const EdgeInsets.symmetric(horizontal: 16.0)
-              : const EdgeInsets.all(0.0),
+          text != null ? const EdgeInsets.symmetric(horizontal: 16.0) : const EdgeInsets.all(0.0),
         ),
         minimumSize: MaterialStateProperty.all<Size>(
           const Size(40, 40),
@@ -101,9 +99,7 @@ class ActionButton extends StatelessWidget {
             ? themeData.colorScheme.onSurface
             : themeData.colorScheme.onSurface.withOpacity(_kDisabledOpacity);
       case Variant.fab:
-        return enabled
-            ? theme.buttonColor
-            : theme.buttonColor.withOpacity(_kDisabledOpacity);
+        return enabled ? theme.buttonColor : theme.buttonColor.withOpacity(_kDisabledOpacity);
     }
     throw Exception('Unknown variant: $variant');
   }
@@ -121,8 +117,7 @@ class ActionButton extends StatelessWidget {
       case Variant.fab:
         return enabled
             ? themeData.textTheme.labelLarge.color
-            : themeData.textTheme.labelLarge.color
-                .withOpacity(_kDisabledOpacity);
+            : themeData.textTheme.labelLarge.color.withOpacity(_kDisabledOpacity);
     }
     throw Exception('Unknown variant: $variant');
   }

--- a/lib/widgets/enable_backup_dialog.dart
+++ b/lib/widgets/enable_backup_dialog.dart
@@ -50,8 +50,8 @@ class EnableBackupDialogState extends State<EnableBackupDialog> {
           }
 
           final backupSettings = snapshot.data;
-          bool isRemoteServer = (backupSettings != null &&
-              backupSettings.backupProvider?.isRemoteServer == true);
+          bool isRemoteServer =
+              (backupSettings != null && backupSettings.backupProvider?.isRemoteServer == true);
 
           return AlertDialog(
             titlePadding: const EdgeInsets.fromLTRB(24.0, 22.0, 0.0, 16.0),
@@ -118,8 +118,7 @@ class _DoNotPromptAgainCheckbox extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  State<_DoNotPromptAgainCheckbox> createState() =>
-      _DoNotPromptAgainCheckboxState();
+  State<_DoNotPromptAgainCheckbox> createState() => _DoNotPromptAgainCheckboxState();
 }
 
 class _DoNotPromptAgainCheckboxState extends State<_DoNotPromptAgainCheckbox> {
@@ -201,8 +200,7 @@ class _BackupNowButtonState extends State<_BackupNowButton> {
         bool hasAuthError = false;
         final backupError = backupStateSnapshot.error;
         if (backupError.runtimeType == BackupFailedException) {
-          hasAuthError =
-              (backupError as BackupFailedException).authenticationError;
+          hasAuthError = (backupError as BackupFailedException).authenticationError;
         }
 
         return TextButton(

--- a/lib/widgets/enter_payment_info_dialog.dart
+++ b/lib/widgets/enter_payment_info_dialog.dart
@@ -76,9 +76,7 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
         hintColor: themeData.dialogTheme.contentTextStyle.color,
         colorScheme: ColorScheme.dark(
           primary: themeData.textTheme.labelLarge.color,
-          error: theme.themeId == "BLUE"
-              ? Colors.red
-              : themeData.colorScheme.error,
+          error: theme.themeId == "BLUE" ? Colors.red : themeData.colorScheme.error,
         ),
         primaryColor: themeData.textTheme.labelLarge.color,
       ),
@@ -138,9 +136,8 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
                   texts.payment_info_dialog_hint_expanded,
                   style: theme.FieldTextStyle.labelStyle.copyWith(
                     fontSize: 13.0,
-                    color: theme.themeId == "BLUE"
-                        ? theme.BreezColors.grey[500]
-                        : theme.BreezColors.white[200],
+                    color:
+                        theme.themeId == "BLUE" ? theme.BreezColors.grey[500] : theme.BreezColors.white[200],
                   ),
                 ),
               ),
@@ -190,8 +187,7 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
             }
 
             if (_decodeInvoice(_paymentInfoController.text) != null) {
-              widget.invoiceBloc.decodeInvoiceSink
-                  .add(_paymentInfoController.text);
+              widget.invoiceBloc.decodeInvoiceSink.add(_paymentInfoController.text);
             }
             if (isLNURL(_paymentInfoController.text)) {
               widget.lnurlBloc.lnurlInputSink.add(_paymentInfoController.text);
@@ -228,8 +224,7 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
   }
 
   String _decodeInvoice(String invoiceString) {
-    String normalized =
-        extractBolt11FromBip21(invoiceString) ?? invoiceString?.toLowerCase();
+    String normalized = extractBolt11FromBip21(invoiceString) ?? invoiceString?.toLowerCase();
     if (normalized == null) {
       return null;
     }

--- a/lib/widgets/escher_dialog.dart
+++ b/lib/widgets/escher_dialog.dart
@@ -129,9 +129,7 @@ class EscherDialogState extends State<EscherDialog> {
         primaryColor: themeData.textTheme.labelLarge.color,
         colorScheme: ColorScheme.dark(
           primary: themeData.textTheme.labelLarge.color,
-          error: theme.themeId == "BLUE"
-              ? Colors.red
-              : themeData.colorScheme.error,
+          error: theme.themeId == "BLUE" ? Colors.red : themeData.colorScheme.error,
         ),
       ),
       child: Form(

--- a/lib/widgets/fee_chooser.dart
+++ b/lib/widgets/fee_chooser.dart
@@ -100,9 +100,7 @@ class FeeChooser extends StatelessWidget {
     return DecoratedBox(
       decoration: BoxDecoration(
         borderRadius: borderRadius,
-        color: isSelected
-            ? themeData.colorScheme.onSurface
-            : themeData.canvasColor,
+        color: isSelected ? themeData.colorScheme.onSurface : themeData.canvasColor,
         border: border,
       ),
       child: TextButton(

--- a/lib/widgets/fixed_sliver_delegate.dart
+++ b/lib/widgets/fixed_sliver_delegate.dart
@@ -6,14 +6,12 @@ FixedSliverDelegate is a delegate that renders a sliver in a fixed height.
 class FixedSliverDelegate extends SliverPersistentHeaderDelegate {
   final double _height;
   final Widget child;
-  final Function(
-      BuildContext context, double shrinkOffset, bool overlapsContent) builder;
+  final Function(BuildContext context, double shrinkOffset, bool overlapsContent) builder;
 
   FixedSliverDelegate(this._height, {this.child, this.builder});
 
   @override
-  Widget build(
-      BuildContext context, double shrinkOffset, bool overlapsContent) {
+  Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
     if (builder != null) {
       return builder(context, shrinkOffset, overlapsContent);
     }

--- a/lib/widgets/home/home_navigation_drawer.dart
+++ b/lib/widgets/home/home_navigation_drawer.dart
@@ -14,8 +14,7 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-final GlobalKey _podcastMenuItemKey =
-    GlobalKey(debugLabel: "podcastMenuItemKey");
+final GlobalKey _podcastMenuItemKey = GlobalKey(debugLabel: "podcastMenuItemKey");
 
 class HomeNavigationDrawer extends StatelessWidget {
   final Function(String) _onNavigationItemSelected;
@@ -36,8 +35,7 @@ class HomeNavigationDrawer extends StatelessWidget {
 
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: themeData.appBarTheme.systemOverlayStyle.copyWith(
-        systemNavigationBarColor:
-            theme.customData[theme.themeId].navigationDrawerBgColor,
+        systemNavigationBarColor: theme.customData[theme.themeId].navigationDrawerBgColor,
       ),
       child: StreamBuilder2<BreezUserModel, AccountModel>(
         streamA: userProfileBloc.userStream,
@@ -46,12 +44,10 @@ class HomeNavigationDrawer extends StatelessWidget {
           final user = userSnapshot.data;
           final account = accountSnapshot.data;
           if (user == null || account == null) {
-            return BreezNavigationDrawer(
-                false, const [], _onNavigationItemSelected);
+            return BreezNavigationDrawer(false, const [], _onNavigationItemSelected);
           }
 
-          final refundableAddresses =
-              account.swapFundsStatus.maturedRefundableAddresses;
+          final refundableAddresses = account.swapFundsStatus.maturedRefundableAddresses;
 
           return Theme(
             data: theme.themeMap[user.themeId],
@@ -138,8 +134,7 @@ class HomeNavigationDrawer extends StatelessWidget {
                         context,
                         user,
                         () {
-                          userProfileBloc.userActionsSink
-                              .add(SetAppMode(AppMode.apps));
+                          userProfileBloc.userActionsSink.add(SetAppMode(AppMode.apps));
                           return Future.value(null);
                         },
                       );
@@ -184,8 +179,7 @@ class HomeNavigationDrawer extends StatelessWidget {
                         "",
                         texts.home_drawer_item_title_security_and_backup,
                         "src/icon/security.png",
-                        onItemSelected: (_) =>
-                            protectAdminRoute(context, user, "/security"),
+                        onItemSelected: (_) => protectAdminRoute(context, user, "/security"),
                       ),
                       DrawerItemConfig(
                         "",
@@ -212,8 +206,7 @@ class HomeNavigationDrawer extends StatelessWidget {
                               "",
                               texts.home_drawer_item_title_pos_settings,
                               "src/icon/settings.png",
-                              onItemSelected: (_) =>
-                                  protectAdminRoute(context, user, "/settings"),
+                              onItemSelected: (_) => protectAdminRoute(context, user, "/settings"),
                             )
                           : DrawerItemConfig(
                               "/developers",

--- a/lib/widgets/loader.dart
+++ b/lib/widgets/loader.dart
@@ -92,9 +92,7 @@ class FullScreenLoader extends StatelessWidget {
                   Loader(value: value, label: message, color: progressColor),
                   Padding(
                     padding: const EdgeInsets.only(top: 16.0),
-                    child: message != null
-                        ? Text(message, textAlign: TextAlign.center)
-                        : const SizedBox(),
+                    child: message != null ? Text(message, textAlign: TextAlign.center) : const SizedBox(),
                   )
                 ],
               ),
@@ -102,8 +100,7 @@ class FullScreenLoader extends StatelessWidget {
           ),
           onClose != null
               ? Padding(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 16, vertical: 30),
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 30),
                   child: Align(
                     alignment: Alignment.topRight,
                     child: IconButton(

--- a/lib/widgets/loading_animated_text.dart
+++ b/lib/widgets/loading_animated_text.dart
@@ -48,9 +48,7 @@ class LoadingAnimatedTextState extends State<LoadingAnimatedText> {
             children: textElements
               ..addAll(<TextSpan>[
                 TextSpan(text: loadingDots),
-                TextSpan(
-                    text: paddingDots,
-                    style: const TextStyle(color: Colors.transparent))
+                TextSpan(text: paddingDots, style: const TextStyle(color: Colors.transparent))
               ])),
         textAlign: widget.textAlign ?? TextAlign.center);
   }

--- a/lib/widgets/lsp_fee.dart
+++ b/lib/widgets/lsp_fee.dart
@@ -50,8 +50,7 @@ String _formatFeeMessage(
   final minFeeFormatted = acc.currency.format(
     longestValidOpeningFeeParams.minMsat ~/ 1000,
   );
-  final setUpFee =
-      (longestValidOpeningFeeParams.proportional / 10000).toString();
+  final setUpFee = (longestValidOpeningFeeParams.proportional / 10000).toString();
   final liquidity = acc.currency.format(acc.maxInboundLiquidity);
 
   if (connected && showMinFeeMessage) {
@@ -71,8 +70,7 @@ String _formatFeeMessage(
       minFeeFormatted,
     );
   } else {
-    return texts
-        .invoice_lightning_warning_without_min_fee_account_not_connected(
+    return texts.invoice_lightning_warning_without_min_fee_account_not_connected(
       setUpFee,
     );
   }

--- a/lib/widgets/nostr_get_dialog_content.dart
+++ b/lib/widgets/nostr_get_dialog_content.dart
@@ -8,12 +8,7 @@ class NostrGetDialogContent extends StatefulWidget {
   final AsyncSnapshot<NostrSettings> streamSnapshot;
   final MarketplaceBloc bloc;
 
-  const NostrGetDialogContent(
-      {Key key,
-      this.textContent,
-      this.choiceType,
-      this.streamSnapshot,
-      this.bloc})
+  const NostrGetDialogContent({Key key, this.textContent, this.choiceType, this.streamSnapshot, this.bloc})
       : super(key: key);
 
   @override
@@ -54,13 +49,11 @@ class _NostrGetDialogContentState extends State<NostrGetDialogContent> {
                   onChanged: (value) {
                     var currentSettings = widget.streamSnapshot.data;
                     if (widget.choiceType == "GetPubKey") {
-                      widget.bloc.nostrSettingsSettingsSink
-                          .add(currentSettings.copyWith(
+                      widget.bloc.nostrSettingsSettingsSink.add(currentSettings.copyWith(
                         isRememberPubKey: value,
                       ));
                     } else if (widget.choiceType == "SignEvent") {
-                      widget.bloc.nostrSettingsSettingsSink
-                          .add(currentSettings.copyWith(
+                      widget.bloc.nostrSettingsSettingsSink.add(currentSettings.copyWith(
                         isRememberSignEvent: value,
                       ));
                     }

--- a/lib/widgets/particles_animations.dart
+++ b/lib/widgets/particles_animations.dart
@@ -23,10 +23,10 @@ class ParticlesState extends State<Particles> {
 
   @override
   void initState() {
+    super.initState();
     List.generate(widget.numberOfParticles, (index) {
       particles.add(ParticleModel(random));
     });
-    super.initState();
   }
 
   @override

--- a/lib/widgets/payment_failed_report_dialog.dart
+++ b/lib/widgets/payment_failed_report_dialog.dart
@@ -28,10 +28,13 @@ class PaymentFailedReportDialogState extends State<PaymentFailedReportDialog> {
   @override
   void initState() {
     super.initState();
-    _settingsSubscription = widget._accountBloc.accountSettingsStream
-        .listen((settings) => setState(() {
-              _settings = settings;
-            }));
+    _settingsSubscription = widget._accountBloc.accountSettingsStream.listen(
+      (settings) {
+        setState(() {
+          _settings = settings;
+        });
+      },
+    );
   }
 
   @override

--- a/lib/widgets/payment_failed_report_dialog.dart
+++ b/lib/widgets/payment_failed_report_dialog.dart
@@ -69,8 +69,7 @@ class PaymentFailedReportDialogState extends State<PaymentFailedReportDialog> {
                     padding: const EdgeInsets.only(left: 15.0, right: 12.0),
                     child: Text(
                       texts.payment_failed_report_dialog_message,
-                      style: themeData.primaryTextTheme.displaySmall
-                          .copyWith(fontSize: 16),
+                      style: themeData.primaryTextTheme.displaySmall.copyWith(fontSize: 16),
                     ),
                   ),
                   Padding(
@@ -79,14 +78,11 @@ class PaymentFailedReportDialogState extends State<PaymentFailedReportDialog> {
                       children: [
                         Theme(
                           data: themeData.copyWith(
-                            unselectedWidgetColor:
-                                themeData.textTheme.labelLarge.color,
+                            unselectedWidgetColor: themeData.textTheme.labelLarge.color,
                           ),
                           child: Checkbox(
                             activeColor: themeData.canvasColor,
-                            value: _doneAsk ??
-                                _settings.failedPaymentBehavior !=
-                                    BugReportBehavior.PROMPT,
+                            value: _doneAsk ?? _settings.failedPaymentBehavior != BugReportBehavior.PROMPT,
                             onChanged: (v) {
                               setState(() {
                                 _doneAsk = v;
@@ -96,8 +92,7 @@ class PaymentFailedReportDialogState extends State<PaymentFailedReportDialog> {
                         ),
                         Text(
                           texts.payment_failed_report_dialog_do_not_ask_again,
-                          style:
-                              themeData.primaryTextTheme.displaySmall.copyWith(
+                          style: themeData.primaryTextTheme.displaySmall.copyWith(
                             fontSize: 16,
                           ),
                         ),
@@ -133,13 +128,10 @@ class PaymentFailedReportDialogState extends State<PaymentFailedReportDialog> {
   }
 
   void onSubmit(bool yesNo) {
-    var dontAsk =
-        _doneAsk ?? _settings.failedPaymentBehavior != BugReportBehavior.PROMPT;
+    var dontAsk = _doneAsk ?? _settings.failedPaymentBehavior != BugReportBehavior.PROMPT;
     if (dontAsk) {
       widget._accountBloc.accountSettingsSink.add(_settings.copyWith(
-          failedPaymentBehavior: yesNo
-              ? BugReportBehavior.SEND_REPORT
-              : BugReportBehavior.IGNORE));
+          failedPaymentBehavior: yesNo ? BugReportBehavior.SEND_REPORT : BugReportBehavior.IGNORE));
     }
   }
 }

--- a/lib/widgets/payment_request_dialog.dart
+++ b/lib/widgets/payment_request_dialog.dart
@@ -28,8 +28,8 @@ class PaymentRequestDialog extends StatefulWidget {
   final ScrollController scrollController;
   final Function() onComplete;
 
-  const PaymentRequestDialog(this.context, this.accountBloc, this.invoice,
-      this.firstPaymentItemKey, this.scrollController, this.onComplete);
+  const PaymentRequestDialog(this.context, this.accountBloc, this.invoice, this.firstPaymentItemKey,
+      this.scrollController, this.onComplete);
 
   @override
   State<StatefulWidget> createState() {
@@ -69,8 +69,8 @@ class PaymentRequestDialogState extends State<PaymentRequestDialog> {
     if (_state == PaymentRequestState.PROCESSING_PAYMENT) {
       return false;
     }
-    widget.accountBloc.userActionsSink.add(CancelPaymentRequest(
-        PayRequest(widget.invoice.rawPayReq, _amountToPay)));
+    widget.accountBloc.userActionsSink
+        .add(CancelPaymentRequest(PayRequest(widget.invoice.rawPayReq, _amountToPay)));
     return true;
   }
 
@@ -80,16 +80,10 @@ class PaymentRequestDialogState extends State<PaymentRequestDialog> {
       return ProcessingPaymentDialog(widget.context, () {
         widget.accountBloc.userActionsSink.add(_sendPayment);
         return _sendPayment.future;
-      }, widget.accountBloc, widget.firstPaymentItemKey, _onStateChange,
-          minHeight);
+      }, widget.accountBloc, widget.firstPaymentItemKey, _onStateChange, minHeight);
     } else if (_state == PaymentRequestState.WAITING_FOR_CONFIRMATION) {
-      return PaymentConfirmationDialog(
-          widget.accountBloc,
-          widget.invoice,
-          _amountToPay,
-          _amountToPayStr,
-          () => _onStateChange(PaymentRequestState.USER_CANCELLED),
-          (sendPayment) {
+      return PaymentConfirmationDialog(widget.accountBloc, widget.invoice, _amountToPay, _amountToPayStr,
+          () => _onStateChange(PaymentRequestState.USER_CANCELLED), (sendPayment) {
         setState(() {
           _sendPayment = sendPayment;
           _onStateChange(PaymentRequestState.PROCESSING_PAYMENT);
@@ -101,8 +95,7 @@ class PaymentRequestDialogState extends State<PaymentRequestDialog> {
           widget.accountBloc,
           widget.invoice,
           () => _onStateChange(PaymentRequestState.USER_CANCELLED),
-          () => _onStateChange(PaymentRequestState.WAITING_FOR_CONFIRMATION),
-          (sendPayment) {
+          () => _onStateChange(PaymentRequestState.WAITING_FOR_CONFIRMATION), (sendPayment) {
         _sendPayment = sendPayment;
         _onStateChange(PaymentRequestState.PROCESSING_PAYMENT);
       }, (map) => _setAmountToPay(map), minHeight);
@@ -117,8 +110,8 @@ class PaymentRequestDialogState extends State<PaymentRequestDialog> {
     }
     if (state == PaymentRequestState.USER_CANCELLED) {
       Navigator.of(context).removeRoute(_currentRoute);
-      widget.accountBloc.userActionsSink.add(CancelPaymentRequest(
-          PayRequest(widget.invoice.rawPayReq, _amountToPay)));
+      widget.accountBloc.userActionsSink
+          .add(CancelPaymentRequest(PayRequest(widget.invoice.rawPayReq, _amountToPay)));
       widget.onComplete();
       return;
     }

--- a/lib/widgets/payment_request_info_dialog.dart
+++ b/lib/widgets/payment_request_info_dialog.dart
@@ -136,10 +136,7 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
         ? null
         : Text(
             widget.invoice.payeeName,
-            style: Theme.of(context)
-                .primaryTextTheme
-                .headlineMedium
-                .copyWith(fontSize: 16),
+            style: Theme.of(context).primaryTextTheme.headlineMedium.copyWith(fontSize: 16),
             textAlign: TextAlign.center,
           );
   }
@@ -173,9 +170,7 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
           hintColor: themeData.dialogTheme.contentTextStyle.color,
           colorScheme: ColorScheme.dark(
             primary: themeData.textTheme.labelLarge.color,
-            error: theme.themeId == "BLUE"
-                ? Colors.red
-                : themeData.colorScheme.error,
+            error: theme.themeId == "BLUE" ? Colors.red : themeData.colorScheme.error,
           ),
           primaryColor: themeData.textTheme.labelLarge.color,
         ),
@@ -194,8 +189,7 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
                 focusNode: _amountFocusNode,
                 controller: _invoiceAmountController,
                 validatorFn: account.validateOutgoingPayment,
-                style: themeData.dialogTheme.contentTextStyle
-                    .copyWith(height: 1.0),
+                style: themeData.dialogTheme.contentTextStyle.copyWith(height: 1.0),
               ),
             ),
           ),
@@ -242,12 +236,10 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
                 child: SingleChildScrollView(
                   child: AutoSizeText(
                     description,
-                    style: themeData.primaryTextTheme.displaySmall
-                        .copyWith(fontSize: 16),
-                    textAlign:
-                        description.length > 40 && !description.contains("\n")
-                            ? TextAlign.start
-                            : TextAlign.center,
+                    style: themeData.primaryTextTheme.displaySmall.copyWith(fontSize: 16),
+                    textAlign: description.length > 40 && !description.contains("\n")
+                        ? TextAlign.start
+                        : TextAlign.center,
                   ),
                 ),
               ),
@@ -273,9 +265,7 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
         textAlign: TextAlign.center,
         style: themeData.primaryTextTheme.displaySmall.copyWith(
           fontSize: 16,
-          color: theme.themeId == "BLUE"
-              ? Colors.red
-              : themeData.colorScheme.error,
+          color: theme.themeId == "BLUE" ? Colors.red : themeData.colorScheme.error,
         ),
       ),
     );
@@ -302,8 +292,7 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
           if (widget.invoice.amount > 0 || _formKey.currentState.validate()) {
             if (widget.invoice.amount == 0) {
               _amountToPayMap["_amountToPay"] = toPay;
-              _amountToPayMap["_amountToPayStr"] =
-                  account.currency.format(amountToPay(account));
+              _amountToPayMap["_amountToPayStr"] = account.currency.format(amountToPay(account));
               widget._setAmountToPay(_amountToPayMap);
               widget._onWaitingConfirmation();
             } else {

--- a/lib/widgets/pin_code_widget.dart
+++ b/lib/widgets/pin_code_widget.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: missing_required_param
+
 import 'dart:math';
 
 import 'package:breez/bloc/user_profile/breez_user_model.dart';

--- a/lib/widgets/pin_code_widget.dart
+++ b/lib/widgets/pin_code_widget.dart
@@ -30,8 +30,7 @@ class PinCodeWidget extends StatefulWidget {
   }
 }
 
-class PinCodeWidgetState extends State<PinCodeWidget>
-    with WidgetsBindingObserver {
+class PinCodeWidgetState extends State<PinCodeWidget> with WidgetsBindingObserver {
   String _enteredPinCode;
   String _errorMessage;
   LocalAuthenticationOption _enrolledBiometrics;
@@ -91,8 +90,7 @@ class PinCodeWidgetState extends State<PinCodeWidget>
   void _validateBiometrics({bool force = false}) async {
     if (mounted && (!biometricsValidated || force)) {
       biometricsValidated = true;
-      var validateBiometricsAction =
-          ValidateBiometrics(localizedReason: widget.localizedReason);
+      var validateBiometricsAction = ValidateBiometrics(localizedReason: widget.localizedReason);
       widget.userProfileBloc.userActionsSink.add(validateBiometricsAction);
       validateBiometricsAction.future.then((isValid) async {
         setState(() => _enteredPinCode = (isValid) ? "123456" : "");
@@ -122,11 +120,7 @@ class PinCodeWidgetState extends State<PinCodeWidget>
             flex: 30,
             child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[
-                  Text(widget.label),
-                  _buildPinCircles(),
-                  _buildErrorMessage()
-                ]),
+                children: <Widget>[Text(widget.label), _buildPinCircles(), _buildErrorMessage()]),
           ),
           Flexible(flex: 50, child: Container(child: _numPad(context)))
         ],
@@ -169,8 +163,7 @@ class PinCodeWidgetState extends State<PinCodeWidget>
         width: _enteredPinCode.length == PIN_CODE_LENGTH ? 28 : 24,
         height: _enteredPinCode.length == PIN_CODE_LENGTH ? 28 : 24,
         decoration: BoxDecoration(
-            color:
-                i < _enteredPinCode.length ? Colors.white : Colors.transparent,
+            color: i < _enteredPinCode.length ? Colors.white : Colors.transparent,
             shape: BoxShape.circle,
             border: Border.all(color: Colors.white, width: 2.0)),
       ));
@@ -182,17 +175,11 @@ class PinCodeWidgetState extends State<PinCodeWidget>
     return _errorMessage.isNotEmpty
         ? Text(
             _errorMessage,
-            style: Theme.of(context)
-                .textTheme
-                .headlineMedium
-                .copyWith(fontSize: 12),
+            style: Theme.of(context).textTheme.headlineMedium.copyWith(fontSize: 12),
           )
         : Text(
             "",
-            style: Theme.of(context)
-                .textTheme
-                .headlineMedium
-                .copyWith(fontSize: 12),
+            style: Theme.of(context).textTheme.headlineMedium.copyWith(fontSize: 12),
           );
   }
 
@@ -206,8 +193,7 @@ class PinCodeWidgetState extends State<PinCodeWidget>
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             mainAxisSize: MainAxisSize.max,
-            children: List<Widget>.generate(
-                3, (i) => _numberButton((i + 1).toString())),
+            children: List<Widget>.generate(3, (i) => _numberButton((i + 1).toString())),
           ),
         ),
         Flexible(
@@ -215,8 +201,7 @@ class PinCodeWidgetState extends State<PinCodeWidget>
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             mainAxisSize: MainAxisSize.max,
-            children: List<Widget>.generate(
-                3, (i) => _numberButton((i + 4).toString())),
+            children: List<Widget>.generate(3, (i) => _numberButton((i + 4).toString())),
           ),
         ),
         Flexible(
@@ -224,8 +209,7 @@ class PinCodeWidgetState extends State<PinCodeWidget>
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             mainAxisSize: MainAxisSize.max,
-            children: List<Widget>.generate(
-                3, (i) => _numberButton((i + 7).toString())),
+            children: List<Widget>.generate(3, (i) => _numberButton((i + 7).toString())),
           ),
         ),
         Flexible(
@@ -237,15 +221,12 @@ class PinCodeWidgetState extends State<PinCodeWidget>
               _buildClearButton(),
               _numberButton("0"),
               widget.onFingerprintEntered == null ||
-                      ((widget.onFingerprintEntered != null) &&
-                          _enteredPinCode.isNotEmpty)
+                      ((widget.onFingerprintEntered != null) && _enteredPinCode.isNotEmpty)
                   ? _buildEraseButton()
                   : StreamBuilder<BreezUserModel>(
                       stream: widget.userProfileBloc.userStream,
                       builder: (context, snapshot) {
-                        if (!snapshot.hasData ||
-                            _enrolledBiometrics ==
-                                LocalAuthenticationOption.NONE) {
+                        if (!snapshot.hasData || _enrolledBiometrics == LocalAuthenticationOption.NONE) {
                           return _buildEraseButton();
                         } else {
                           return _buildBiometricsButton(snapshot, context);
@@ -259,8 +240,7 @@ class PinCodeWidgetState extends State<PinCodeWidget>
     );
   }
 
-  Widget _buildBiometricsButton(
-      AsyncSnapshot<BreezUserModel> snapshot, BuildContext context) {
+  Widget _buildBiometricsButton(AsyncSnapshot<BreezUserModel> snapshot, BuildContext context) {
     return CircularButton(
       onTap: _inputEnabled ? () => _validateBiometrics(force: true) : null,
       child: Icon(
@@ -291,8 +271,7 @@ class PinCodeWidgetState extends State<PinCodeWidget>
     return InkWell(
       customBorder: const CircleBorder(),
       onTap: _inputEnabled
-          ? () => _setPinCodeInput(
-              _enteredPinCode.substring(0, max(_enteredPinCode.length, 1) - 1))
+          ? () => _setPinCodeInput(_enteredPinCode.substring(0, max(_enteredPinCode.length, 1) - 1))
           : null,
       child: TextButton(
         style: TextButton.styleFrom(padding: const EdgeInsets.all(0)),

--- a/lib/widgets/pos_report_dialog.dart
+++ b/lib/widgets/pos_report_dialog.dart
@@ -188,8 +188,7 @@ class PosReportDialog extends StatelessWidget {
                   }
                 });
               } else {
-                posCatalogBloc.actionsSink
-                    .add(UpdatePosReportTimeRange(newOption));
+                posCatalogBloc.actionsSink.add(UpdatePosReportTimeRange(newOption));
               }
             }
           },

--- a/lib/widgets/preview/preview.dart
+++ b/lib/widgets/preview/preview.dart
@@ -41,9 +41,7 @@ class _PreviewState extends State<Preview> {
                       final oddRow = (index ~/ cols).isOdd;
                       final oddCol = (index % cols).isOdd;
                       return Container(
-                        color: oddRow == oddCol
-                            ? Colors.grey.withAlpha(128)
-                            : Colors.blueGrey.withAlpha(128),
+                        color: oddRow == oddCol ? Colors.grey.withAlpha(128) : Colors.blueGrey.withAlpha(128),
                       );
                     },
                   );

--- a/lib/widgets/processing_payment_dialog.dart
+++ b/lib/widgets/processing_payment_dialog.dart
@@ -157,9 +157,7 @@ class ProcessingPaymentDialogState extends State<ProcessingPaymentDialog>
 
   @override
   Widget build(BuildContext context) {
-    return _animating
-        ? _createAnimatedContent(context)
-        : _createContentDialog(context);
+    return _animating ? _createAnimatedContent(context) : _createContentDialog(context);
   }
 
   List<Widget> _buildProcessingPaymentDialog(BuildContext context) {
@@ -173,9 +171,7 @@ class ProcessingPaymentDialogState extends State<ProcessingPaymentDialog>
           themeData.loaderAssetPath,
           height: 64.0,
           colorBlendMode: themeData.loaderColorBlendMode ?? BlendMode.srcIn,
-          color: theme.themeId == "BLUE"
-              ? colorAnimation?.value ?? Colors.transparent
-              : null,
+          color: theme.themeId == "BLUE" ? colorAnimation?.value ?? Colors.transparent : null,
           gaplessPlayback: true,
         ),
       )

--- a/lib/widgets/processing_payment_dialog.dart
+++ b/lib/widgets/processing_payment_dialog.dart
@@ -52,12 +52,8 @@ class ProcessingPaymentDialogState extends State<ProcessingPaymentDialog>
   bool _isInit = false;
 
   @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
   void didChangeDependencies() {
+    super.didChangeDependencies();
     if (!_isInit) {
       Future.value(true).then((_) {
         _payAncClose();
@@ -93,7 +89,6 @@ class ProcessingPaymentDialogState extends State<ProcessingPaymentDialog>
       });
       _isInit = true;
     }
-    super.didChangeDependencies();
   }
 
   _closeDialog() {

--- a/lib/widgets/rotator.dart
+++ b/lib/widgets/rotator.dart
@@ -20,8 +20,7 @@ class _RotatorState extends State<Rotator> with SingleTickerProviderStateMixin {
   @override
   void initState() {
     super.initState();
-    _animationController =
-        AnimationController(vsync: this, duration: const Duration(seconds: 1));
+    _animationController = AnimationController(vsync: this, duration: const Duration(seconds: 1));
     _animation = Tween<double>(begin: 1.0, end: 0.0).animate(
         _animationController); //use Tween animation here, to animate between the values of 1.0 & 2.5.
     _animation.addListener(() {

--- a/lib/widgets/route.dart
+++ b/lib/widgets/route.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/cupertino.dart';
 
 class FadeInRoute<T> extends CupertinoPageRoute<T> {
-  FadeInRoute({WidgetBuilder builder, RouteSettings settings})
-      : super(builder: builder, settings: settings);
+  FadeInRoute({WidgetBuilder builder, RouteSettings settings}) : super(builder: builder, settings: settings);
 
   @override
-  Widget buildTransitions(BuildContext context, Animation<double> animation,
-      Animation<double> secondaryAnimation, Widget child) {
+  Widget buildTransitions(
+      BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
     // Fades between routes. (If you don't want any animation,
     // just return child.)
     return FadeTransition(opacity: animation, child: child);
@@ -18,8 +17,8 @@ class NoTransitionRoute<T> extends CupertinoPageRoute<T> {
       : super(builder: builder, settings: settings);
 
   @override
-  Widget buildTransitions(BuildContext context, Animation<double> animation,
-      Animation<double> secondaryAnimation, Widget child) {
+  Widget buildTransitions(
+      BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
     return child;
   }
 }

--- a/lib/widgets/send_onchain.dart
+++ b/lib/widgets/send_onchain.dart
@@ -55,14 +55,14 @@ class SendOnchainState extends State<SendOnchain> {
 
   @override
   void didChangeDependencies() {
-    _updateFee();
     super.didChangeDependencies();
+    _updateFee();
   }
 
   @override
   void didUpdateWidget(Widget oldWidget) {
-    _updateFee();
     super.didUpdateWidget(oldWidget);
+    _updateFee();
   }
 
   void _updateFee() {

--- a/lib/widgets/send_onchain.dart
+++ b/lib/widgets/send_onchain.dart
@@ -67,9 +67,7 @@ class SendOnchainState extends State<SendOnchain> {
 
   void _updateFee() {
     final account = widget._account;
-    if (!feeUpdated &&
-        _feeController.text.isEmpty &&
-        account.onChainFeeRate != null) {
+    if (!feeUpdated && _feeController.text.isEmpty && account.onChainFeeRate != null) {
       _feeController.text = account.onChainFeeRate.toString();
       feeUpdated = true;
     }
@@ -97,9 +95,7 @@ class SendOnchainState extends State<SendOnchain> {
         hintColor: dialogTheme.contentTextStyle.color,
         colorScheme: ColorScheme.dark(
           primary: themeData.textTheme.labelLarge.color,
-          error: theme.themeId == "BLUE"
-              ? Colors.red
-              : themeData.colorScheme.error,
+          error: theme.themeId == "BLUE" ? Colors.red : themeData.colorScheme.error,
         ),
         primaryColor: themeData.textTheme.labelLarge.color,
         unselectedWidgetColor: themeData.canvasColor,
@@ -131,9 +127,7 @@ class SendOnchainState extends State<SendOnchain> {
                   onPressed: () => _asyncValidate().then((validated) {
                     if (validated) {
                       _formKey.currentState.save();
-                      widget
-                          ._onBroadcast(_addressValidated, _getFee())
-                          .then((msg) {
+                      widget._onBroadcast(_addressValidated, _getFee()).then((msg) {
                         Navigator.of(context).pop();
                         if (msg != null) {
                           showFlushbar(context, message: msg);
@@ -263,9 +257,7 @@ class SendOnchainState extends State<SendOnchain> {
   }
 
   Int64 _getFee() {
-    return _feeController.text.isNotEmpty
-        ? Int64.parseInt(_feeController.text)
-        : Int64(0);
+    return _feeController.text.isNotEmpty ? Int64.parseInt(_feeController.text) : Int64(0);
   }
 
   Future _scanBarcode() async {

--- a/lib/widgets/single_button_bottom_bar.dart
+++ b/lib/widgets/single_button_bottom_bar.dart
@@ -17,9 +17,7 @@ class SingleButtonBottomBar extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: EdgeInsets.only(
-        bottom: stickToBottom
-            ? MediaQuery.of(context).viewInsets.bottom + 40.0
-            : 40.0,
+        bottom: stickToBottom ? MediaQuery.of(context).viewInsets.bottom + 40.0 : 40.0,
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,

--- a/lib/widgets/static_loader.dart
+++ b/lib/widgets/static_loader.dart
@@ -4,9 +4,6 @@ class StaticLoader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-        width: 0.0,
-        height: 0.0,
-        decoration:
-            const BoxDecoration(color: Color.fromRGBO(5, 93, 235, 1.0)));
+        width: 0.0, height: 0.0, decoration: const BoxDecoration(color: Color.fromRGBO(5, 93, 235, 1.0)));
   }
 }

--- a/lib/widgets/sync_loader.dart
+++ b/lib/widgets/sync_loader.dart
@@ -6,11 +6,10 @@ class SyncUIRoute<T> extends TransparentPageRoute<T> {
   SyncUIRoute(Widget Function(BuildContext context) builder) : super(builder);
 
   @override
-  Widget buildTransitions(BuildContext context, Animation<double> animation,
-      Animation<double> secondaryAnimation, Widget child) {
+  Widget buildTransitions(
+      BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
     var curve = CurvedAnimation(parent: controller, curve: Curves.easeOut);
-    return ScaleTransition(
-        scale: curve, alignment: Alignment.topRight, child: child);
+    return ScaleTransition(scale: curve, alignment: Alignment.topRight, child: child);
   }
 
   @override
@@ -23,8 +22,7 @@ class TransparentRouteLoader extends StatefulWidget {
   final double value;
   final Function onClose;
 
-  const TransparentRouteLoader(
-      {Key key, this.message, this.opacity = 0.5, this.value, this.onClose})
+  const TransparentRouteLoader({Key key, this.message, this.opacity = 0.5, this.value, this.onClose})
       : super(key: key);
 
   @override
@@ -72,9 +70,7 @@ class TransparentRouteLoaderState extends State<TransparentRouteLoader> {
             child: Align(
               alignment: Alignment.topRight,
               child: IconButton(
-                  color: Colors.white,
-                  onPressed: widget.onClose,
-                  icon: const Icon(Icons.unfold_less)),
+                  color: Colors.white, onPressed: widget.onClose, icon: const Icon(Icons.unfold_less)),
             ),
           ),
         ],
@@ -88,9 +84,7 @@ class SyncProgressLoader extends StatelessWidget {
   final String title;
   final Color progressColor;
 
-  const SyncProgressLoader(
-      {Key key, this.value, this.title, this.progressColor})
-      : super(key: key);
+  const SyncProgressLoader({Key key, this.value, this.title, this.progressColor}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/transparent_page_route.dart
+++ b/lib/widgets/transparent_page_route.dart
@@ -18,8 +18,7 @@ class TransparentPageRoute<T> extends ModalRoute<T> {
   String get barrierLabel => null;
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> animation,
-      Animation<double> secondaryAnimation) {
+  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
     return builder(context);
   }
 

--- a/lib/widgets/warning_box.dart
+++ b/lib/widgets/warning_box.dart
@@ -19,11 +19,9 @@ class WarningBox extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: boxPadding ??
-          const EdgeInsets.symmetric(vertical: 16, horizontal: 30),
+      padding: boxPadding ?? const EdgeInsets.symmetric(vertical: 16, horizontal: 30),
       child: Container(
-          padding: contentPadding ??
-              const EdgeInsets.symmetric(horizontal: 12.3, vertical: 16.2),
+          padding: contentPadding ?? const EdgeInsets.symmetric(horizontal: 12.3, vertical: 16.2),
           width: MediaQuery.of(context).size.width,
           decoration: BoxDecoration(
               color: backgroundColor ?? theme.warningBoxColor,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,8 +37,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: c30de552580d8e64233c4372a7e438b0550de64e
-      resolved-ref: c30de552580d8e64233c4372a7e438b0550de64e
+      ref: "7ae0038eb14e1ebaa1eb8a26ae144a795e0b787d"
+      resolved-ref: "7ae0038eb14e1ebaa1eb8a26ae144a795e0b787d"
       url: "https://github.com/breez/anytime_podcast_player.git"
     source: git
     version: "1.2.1+74-breez"
@@ -2094,10 +2094,10 @@ packages:
     dependency: "direct main"
     description:
       name: webdav_client
-      sha256: b3f5afee27e7db5635817ddd79d57f56d43fdc6dad4c6bc93b0703261f96064c
+      sha256: "682fffc50b61dc0e8f46717171db03bf9caaa17347be41c0c91e297553bf86b2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   webfeed:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -94,14 +94,14 @@ dependencies:
   url_launcher: <=6.1.11 # Requires Flutter 3.10
   uuid: <=4.2.2  # Requires Flutter 3.10
   validators: ^3.0.0
-  webdav_client: ^1.2.1
+  webdav_client: ^1.2.2
   webview_flutter: <=4.4.2 # Requires Flutter 3.10
   webview_flutter_android: <=3.12.1 # Requires Flutter 3.10
 
   anytime:
     git:
       url: https://github.com/breez/anytime_podcast_player.git
-      ref: c30de552580d8e64233c4372a7e438b0550de64e
+      ref: 7ae0038eb14e1ebaa1eb8a26ae144a795e0b787d
   flutter_downloader:
     git:
       url: https://github.com/breez/flutter_downloader.git

--- a/test/bloc/backup/backup_bloc_test.dart
+++ b/test/bloc/backup/backup_bloc_test.dart
@@ -78,8 +78,7 @@ void main() {
       final newSettings = await action.future;
 
       expect(newSettings, googleSettings);
-      expect(injectorMock.breezLibMock.backupProviderSet,
-          googleSettings.backupProvider.name);
+      expect(injectorMock.breezLibMock.backupProviderSet, googleSettings.backupProvider.name);
       expect(injectorMock.breezLibMock.backupAuthDataSet, isNull);
     });
   });

--- a/test/bloc/csv_exporter_test.dart
+++ b/test/bloc/csv_exporter_test.dart
@@ -32,8 +32,7 @@ void main() {
     test('csv file should have header', () async {
       final filePath = await _make().export();
       final lines = await File(filePath).readAsLines();
-      expect(lines[0],
-          "Date & Time,Title,Description,Node ID,Amount,Preimage,TX Hash,Fee,USD");
+      expect(lines[0], "Date & Time,Title,Description,Node ID,Amount,Preimage,TX Hash,Fee,USD");
     });
 
     test('csv file should have item line', () async {

--- a/test/bloc_tester.dart
+++ b/test/bloc_tester.dart
@@ -28,8 +28,6 @@ class BlocTester<Input, Out> {
     if (inSink != null) {
       inSink.add(input);
     }
-    return completer.future
-        .then((out) => this.testFunction(out))
-        .catchError((e) {});
+    return completer.future.then((out) => this.testFunction(out)).catchError((e) {});
   }
 }

--- a/test/fastbitcoins_bloc_test.dart
+++ b/test/fastbitcoins_bloc_test.dart
@@ -54,8 +54,7 @@ void main() {
         }
         expect(res, isNotNull);
         expect(res.error, 1);
-      }, fastBitcoinsBloc.validateRequestSink,
-          ValidateRequestModel("test@gmail.com", "code", 1, "USD"));
+      }, fastBitcoinsBloc.validateRequestSink, ValidateRequestModel("test@gmail.com", "code", 1, "USD"));
       await tester.run();
     });
 
@@ -73,12 +72,10 @@ void main() {
         }""",
       );
       FastbitcoinsBloc fastBitcoinsBloc = _make();
-      var redeemRequest =
-          RedeemRequestModel("test@gmail.com", "code", 1, "USD", 0, "")
-            ..validateResponse =
-                ValidateResponseModel(0, "", 0, 0, "", 0, 1.0, 1.0, 0, 0.0, 0);
-      var tester = BlocTester<RedeemRequestModel, RedeemResponseModel>(
-          fastBitcoinsBloc.redeemResponseStream, (res) {
+      var redeemRequest = RedeemRequestModel("test@gmail.com", "code", 1, "USD", 0, "")
+        ..validateResponse = ValidateResponseModel(0, "", 0, 0, "", 0, 1.0, 1.0, 0, 0.0, 0);
+      var tester =
+          BlocTester<RedeemRequestModel, RedeemResponseModel>(fastBitcoinsBloc.redeemResponseStream, (res) {
         if (kDebugMode) {
           print(jsonEncode(res.toJson()));
         }
@@ -131,10 +128,8 @@ void main() {
         }""",
       );
       FastbitcoinsBloc fastBitcoinsBloc = _make();
-      var redeemRequest =
-          RedeemRequestModel("test@gmail.com", "code", 1, "USD", 0, "")
-            ..validateResponse =
-                ValidateResponseModel(0, "", 0, 0, "", 0, 1.0, 1.0, 0, 0.0, 0);
+      var redeemRequest = RedeemRequestModel("test@gmail.com", "code", 1, "USD", 0, "")
+        ..validateResponse = ValidateResponseModel(0, "", 0, 0, "", 0, 1.0, 1.0, 0, 0.0, 0);
       var tester = BlocTester<RedeemRequestModel, RedeemResponseModel>(
           fastBitcoinsBloc.redeemResponseStream,
           (res) {
@@ -180,10 +175,8 @@ void main() {
         }""",
       );
       FastbitcoinsBloc fastBitcoinsBloc = _make();
-      var redeemRequest =
-          RedeemRequestModel("test@gmail.com", "code", 1, "USD", 0, "")
-            ..validateResponse =
-                ValidateResponseModel(0, "", 0, 0, "", 0, 1.0, 1.0, 0, 0.0, 0);
+      var redeemRequest = RedeemRequestModel("test@gmail.com", "code", 1, "USD", 0, "")
+        ..validateResponse = ValidateResponseModel(0, "", 0, 0, "", 0, 1.0, 1.0, 0, 0.0, 0);
       var tester = BlocTester<RedeemRequestModel, RedeemResponseModel>(
           fastBitcoinsBloc.redeemResponseStream,
           (res) {

--- a/test/invoice_test.dart
+++ b/test/invoice_test.dart
@@ -5,7 +5,8 @@ void main() {
   group('invoice_tests', () {
     test("should extract bolt11 from bip21 full info", () async {
       String bolt11 = extractBolt11FromBip21(
-          "bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?amount=0.000001&lightning=1234");
+        "bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?amount=0.000001&lightning=1234",
+      );
       expect(bolt11, "1234");
     });
 
@@ -17,13 +18,15 @@ void main() {
 
     test("should extract bolt11 from bip21 amount last", () async {
       String bolt11 = extractBolt11FromBip21(
-          "bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?lightning=1234&amount=0.000001");
+        "bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?lightning=1234&amount=0.000001",
+      );
       expect(bolt11, "1234");
     });
 
     test("should extract bolt11 from bip21 upper case", () async {
       String bolt11 = extractBolt11FromBip21(
-          "BITCOIN:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?amount=0.000001&lightning=1234");
+        "BITCOIN:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?amount=0.000001&lightning=1234",
+      );
       expect(bolt11, "1234");
     });
 
@@ -33,22 +36,24 @@ void main() {
       expect(bolt11, null);
     });
 
-    test("should extract bitcoin addresss from bip21 full info legacy address",
-        () async {
+    test("should extract bitcoin addresss from bip21 full info legacy address", () async {
       String bitcoinAddress = extractBitcoinAddress(
-          "bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?amount=0.000001&lightning=1234");
+        "bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?amount=0.000001&lightning=1234",
+      );
       expect(bitcoinAddress, "1DamianM2k8WfNEeJmyqSe2YW1upB7UATx");
     });
 
     test("should extract bitcoin address from bip 21 nested segwit", () async {
       String bitcoinAddress = extractBitcoinAddress(
-          "BITCOIN:3K2CfYmqYuD99CDyqrdzt481F9jkLKirEn?amount=0.00001&label=sbddesign%3A%20For%20lunch%20Tuesday&message=For%20lunch%20Tuesday&lightning=LNBC10U1P3PJ257PP5YZTKWJCZ5FTL5LAXKAV23ZMZEKAW37ZK6KMV80PK4XAEV5QHTZ7QDPDWD3XGER9WD5KWM36YPRX7U3QD36KUCMGYP282ETNV3SHJCQZPGXQYZ5VQSP5USYC4LK9CHSFP53KVCNVQ456GANH60D89REYKDNGSMTJ6YW3NHVQ9QYYSSQJCEWM5CJWZ4A6RFJX77C490YCED6PEMK0UPKXHY89CMM7SCT66K8GNEANWYKZGDRWRFJE69H9U5U0W57RRCSYSAS7GADWMZXC8C6T0SPJAZUP6");
+        "BITCOIN:3K2CfYmqYuD99CDyqrdzt481F9jkLKirEn?amount=0.00001&label=sbddesign%3A%20For%20lunch%20Tuesday&message=For%20lunch%20Tuesday&lightning=LNBC10U1P3PJ257PP5YZTKWJCZ5FTL5LAXKAV23ZMZEKAW37ZK6KMV80PK4XAEV5QHTZ7QDPDWD3XGER9WD5KWM36YPRX7U3QD36KUCMGYP282ETNV3SHJCQZPGXQYZ5VQSP5USYC4LK9CHSFP53KVCNVQ456GANH60D89REYKDNGSMTJ6YW3NHVQ9QYYSSQJCEWM5CJWZ4A6RFJX77C490YCED6PEMK0UPKXHY89CMM7SCT66K8GNEANWYKZGDRWRFJE69H9U5U0W57RRCSYSAS7GADWMZXC8C6T0SPJAZUP6",
+      );
       expect(bitcoinAddress, "3K2CfYmqYuD99CDyqrdzt481F9jkLKirEn");
     });
 
     test("should extract bitcoin address from bip 21 bech32", () async {
       String bitcoinAddress = extractBitcoinAddress(
-          "BITCOIN:BC1QYLH3U67J673H6Y6ALV70M0PL2YZ53TZHVXGG7U?amount=0.00001&label=sbddesign%3A%20For%20lunch%20Tuesday&message=For%20lunch%20Tuesday&lightning=LNBC10U1P3PJ257PP5YZTKWJCZ5FTL5LAXKAV23ZMZEKAW37ZK6KMV80PK4XAEV5QHTZ7QDPDWD3XGER9WD5KWM36YPRX7U3QD36KUCMGYP282ETNV3SHJCQZPGXQYZ5VQSP5USYC4LK9CHSFP53KVCNVQ456GANH60D89REYKDNGSMTJ6YW3NHVQ9QYYSSQJCEWM5CJWZ4A6RFJX77C490YCED6PEMK0UPKXHY89CMM7SCT66K8GNEANWYKZGDRWRFJE69H9U5U0W57RRCSYSAS7GADWMZXC8C6T0SPJAZUP6");
+        "BITCOIN:BC1QYLH3U67J673H6Y6ALV70M0PL2YZ53TZHVXGG7U?amount=0.00001&label=sbddesign%3A%20For%20lunch%20Tuesday&message=For%20lunch%20Tuesday&lightning=LNBC10U1P3PJ257PP5YZTKWJCZ5FTL5LAXKAV23ZMZEKAW37ZK6KMV80PK4XAEV5QHTZ7QDPDWD3XGER9WD5KWM36YPRX7U3QD36KUCMGYP282ETNV3SHJCQZPGXQYZ5VQSP5USYC4LK9CHSFP53KVCNVQ456GANH60D89REYKDNGSMTJ6YW3NHVQ9QYYSSQJCEWM5CJWZ4A6RFJX77C490YCED6PEMK0UPKXHY89CMM7SCT66K8GNEANWYKZGDRWRFJE69H9U5U0W57RRCSYSAS7GADWMZXC8C6T0SPJAZUP6",
+      );
       expect(bitcoinAddress, "bc1qylh3u67j673h6y6alv70m0pl2yz53tzhvxgg7u");
     });
 

--- a/test/invoice_test.dart
+++ b/test/invoice_test.dart
@@ -11,8 +11,7 @@ void main() {
     });
 
     test("should extract bolt11 from bip21 no amount", () async {
-      String bolt11 = extractBolt11FromBip21(
-          "bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?lightning=1234");
+      String bolt11 = extractBolt11FromBip21("bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?lightning=1234");
       expect(bolt11, "1234");
     });
 
@@ -31,8 +30,7 @@ void main() {
     });
 
     test("should extract bolt11 from bip21 negative, no lightning", () async {
-      String bolt11 = extractBolt11FromBip21(
-          "bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?amount=0.000001");
+      String bolt11 = extractBolt11FromBip21("bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?amount=0.000001");
       expect(bolt11, null);
     });
 
@@ -58,20 +56,17 @@ void main() {
     });
 
     test("should extract the same address as it receives", () {
-      String bitcoinAddress =
-          extractBitcoinAddress("3K2CfYmqYuD99CDyqrdzt481F9jkLKirEn");
+      String bitcoinAddress = extractBitcoinAddress("3K2CfYmqYuD99CDyqrdzt481F9jkLKirEn");
       expect(bitcoinAddress, "3K2CfYmqYuD99CDyqrdzt481F9jkLKirEn");
     });
 
     test("should extract the address from bip21 scheme", () async {
-      String bitcoinAddress = extractBitcoinAddress(
-          "BITCOIN:BC1QYLH3U67J673H6Y6ALV70M0PL2YZ53TZHVXGG7U");
+      String bitcoinAddress = extractBitcoinAddress("BITCOIN:BC1QYLH3U67J673H6Y6ALV70M0PL2YZ53TZHVXGG7U");
       expect(bitcoinAddress, "bc1qylh3u67j673h6y6alv70m0pl2yz53tzhvxgg7u");
     });
 
     test("should extract the same address as it receives", () {
-      String bitcoinAddress =
-          extractBitcoinAddress("BItCOiN:3K2CfYmqYuD99CDyqrdzt481F9jkLKirEn");
+      String bitcoinAddress = extractBitcoinAddress("BItCOiN:3K2CfYmqYuD99CDyqrdzt481F9jkLKirEn");
       expect(bitcoinAddress, "3K2CfYmqYuD99CDyqrdzt481F9jkLKirEn");
     });
   });

--- a/test/mocks/breez_lib_mock.dart
+++ b/test/mocks/breez_lib_mock.dart
@@ -20,8 +20,7 @@ class BreezLibMock extends Mock implements BreezBridge {
     return Future.value(AddInvoiceReply());
   }
 
-  StreamController eventsController =
-      StreamController<NotificationEvent>.broadcast();
+  StreamController eventsController = StreamController<NotificationEvent>.broadcast();
 
   @override
   Stream<NotificationEvent> get notificationStream => eventsController.stream;

--- a/test/mocks/breez_server_mock.dart
+++ b/test/mocks/breez_server_mock.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 
 class BreezServerMock extends Mock implements BreezServer {
+  @override
   Future<String> registerDevice(String token, String nodeid) {
     return Future<String>.value("1234");
   }

--- a/test/mocks/device_mock.dart
+++ b/test/mocks/device_mock.dart
@@ -6,6 +6,7 @@ import 'package:mockito/mockito.dart';
 class DeviceMock extends Mock implements Device {
   final StreamController<NotificationType> _eventsController = StreamController.broadcast();
 
+  @override
   Stream<NotificationType> get eventStream => _eventsController.stream;
 
   void dispose() {

--- a/test/mocks/fake_path_provider_platform.dart
+++ b/test/mocks/fake_path_provider_platform.dart
@@ -52,7 +52,8 @@ class FakePathProviderPlatform extends Fake with MockPlatformInterfaceMixin impl
   Future<List<String>> getExternalCachePaths() async => ["$basePath/externalCachePath"];
 
   @override
-  Future<List<String>> getExternalStoragePaths({StorageDirectory type}) async => ["$basePath/externalStoragePath"];
+  Future<List<String>> getExternalStoragePaths({StorageDirectory type}) async =>
+      ["$basePath/externalStoragePath"];
 
   @override
   Future<String> getDownloadsPath() async => "$basePath/downloadsPath";

--- a/test/mocks/flutter_secure_storage_mock.dart
+++ b/test/mocks/flutter_secure_storage_mock.dart
@@ -2,6 +2,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:mockito/mockito.dart';
 
 class FlutterSecureStorageMock extends Mock implements FlutterSecureStorage {
+  @override
   Future<String> read({
     String key,
     IOSOptions iOptions,
@@ -13,6 +14,7 @@ class FlutterSecureStorageMock extends Mock implements FlutterSecureStorage {
   }) =>
       Future<String>.value("${key}_value");
 
+  @override
   Future<void> write({
     String key,
     String value,

--- a/test/mocks/injector_mock.dart
+++ b/test/mocks/injector_mock.dart
@@ -16,6 +16,7 @@ import 'shared_preferences_mock.dart';
 class InjectorMock extends Mock implements ServiceInjector {
   BreezLibMock breezLibMock = BreezLibMock();
 
+  @override
   BreezBridge get breezBridge => breezLibMock;
 
   SharedPreferencesMock sharedPreferencesMock = SharedPreferencesMock();

--- a/test/sqlite_repository_test.dart
+++ b/test/sqlite_repository_test.dart
@@ -54,8 +54,22 @@ void main() {
       int saleID = await repo.addSale(
         Sale(
           saleLines: [
-            SaleLine(itemName: "SaleLine1", quantity: 1, itemImageURL: "testURL1", pricePerItem: 1.0, currency: "USD", satConversionRate: 1.5 ),
-            SaleLine(itemName: "SaleLine2", quantity: 1, itemImageURL: "testURL2", pricePerItem: 2.0, currency: "USD", satConversionRate: 2.5 ),
+            SaleLine(
+              itemName: "SaleLine1",
+              quantity: 1,
+              itemImageURL: "testURL1",
+              pricePerItem: 1.0,
+              currency: "USD",
+              satConversionRate: 1.5,
+            ),
+            SaleLine(
+              itemName: "SaleLine2",
+              quantity: 1,
+              itemImageURL: "testURL2",
+              pricePerItem: 2.0,
+              currency: "USD",
+              satConversionRate: 2.5,
+            ),
           ],
         ),
         "hash",
@@ -106,8 +120,22 @@ void main() {
       await repo.addSale(
         Sale(
           saleLines: [
-            SaleLine(itemName: "SaleLine1", quantity: 1, itemImageURL: "testURL1", pricePerItem: 1.0, currency: "USD", satConversionRate: 1.5),
-            SaleLine(itemName: "SaleLine2", quantity: 1, itemImageURL: "testURL2", pricePerItem: 2.0, currency: "USD", satConversionRate: 2.5),
+            SaleLine(
+              itemName: "SaleLine1",
+              quantity: 1,
+              itemImageURL: "testURL1",
+              pricePerItem: 1.0,
+              currency: "USD",
+              satConversionRate: 1.5,
+            ),
+            SaleLine(
+              itemName: "SaleLine2",
+              quantity: 1,
+              itemImageURL: "testURL2",
+              pricePerItem: 2.0,
+              currency: "USD",
+              satConversionRate: 2.5,
+            ),
           ],
         ),
         hash,

--- a/test/utils/exceptions_test.dart
+++ b/test/utils/exceptions_test.dart
@@ -29,9 +29,7 @@ void main() {
             '"Withdraw link does not exist."} method: fetchLnurl',
             clearTrailingDot: clearTrailingDot,
           ),
-          clearTrailingDot
-              ? 'Withdraw link does not exist'
-              : 'Withdraw link does not exist.',
+          clearTrailingDot ? 'Withdraw link does not exist' : 'Withdraw link does not exist.',
         );
       });
 
@@ -82,13 +80,11 @@ void main() {
           extractExceptionMessage(
             PlatformException(
               code: "Method Error",
-              message:
-                  "Error Domain=go Code=1 \"rpc error: code = Unknown desc = fees are too high for the "
+              message: "Error Domain=go Code=1 \"rpc error: code = Unknown desc = fees are too high for the "
                   "given amount transaction output amount is negative\" UserInfo={NSLocalizedDescription=rpc "
                   "error: code = Unknown desc = fees are too high for the given amount transaction output "
                   "amount is negative}",
-              details:
-                  "Error Domain=go Code=1 \"rpc error: code = Unknown desc = fees are too high for the "
+              details: "Error Domain=go Code=1 \"rpc error: code = Unknown desc = fees are too high for the "
                   "given amount transaction output amount is negative\" UserInfo={NSLocalizedDescription=rpc "
                   "error: code = Unknown desc = fees are too high for the given amount transaction output "
                   "amount is negative}",


### PR DESCRIPTION
This PR addresses the lint warnings and increases line length of project to 110.


### Changelist:
- Clean up linter errors and address render errors on home & account pages 5317cd638ee4d5e4fc64fe1471423d8930574e87
  - Fix `super` calls on `initState`, `didChangeDependencies`, `didUpdateWidget` & `dispose`
  - ignore: `overridden_fields` for `BreezDrawerHeader`
  - ignore: `deprecated_member_use_from_same_package` for `LSPInformation`'s `channelFeePermyriad`, `maxInactiveDuration`, `channelMinimumFeeMsat`.
  - ignore: `missing_required_param` for `TextButton`'s wrapped with `InkWell`
- Set line length to 110 324d13087cd3d9bfccd9f4cd3fc91da5551e1c12
  - Increase line length to 110 across the project
  - Format generated files with 110 line length
