### PR TITLE
Only update POS currency list if there's a change

### DIFF
--- a/lib/routes/charge/cart/cart_bar_drop_down_button.dart
+++ b/lib/routes/charge/cart/cart_bar_drop_down_button.dart
@@ -3,12 +3,13 @@ import 'package:breez/bloc/user_profile/currency.dart';
 import 'package:breez/routes/charge/cart/cart_bar_drop_down_item.dart';
 import 'package:breez/routes/charge/currency_wrapper.dart';
 import 'package:breez/theme_data.dart' as theme;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 
 final _log = Logger("CartBarDropDownButton");
 
-class CartBarDropDownButton extends StatelessWidget {
+class CartBarDropDownButton extends StatefulWidget {
   final String value;
   final AccountModel accountModel;
   final ValueChanged<String> onChanged;
@@ -21,49 +22,74 @@ class CartBarDropDownButton extends StatelessWidget {
   }) : super(key: key);
 
   @override
+  State<CartBarDropDownButton> createState() => _CartBarDropDownButtonState();
+}
+
+class _CartBarDropDownButtonState extends State<CartBarDropDownButton> {
+  List<CurrencyWrapper> currencyList = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _updateCurrencyList(_generateCurrencyList());
+  }
+
+  @override
+  void didUpdateWidget(CartBarDropDownButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    List<CurrencyWrapper> newCurrencyList = _generateCurrencyList();
+    if (_isCurrencyListDifferent(currencyList, newCurrencyList)) {
+      _updateCurrencyList(newCurrencyList);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
 
     return DropdownButtonHideUnderline(
-      key: key,
+      key: widget.key,
       child: ButtonTheme(
         alignedDropdown: true,
         child: DropdownButton(
-          onChanged: onChanged,
+          onChanged: widget.onChanged,
           iconEnabledColor: textTheme.headlineSmall.color,
-          value: value,
+          value: widget.value,
           style: theme.invoiceAmountStyle.copyWith(
             color: textTheme.headlineSmall.color,
           ),
-          items: _items(context, accountModel),
+          items: currencyList.map((currency) => CartBarDropDownItem(context, currency)).toList(),
         ),
       ),
     );
   }
 
-  List<DropdownMenuItem<String>> _items(
-    BuildContext context,
-    AccountModel accountModel,
-  ) {
-    _log.info("Building the cart drop down items");
-    List<CurrencyWrapper> currencies = [];
-    currencies.addAll(
-      Currency.currencies.map((c) => CurrencyWrapper.fromBTC(c)),
+  List<CurrencyWrapper> _generateCurrencyList() {
+    List<CurrencyWrapper> newCurrencyList = [
+      ...Currency.currencies.map((c) => CurrencyWrapper.fromBTC(c)),
+      ...widget.accountModel.preferredFiatConversionList.map((f) => CurrencyWrapper.fromFiat(f)),
+    ];
+    return newCurrencyList;
+  }
+
+  bool _isCurrencyListDifferent(List<CurrencyWrapper> oldList, List<CurrencyWrapper> newList) {
+    // We compare currency names instead of the entire CurrencyWrapper list
+    // because we're interested in changes in the currency selection,
+    // not in their properties(i.e. changes in exchange rates).
+    return !listEquals(
+      oldList.map((e) => e.shortName).toList(),
+      newList.map((e) => e.shortName).toList(),
     );
-    _log.info('Currencies after first addition: [${_fold(currencies)}]');
-    currencies.addAll(
-      accountModel.preferredFiatConversionList.map((f) => CurrencyWrapper.fromFiat(f)),
-    );
-    _log.info('Currencies after second addition: [${_fold(currencies)}]');
-    final dropDownItems = currencies.map(
-      (currency) => CartBarDropDownItem(context, currency),
-    );
-    _log.info(
-        'Drop down items: [${dropDownItems.fold("", (p, e) => p.isEmpty ? e.value : "$p, ${e.value}")}]');
-    return dropDownItems.toList();
+  }
+
+  void _updateCurrencyList(List<CurrencyWrapper> newCurrencyList) {
+    _log.info('POS Currency list: [${_fold(newCurrencyList)}]');
+    setState(() {
+      currencyList = newCurrencyList;
+    });
   }
 
   String _fold(List<CurrencyWrapper> currencies) {
-    return currencies.fold("", (p, e) => p.isEmpty ? e.shortName : "$p, ${e.shortName}");
+    return currencies.map((e) => e.shortName).join(", ");
   }
 }

--- a/lib/widgets/error_dialog.dart
+++ b/lib/widgets/error_dialog.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:anytime/ui/anytime_podcast_app.dart';
 import 'package:breez/theme_data.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -802,18 +802,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_macos
-      sha256: "8cfa53010a294ff095d7be8fa5bb15f2252c50018d69c5104851303f3ff92510"
+      sha256: b768a7dab26d6186b68e2831b3104f8968154f0f4fdbf66e7c2dd7bdf299daaf
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
       name: flutter_secure_storage_platform_interface
-      sha256: "301f67ee9b87f04aef227f57f13f126fa7b13543c8e7a93f25c5d2d534c28a4a"
+      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   flutter_secure_storage_web:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR improves upon previous approach which was updating currency list and adding logs on each rebuild.

POS currency list is now populated 
- once on `initState` when the widget is built
- every time there's a change* on currency list
  - *: removal/addition/reordering of preferred fiat currencies