### PR TITLE
Fixed a bug where a blob(non-text) item on clipboard would crash the app on Android

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -294,10 +294,11 @@ packages:
   clipboard_watcher:
     dependency: "direct main"
     description:
-      name: clipboard_watcher
-      sha256: "2fa9c728f46962668dbc1c07870695c9163524f8dbea25dc176277d1ef1cc2bd"
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: f2faa4e2c93db77b244cd34e4c8027fd9eca362d
+      resolved-ref: f2faa4e2c93db77b244cd34e4c8027fd9eca362d
+      url: "https://github.com/breez/clipboard_watcher.git"
+    source: git
     version: "0.2.0"
   clock:
     dependency: transitive
@@ -802,18 +803,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_macos
-      sha256: "8cfa53010a294ff095d7be8fa5bb15f2252c50018d69c5104851303f3ff92510"
+      sha256: b768a7dab26d6186b68e2831b3104f8968154f0f4fdbf66e7c2dd7bdf299daaf
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
       name: flutter_secure_storage_platform_interface
-      sha256: "301f67ee9b87f04aef227f57f13f126fa7b13543c8e7a93f25c5d2d534c28a4a"
+      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   flutter_secure_storage_web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,10 @@ dependencies:
     git:
       url: https://github.com/breez/Breez-Translations.git
       ref: 106e187b7290b4bb0ffe5d2e20e4110c893aaf63
-  clipboard_watcher: <=0.2.0 # Requires Flutter 3.10
+  clipboard_watcher:
+    git:
+      url: https://github.com/breez/clipboard_watcher.git
+      ref: f2faa4e2c93db77b244cd34e4c8027fd9eca362d
   collection: <=1.17.0 # flutter_test
   confetti: ^0.7.0
   connectivity_plus: <=4.0.2  # anytime


### PR DESCRIPTION
Fixes #1275

This crash was fixed on `clipboard_watcher` v2.1.0 but v2.1.0 also made it incompatible with Flutter 3.7.12

Forked `clipboard_watcher` and excluded Dart 3/Flutter 3.10 upgrades. [breez/clipboard_watcher@3.7.12_npe_crash](https://github.com/breez/clipboard_watcher/tree/3.7.12_npe_crash)