### PR TITLE
Use a transparent placeholder when transitioning Podcast chapter image

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,12 +45,14 @@ void main() async {
     final repository = SembastRepository();
     await Firebase.initializeApp();
     _configureEasyLoading();
-    SharedPreferences.getInstance().then((preferences) async {
-      await runMigration(preferences);
-      AppBlocs blocs = AppBlocs(repository.backupDatabaseListener);
-      runApp(AppBlocsProvider(
-          appBlocs: blocs,
-          child: AnytimePodcastApp(
+    SharedPreferences.getInstance().then(
+      (preferences) async {
+        await runMigration(preferences);
+        AppBlocs blocs = AppBlocs(repository.backupDatabaseListener);
+        runApp(
+          AppBlocsProvider(
+            appBlocs: blocs,
+            child: AnytimePodcastApp(
               mobileService,
               repository,
               Provider<PodcastPaymentsBloc>(
@@ -65,17 +67,26 @@ void main() async {
                 ),
                 dispose: (_, value) => value.dispose(),
                 child: PlayerControlsBuilder(
-                    builder: playerBuilder,
-                    child: PlaceholderBuilder(
-                        builder: placeholderBuilder,
-                        errorBuilder: errorPlaceholderBuilder,
-                        child: SharePodcastButtonBuilder(
-                            builder: sharePodcastButtonBuilder,
-                            child: ShareEpisodeButtonBuilder(
-                                builder: shareEpisodeButtonBuilder,
-                                child: UserApp(repository.reloadDatabaseSink))))),
-              ))));
-    });
+                  builder: playerBuilder,
+                  child: PlaceholderBuilder(
+                    builder: placeholderBuilder,
+                    errorBuilder: errorPlaceholderBuilder,
+                    podcastImageBuilder: podcastImagePlaceholderBuilder,
+                    child: SharePodcastButtonBuilder(
+                      builder: sharePodcastButtonBuilder,
+                      child: ShareEpisodeButtonBuilder(
+                        builder: shareEpisodeButtonBuilder,
+                        child: UserApp(repository.reloadDatabaseSink),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
   }, (error, stackTrace) async {
     BreezBridge breezBridge = ServiceInjector().breezBridge;
     if (error is! FlutterErrorDetails) {

--- a/lib/routes/podcast/podcast_page.dart
+++ b/lib/routes/podcast/podcast_page.dart
@@ -264,6 +264,14 @@ WidgetBuilder placeholderBuilder() {
   return builder;
 }
 
+WidgetBuilder podcastImagePlaceholderBuilder() {
+  builder(BuildContext context) => Container(
+        color: Colors.transparent,
+        constraints: const BoxConstraints.expand(),
+      );
+  return builder;
+}
+
 WidgetBuilder errorPlaceholderBuilder() {
   builder(BuildContext context) => Placeholder(
         color: Theme.of(context).colorScheme.error,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,8 +37,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "7ae0038eb14e1ebaa1eb8a26ae144a795e0b787d"
-      resolved-ref: "7ae0038eb14e1ebaa1eb8a26ae144a795e0b787d"
+      ref: db9f878aa640954aa272e92bd7a5c364683179a9
+      resolved-ref: db9f878aa640954aa272e92bd7a5c364683179a9
       url: "https://github.com/breez/anytime_podcast_player.git"
     source: git
     version: "1.2.1+74-breez"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -101,7 +101,7 @@ dependencies:
   anytime:
     git:
       url: https://github.com/breez/anytime_podcast_player.git
-      ref: 7ae0038eb14e1ebaa1eb8a26ae144a795e0b787d
+      ref: db9f878aa640954aa272e92bd7a5c364683179a9
   flutter_downloader:
     git:
       url: https://github.com/breez/flutter_downloader.git


### PR DESCRIPTION
closes #583

>by default the player shows the podcast logo. When a chapter comes up with a dedicated picture, that podcast logo disappears, there is a split-second blue screen, and then the chapter picture fades in.
> Is that blue screen expected / necessary?

Blue placeholder is replaced with a transparent one.

> It seems to be better to fade out the podcast logo and directly fade in the chapter pic.

While this is possible, it requires a product decision and won't be addressed as part of this PR.

### Changelist:
- [Use a transparent placeholder when switching chapter image](https://github.com/breez/breezmobile/commit/38551bb5fc5456635ca1e4954f96fd2ea53fb864)

## Demonstration

Picked a Podcast with many chapters with different images in a short timeframe:

<img src="https://github.com/breez/breezmobile/assets/4012752/cdf47df7-ce13-439c-bb36-c83373dc8eab" height="200" />

|Before|After|
|---|---|
|<video src="https://github.com/breez/breezmobile/assets/4012752/7801e7b9-052e-4c52-adbc-014fe22f80d1">|<video src="https://github.com/breez/breezmobile/assets/4012752/c2b55310-0c31-46f2-a56f-f144d505c3f2">|

First half of the video showcases transition animation without caching, which was addressed.
Second half of the video showcases transition animation with the images cached, which wasn't changed.

_Reproduces on light theme as well._
