### PR TITLE
Limit amount of decimals of BTC in amount field

### DIFF
--- a/lib/widgets/amount_form_field.dart
+++ b/lib/widgets/amount_form_field.dart
@@ -73,7 +73,7 @@ class AmountFormField extends TextFormField {
           enabled: enabled,
           controller: controller,
           inputFormatters: accountModel.currency != Currency.SAT
-              ? [FilteringTextInputFormatter.allow(RegExp(r'\d+\.?\d*'))]
+              ? [FilteringTextInputFormatter.allow(RegExp(r'\d+\.?\d{0,8}'))]
               : [SatAmountFormFieldFormatter()],
           onFieldSubmitted: onFieldSubmitted,
           onSaved: onSaved,


### PR DESCRIPTION
fixes #1163 

Limits amount field decimals to 8 for BTC.


https://github.com/breez/breezmobile/assets/4012752/ce2731ba-52fd-4fe2-b4fe-3eb4aeabc61f

