### PR TITLE
Update app to target Android 14 (API level 34)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -31,7 +31,7 @@ android {
     defaultConfig {
         applicationId "com.breez.client"
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 34
         multiDexEnabled true
         versionCode 1
         versionName "0.17.6-beta"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -235,9 +235,9 @@ PODS:
     - Flutter
   - PromisesObjC (2.4.0)
   - ReachabilitySwift (5.2.3)
-  - SDWebImage (5.19.2):
-    - SDWebImage/Core (= 5.19.2)
-  - SDWebImage/Core (5.19.2)
+  - SDWebImage (5.19.4):
+    - SDWebImage/Core (= 5.19.4)
+  - SDWebImage/Core (5.19.4)
   - share_plus (0.0.1):
     - Flutter
   - shared_preferences_foundation (0.0.1):
@@ -470,7 +470,7 @@ SPEC CHECKSUMS:
   printing: 233e1b73bd1f4a05615548e9b5a324c98588640b
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   ReachabilitySwift: 7f151ff156cea1481a8411701195ac6a984f4979
-  SDWebImage: dfe95b2466a9823cf9f0c6d01217c06550d7b29a
+  SDWebImage: 066c47b573f408f18caa467d71deace7c0f8280d
   share_plus: c3fef564749587fc939ef86ffb283ceac0baf9f5
   shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
   sqflite: 31f7eba61e3074736dff8807a9b41581e4f7f15a

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -440,18 +440,26 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: "11e40df547d418cc0c4900a9318b26304e665da6fa4755399a9ff9efd09034b5"
+      sha256: e17f6b3097b8c51b72c74c9f071a605c47bcc8893839bd66732457a5ebe73714
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.3+1"
+    version: "5.5.0+1"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "36c5b2d79eb17cdae41e974b7a8284fec631651d2a6f39a8a2ff22327e90aeac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   drag_and_drop_lists:
     dependency: "direct main"
     description:
       name: drag_and_drop_lists
-      sha256: "83fab4a9d4d99d9c683858ac5e1975028d87aa796bf68bfd654b19154004b6bb"
+      sha256: "9a14595f9880be7953f23578aef88c15cc9b367eeb39dbc1f1bd6af52f70872b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.1"
+    version: "0.3.3"
   duration:
     dependency: "direct main"
     description:
@@ -1416,10 +1424,10 @@ packages:
     dependency: "direct main"
     description:
       name: pdf
-      sha256: "243f05342fc0bdf140eba5b069398985cdbdd3dbb1d776cf43d5ea29cc570ba6"
+      sha256: "81d5522bddc1ef5c28e8f0ee40b71708761753c163e0c93a40df56fd515ea0f0"
       url: "https://pub.dev"
     source: hosted
-    version: "3.10.8"
+    version: "3.11.0"
   pdf_widget_wrapper:
     dependency: transitive
     description:
@@ -1903,10 +1911,10 @@ packages:
     dependency: "direct main"
     description:
       name: timeago
-      sha256: d3204eb4c788214883380253da7f23485320a58c11d145babc82ad16bf4e7764
+      sha256: "054cedf68706bb142839ba0ae6b135f6b68039f0b8301cbe8784ae653d5ff8de"
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.1"
+    version: "3.7.0"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   crypto: ^3.0.3
   csv: ^6.0.0
   device_info_plus: <=9.1.2 # anytime
-  dio: ^5.4.3+1
+  dio: ^5.5.0+1
   drag_and_drop_lists: <0.4.0 # drag_and_drop_lists >= 0.4.0 is incompatible with Flutter 3.7.12
   duration: ^3.0.13
   email_validator: ^3.0.0
@@ -71,7 +71,7 @@ dependencies:
   path: <=1.8.2 # flutter_test(^1.8.2) anytime(^1.8.3)
   path_provider: <=2.1.1 # Requires Flutter 3.10
   path_provider_platform_interface: <=2.1.1 # Requires Flutter 3.10
-  pdf: ^3.10.8
+  pdf: ^3.11.0
   plugin_platform_interface: <=2.1.6 # Requires Flutter 3.10
   printing: <=5.10.4 # Requires Flutter 3.10
   protobuf: <=2.1.0 # Requires Flutter 3.10
@@ -83,7 +83,7 @@ dependencies:
     git:
       url: https://github.com/theyakka/qr.flutter.git
       ref: 1fc6e38c198a76a6fd60b7bd3b4c190cd6c9330b
-  rxdart: ^0.27.7
+  rxdart: ^0.27.7 # anytime
   screenshot: <=1.3.0 # Requires Flutter 3.10
   share_plus: <=7.2.2 # anytime
   shared_preferences: <=2.2.2 # Requires Flutter 3.10
@@ -91,7 +91,7 @@ dependencies:
   simple_animations: ^5.0.2
   sqflite: <=2.2.8+4 # Requires Flutter 3.10
   store_checker: ^1.4.0
-  timeago: ^3.6.1
+  timeago: ^3.7.0
   tutorial_coach_mark: ^1.2.11
   uni_links: ^0.5.1
   url_launcher: <=6.1.11 # Requires Flutter 3.10
@@ -125,7 +125,7 @@ dependencies:
 dependency_overrides:
   intl: <=0.18.1 # anytime
   meta: <=1.9.1 # anytime
-  path: <=1.8.3
+  path: <=1.8.3 # 1.9.0 Requires Dart 3.0
   flutter_downloader:
     git:
       url: https://github.com/breez/flutter_downloader.git


### PR DESCRIPTION
App target API level has been updated to API level 34 to meet requirements of updated Google Play Store policies.

> From Aug 31, 2024, if your target API level is not within 1 year of the latest Android release, you won't be able to update your app.

#### Other changelist:
- Updated dependencies to latest resolvable