### PR TITLE
"Update URL for Sms4Sats"

### DIFF
--- a/src/json/vendors.json
+++ b/src/json/vendors.json
@@ -37,7 +37,7 @@
     "endpointURI": "https://lightsats.com/api/auth/lnurl/generate-secret"
   },
   "Sms4Sats": {
-    "url": "http://sms4sats.com/"
+    "url": "https://sms4sats.com/"
   },
   "ln.pizza": {
     "url": "https://ln.pizza/?breez_wallet"


### PR DESCRIPTION
Changes made: Corrected the URL for the 'Sms4Sats' service from 'http://sms4sats.com/' to 'https://sms4sats.com/'. This ensures that the application uses a secure (HTTPS) connection when accessing the Sms4Sats API, which helps protect user data and maintain trust in the service.