### PR TITLE
Update Key Name for The Bitcoin Company

### DIFF
--- a/src/json/vendors.json
+++ b/src/json/vendors.json
@@ -17,7 +17,7 @@
   "FixedFloat": {
     "url": "https://widget.fixedfloat.com/?from=BTCLN&to=LTC&cciesRcvNot=BTCLN"
   },
-  "tbc" : {
+  "TBC" : {
     "displayName": "The Bitcoin Company",
     "url": "https://app.thebitcoincompany.com",
     "endpointURI": "https://api.thebitcoincompany.com/auth/auth-lnurl?flatResponse=true",


### PR DESCRIPTION
Changes made: Updated the key name from 'tbc' to 'TBC' in the configuration for The Bitcoin Company.