### PR TITLE
fix tor config receiver

### DIFF
--- a/android/app/src/main/java/com/breez/client/plugins/breez/Tor.java
+++ b/android/app/src/main/java/com/breez/client/plugins/breez/Tor.java
@@ -19,6 +19,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.ServiceConnection;
+import android.os.Build;
 import android.os.IBinder;
 import android.util.Log;
 import java.util.concurrent.Executor;
@@ -151,7 +152,11 @@ public class Tor implements FlutterPlugin, MethodCallHandler {
 
 
         Context context = binding.getApplicationContext();
-        context.registerReceiver(receiver, new IntentFilter(TorService.ACTION_STATUS));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.registerReceiver(receiver, new IntentFilter(TorService.ACTION_STATUS), Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            context.registerReceiver(receiver, new IntentFilter(TorService.ACTION_STATUS));
+        }
 
         // Ref. https://developer.android.com/guide/components/services
         // Your service can work both ways—it can be started (to run indefinitely) and also allow binding. 


### PR DESCRIPTION
The tor config failed to initialize with the following error:

```
[TorBloc] {INFO} (2024-12-02T18:52:43.172705Z) : TorBloc.startTor failed: PlatformException(error, com.breez.client: One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts, null, java.lang.SecurityException: com.breez.client: One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts
	at android.os.Parcel.createExceptionOrNull(Parcel.java:3251)
	at android.os.Parcel.createException(Parcel.java:3235)
	at android.os.Parcel.readException(Parcel.java:3211)
	at android.os.Parcel.readException(Parcel.java:3153)
	at android.app.IActivityManager$Stub$Proxy.registerReceiverWithFeature(IActivityManager.java:6130)
	at android.app.ContextImpl.registerReceiverInternal(ContextImpl.java:1947)
	at android.app.ContextImpl.registerReceiver(ContextImpl.java:1887)
	at android.app.ContextImpl.registerReceiver(ContextImpl.java:1875)
	at android.content.ContextWrapper.registerReceiver(ContextWrapper.java:757)
	at m2.i.l(Unknown Source:25)
	at m2.i.E(Unknown Source:17)
	at mc.j$a.a(Unknown Source:17)
	at zb.c.l(Unknown Source:18)
	at zb.c.m(Unknown Source:40)
	at zb.c.i(Unknown Source:0)
	at zb.b.run(Unknown Source:12)
	at android.os.Handler.handleCallback(Handler.java:959)
	at android.os.Handler.dispatchMessage(Handler.java:100)
	at android.os.Looper.loopOnce(Looper.java:232)
	at android.os.Looper.loop(Looper.java:317)
	at android.app.ActivityThread.main(ActivityThread.java:8744)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
	at com.android.internal.os.ExecInit.main(ExecInit.java:50)
	at com.android.internal.os.RuntimeInit.nativeFinishInit(Native Method)
	at com.android.internal.os.RuntimeInit.main(RuntimeInit.java:369)
Caused by: android.os.RemoteException: Remote stack trace:
	at com.android.server.am.ActivityManagerService.registerReceiverWithFeatureTraced(ActivityManagerService.java:14921)
	at com.android.server.am.ActivityManagerService.registerReceiverWithFeature(ActivityManagerService.java:14723)
	at android.app.IActivityManager$Stub.onTransact(IActivityManager.java:2772)
	at com.android.server.am.ActivityManagerService.onTransact(ActivityManagerService.java:2818)
	at android.os.Binder.execTransactInternal(Binder.java:1529)

)

```

This PR fixes that error. And with that fixes tor initialization.