### PR TITLE
Update Tor to latest on iOS

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -31,7 +31,7 @@ target 'Runner' do
   use_frameworks!
   use_modular_headers!
 
-  pod 'Tor', podspec: 'https://raw.githubusercontent.com/iCepa/Tor.framework/v405.8.1/Tor.podspec'
+  pod 'Tor', podspec: 'https://raw.githubusercontent.com/iCepa/Tor.framework/v408.14.1/Tor.podspec'
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -245,7 +245,11 @@ PODS:
     - Flutter
   - SwiftyGif (5.4.5)
   - TOCropViewController (2.6.1)
-  - Tor (405.8.1)
+  - Tor (408.14.1):
+    - Tor/CTor (= 408.14.1)
+  - Tor/Core (408.14.1)
+  - Tor/CTor (408.14.1):
+    - Tor/Core
   - uni_links (0.0.1):
     - Flutter
   - url_launcher_ios (0.0.1):
@@ -287,7 +291,7 @@ DEPENDENCIES:
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/ios`)
   - sqflite (from `.symlinks/plugins/sqflite/ios`)
   - store_checker (from `.symlinks/plugins/store_checker/ios`)
-  - Tor (from `https://raw.githubusercontent.com/iCepa/Tor.framework/v405.8.1/Tor.podspec`)
+  - Tor (from `https://raw.githubusercontent.com/iCepa/Tor.framework/v408.14.1/Tor.podspec`)
   - uni_links (from `.symlinks/plugins/uni_links/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
   - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/ios`)
@@ -393,7 +397,7 @@ EXTERNAL SOURCES:
   store_checker:
     :path: ".symlinks/plugins/store_checker/ios"
   Tor:
-    :podspec: https://raw.githubusercontent.com/iCepa/Tor.framework/v405.8.1/Tor.podspec
+    :podspec: https://raw.githubusercontent.com/iCepa/Tor.framework/v408.14.1/Tor.podspec
   uni_links:
     :path: ".symlinks/plugins/uni_links/ios"
   url_launcher_ios:
@@ -466,11 +470,11 @@ SPEC CHECKSUMS:
   store_checker: 359c5051d9ec30ff0a8fa39eb5ec9df021bb745d
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
   TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863
-  Tor: fad2cec0e7ef5f889fecdaf69e5edd6df0438326
+  Tor: e37a153222ca73ca10a7fe80d1a543b8cc009da8
   uni_links: d97da20c7701486ba192624d99bffaaffcfc298a
   url_launcher_ios: 68d46cc9766d0c41dbdc884310529557e3cd7a86
   webview_flutter_wkwebview: 2e2d318f21a5e036e2c3f26171342e95908bd60a
 
-PODFILE CHECKSUM: ef7fa92d8242f8f58d9aa60a4928be7b473f69a9
+PODFILE CHECKSUM: c37093e3fd7ed6531a5f60007c7da5f63d4704e6
 
 COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -28,18 +28,19 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		E79A374D29D9328F93993502 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55255952F592B2DE772C2341 /* Pods_Runner.framework */; };
 		E87684212DC0A93700393174 /* libresolv.9.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E87684202DC0A92F00393174 /* libresolv.9.tbd */; };
 		E87684222DC0A93700393174 /* libresolv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E876841F2DC0A92F00393174 /* libresolv.tbd */; };
-		FAB16EE157A70668293EF54A /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BBDC8D2DE14909D7CCFC107C /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		254C886E299EB599003043D5 /* bindings.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = bindings.xcframework; sourceTree = "<group>"; };
-		3379811767115C37E9541CBB /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		3265DDA7BBBFFB3E88443EF8 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		425D0A0CA51E087037A4B990 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		4D1A4BDE0062CE8D9C5D687C /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		55255952F592B2DE772C2341 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F068F362301566B009A1818 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		6F09D3B0225DEDEC00867443 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		6F09D3B1225DEDEC00867443 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -66,7 +67,6 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		BBDC8D2DE14909D7CCFC107C /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E876841F2DC0A92F00393174 /* libresolv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.tbd; path = usr/lib/libresolv.tbd; sourceTree = SDKROOT; };
 		E87684202DC0A92F00393174 /* libresolv.9.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.9.tbd; path = usr/lib/libresolv.9.tbd; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
@@ -80,7 +80,7 @@
 				254C886F299EB599003043D5 /* bindings.xcframework in Frameworks */,
 				E87684222DC0A93700393174 /* libresolv.tbd in Frameworks */,
 				6F3FAFCA232E610400680AC5 /* CloudKit.framework in Frameworks */,
-				FAB16EE157A70668293EF54A /* Pods_Runner.framework in Frameworks */,
+				E79A374D29D9328F93993502 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -90,8 +90,8 @@
 		4D11D739AD83EE6648F33D6C /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				3379811767115C37E9541CBB /* Pods-Runner.debug.xcconfig */,
-				425D0A0CA51E087037A4B990 /* Pods-Runner.release.xcconfig */,
+				4D1A4BDE0062CE8D9C5D687C /* Pods-Runner.debug.xcconfig */,
+				3265DDA7BBBFFB3E88443EF8 /* Pods-Runner.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -195,7 +195,7 @@
 				6F262CE4247EAEE100BAC844 /* libsqlite3.tbd */,
 				6F262CE2247EAED200BAC844 /* libsqlite3.0.tbd */,
 				6F3FAFC9232E610400680AC5 /* CloudKit.framework */,
-				BBDC8D2DE14909D7CCFC107C /* Pods_Runner.framework */,
+				55255952F592B2DE772C2341 /* Pods_Runner.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -207,14 +207,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				562090996B38DE56A8A42396 /* [CP] Check Pods Manifest.lock */,
+				B28CCFFC6D38544AA7E172E0 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				B8DC45DC7B6A71936FEF125E /* [CP] Embed Pods Frameworks */,
-				E87684232DC108F700393174 /* ShellScript */,
+				8E7483837E6AE84D25002C75 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -306,44 +305,7 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin\n";
 		};
-		562090996B38DE56A8A42396 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9740EEB61CF901F6004384FC /* Run Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run Script";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
-		};
-		B8DC45DC7B6A71936FEF125E /* [CP] Embed Pods Frameworks */ = {
+		8E7483837E6AE84D25002C75 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -373,7 +335,7 @@
 				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftyGif/SwiftyGif.framework",
 				"${BUILT_PRODUCTS_DIR}/TOCropViewController/TOCropViewController.framework",
-				"${PODS_ROOT}/Tor/Build/iOS/Tor.framework",
+				"${BUILT_PRODUCTS_DIR}/Tor/Tor.framework",
 				"${BUILT_PRODUCTS_DIR}/app_settings/app_settings.framework",
 				"${BUILT_PRODUCTS_DIR}/audio_service/audio_service.framework",
 				"${BUILT_PRODUCTS_DIR}/audio_session/audio_session.framework",
@@ -467,7 +429,22 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E87684232DC108F700393174 /* ShellScript */ = {
+		9740EEB61CF901F6004384FC /* Run Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
+		};
+		B28CCFFC6D38544AA7E172E0 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -475,14 +452,19 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
+			name = "[CP] Check Pods Manifest.lock";
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ -f \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Tor.framework/Tor\" ]; then\n  xcrun bitcode_strip -r \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Tor.framework/Tor\" -o \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Tor.framework/Tor\"\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Fixes Xcode 14 & 16 issues without the need to strip bitcode from Tor.framework.

--- 

Currently in draft due to issues with the online build:
```
Building technology.breez.client for device (ios-release)...
Running pod install...                                            210.8s
Running Xcode build...                                          
Xcode build done.                                           14.8s
Failed to build iOS app
Encountered error while building for device.
Error output from Xcode build:
↳
    ** BUILD FAILED **


Xcode's output:
↳
    Writing result bundle at path:
    	/var/folders/bb/y4gtvgtn7754r1_1cgzy9bl40000gn/T/flutter_tools.zvdpHL/flutter_ios_build_temp_dirBLp9Pb/temporary_xcresult_bundle

    + autopoint -f
    /opt/homebrew/bin/autopoint: line 321: autom4te: command not found
    autopoint: using AM_GNU_GETTEXT_REQUIRE_VERSION instead of AM_GNU_GETTEXT_VERSION
    /opt/homebrew/bin/autopoint: line 334: autom4te: command not found
    autopoint: *** gettext version 0.19.6 or newer is required
    autopoint: *** Stop.
    ../xz.sh: line 76: ./configure: No such file or directory
    make: *** No targets specified and no makefile found.  Stop.
    make: Nothing to be done for `install'.
    make: *** No rule to make target `distclean'.  Stop.
    cp: /Users/runner/Library/Developer/Xcode/DerivedData/Runner-gcazyvfnaozyzqcbvzyfjczzlkra/Build/Intermediates.noindex/Pods.build/Release-iphoneos/liblzma-arm64/lib/*.a: No such file or directory
    fatal error: /Applications/Xcode_16.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo: can't open input file: /Users/runner/work/breezmobile/breezmobile/build/ios/Release-iphoneos/Tor/liblzma.*.a (No such file or directory)
    rm: /Users/runner/work/breezmobile/breezmobile/build/ios/Release-iphoneos/Tor/liblzma*.*.a: No such file or directory
```